### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- 
+
+Thank you for taking the time to report an ODK Web Forms issue!
+
+This space is for bugs that have clear reproduction steps and expected behavior. For unexpected behavior that is unclear how to address, general usage questions, form design questions, and to ask about the source code, please visit the ODK forum: https://forum.getodk.org
+
+Before filling the template below, visit https://github.com/getodk/web-forms/issues?q=is%3Aissue and search to see whether your issue was already reported or fixed. If you find a match, comment on it or add a +1 rather than posting a new issue. If you find a problem you know how to fix, submit a pull request. 🎉
+
+Feature suggestions should be described [in the forum Features category](https://forum.getodk.org/c/features) and discussed by the broader user community. Once there is a clear way forward, issues should be filed on the relevant repositories.
+
+-->
+
+#### Web Forms version and package (e.g. are you using `ui-vue` or only the engine?)
+
+#### Browser and version
+
+#### Device used
+
+#### Problem description
+
+#### Steps to reproduce the problem
+
+#### Expected behavior
+
+#### Other information 
+
+Things you tried, stack traces, related issues, suggestions on how to fix it...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links: 
+  - name: "Report an issue"
+    about: "For when ODK Web Forms is behaving in an unexpected way"
+    url: "https://forum.getodk.org/c/support/6"
+  - name: "Request a feature"
+    about: "For when ODK Web Forms is missing functionality"
+    url: "https://forum.getodk.org/c/features/9"
+  - name: "Everything else"
+    about: "For everything else"
+    url: "https://forum.getodk.org/c/support/6"


### PR DESCRIPTION
Closes #88 

Github has some new functionality to build issue forms but I went with a setup that matches Collect and Central for now. I think it meets our needs well.