### PR TITLE
Fix: client reactivity of translated select item labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,57 +23,6 @@ env:
   TZ: 'America/Phoenix'
 
 jobs:
-  changes:
-    name: 'Determine package changes'
-    runs-on: 'ubuntu-latest'
-
-    outputs:
-      root: ${{ steps.changes.outputs.root }}
-      odk-common: ${{ steps.changes.outputs.odk-common }}
-      tree-sitter-xpath: ${{ steps.changes.outputs.tree-sitter-xpath }}
-      xforms-engine: ${{ steps.changes.outputs.xforms-engine }}
-      xpath: ${{ steps.changes.outputs.xpath }}
-      scenario: ${{ steps.changes.outputs.scenario }}
-      ui-solid: ${{ steps.changes.outputs.ui-solid }}
-      ui-vue: ${{ steps.changes.outputs.ui-vue }}
-
-    steps:
-      - uses: 'actions/checkout@v3'
-      - uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          filters: |
-            root:
-              - '*'
-              - '.github/workflows/*'
-
-            odk-common:
-              - 'packages/common/**'
-
-            tree-sitter-xpath:
-              - 'packages/tree-sitter-xpath/grammar.ts'
-              - 'packages/tree-sitter-xpath/scripts/**'
-              - 'packages/tree-sitter-xpath/test/**'
-
-            xforms-engine:
-              - 'packages/xforms-engine/**'
-
-            scenario:
-              - 'packages/scenario/**'
-
-            xpath:
-              - 'packages/xpath/**'
-
-            ui-solid:
-              - 'packages/ui-solid/**'
-
-            ui-vue:
-              - 'packages/ui-vue/**'
-
-          # So the `paths-filter` action doesn't attempt to use the GitHub API
-          # when run on pull requests
-          token: ''
-
   install-and-build:
     name: 'Install dependencies and build packages'
     runs-on: 'ubuntu-latest'
@@ -128,7 +77,7 @@ jobs:
 
   lint:
     name: 'Lint (global)'
-    needs: ['install-and-build', 'changes']
+    needs: ['install-and-build']
     runs-on: 'ubuntu-latest'
 
     strategy:
@@ -171,8 +120,7 @@ jobs:
 
   odk-common:
     name: '@odk-web-forms/common'
-    needs: ['install-and-build', 'changes']
-    if: needs.changes.outputs.root == 'true' || needs.changes.outputs.odk-common == 'true'
+    needs: ['install-and-build']
     runs-on: 'ubuntu-latest'
 
     strategy:
@@ -236,8 +184,7 @@ jobs:
 
   xforms-engine:
     name: '@odk-web-forms/xforms-engine'
-    needs: ['install-and-build', 'changes']
-    if: needs.changes.outputs.root == 'true' || needs.changes.outputs.xforms-engine == 'true'
+    needs: ['install-and-build']
     runs-on: 'ubuntu-latest'
 
     strategy:
@@ -301,8 +248,7 @@ jobs:
 
   scenario:
     name: 'scenario'
-    needs: ['install-and-build', 'changes']
-    if: needs.changes.outputs.root == 'true' || needs.changes.outputs.scenario == 'true'
+    needs: ['install-and-build']
     runs-on: 'ubuntu-latest'
 
     strategy:
@@ -366,8 +312,7 @@ jobs:
 
   xpath:
     name: '@odk-web-forms/xpath'
-    needs: ['install-and-build', 'changes']
-    if: needs.changes.outputs.root == 'true' || needs.changes.outputs.tree-sitter-xpath == 'true' || needs.changes.outputs.xpath == 'true'
+    needs: ['install-and-build']
     runs-on: 'ubuntu-latest'
 
     strategy:
@@ -437,8 +382,7 @@ jobs:
 
   tree-sitter-xpath:
     name: '@odk-web-forms/tree-sitter-xpath'
-    needs: ['install-and-build', 'changes']
-    if: needs.changes.outputs.root == 'true' || needs.changes.outputs.tree-sitter-xpath == 'true'
+    needs: ['install-and-build']
     runs-on: 'ubuntu-latest'
 
     strategy:
@@ -481,8 +425,7 @@ jobs:
 
   ui-solid:
     name: 'ui-solid'
-    needs: ['install-and-build', 'changes']
-    if: needs.changes.outputs.root == 'true' || needs.changes.outputs.ui-solid == 'true'
+    needs: ['install-and-build']
     runs-on: 'ubuntu-latest'
 
     strategy:
@@ -546,8 +489,7 @@ jobs:
 
   ui-vue:
     name: 'ui-vue'
-    needs: ['install-and-build', 'changes']
-    if: needs.changes.outputs.root == 'true' || needs.changes.outputs.ui-vue == 'true'
+    needs: ['install-and-build']
     runs-on: 'ubuntu-latest'
 
     strategy:

--- a/packages/xforms-engine/src/lib/reactivity/createSelectItems.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createSelectItems.ts
@@ -126,14 +126,16 @@ const createItemset = (
 	selectField: SelectField,
 	itemset: ItemsetDefinition
 ): Accessor<readonly SelectItem[]> => {
-	const itemsetItems = createItemsetItems(selectField, itemset);
+	return selectField.scope.runTask(() => {
+		const itemsetItems = createItemsetItems(selectField, itemset);
 
-	return createMemo(() => {
-		return itemsetItems().map((item) => {
-			return {
-				label: item.label(),
-				value: item.value(),
-			};
+		return createMemo(() => {
+			return itemsetItems().map((item) => {
+				return {
+					label: item.label(),
+					value: item.value(),
+				};
+			});
 		});
 	});
 };
@@ -151,13 +153,11 @@ const createItemset = (
  *   referencing a form's `itext` translations, etc).
  */
 export const createSelectItems = (selectField: SelectField): Accessor<readonly SelectItem[]> => {
-	return selectField.scope.runTask(() => {
-		const { items, itemset } = selectField.definition.bodyElement;
+	const { items, itemset } = selectField.definition.bodyElement;
 
-		if (itemset == null) {
-			return createTranslatedStaticSelectItems(selectField, items);
-		}
+	if (itemset == null) {
+		return createTranslatedStaticSelectItems(selectField, items);
+	}
 
-		return createItemset(selectField, itemset);
-	});
+	return createItemset(selectField, itemset);
 };

--- a/packages/xforms-engine/src/lib/reactivity/createSelectItems.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createSelectItems.ts
@@ -27,21 +27,23 @@ const createSelectItemLabel = (
 	});
 };
 
-const buildStaticSelectItems = (
+const createTranslatedStaticSelectItems = (
 	selectField: SelectField,
 	items: readonly ItemDefinition[]
-): readonly SelectItem[] => {
+): Accessor<readonly SelectItem[]> => {
 	return selectField.scope.runTask(() => {
-		return items.map((item) => {
+		const labeledItems = items.map((item) => {
 			const { value } = item;
 			const label = createSelectItemLabel(selectField, item);
 
-			return {
+			return () => ({
 				value,
-				get label() {
-					return label();
-				},
-			};
+				label: label(),
+			});
+		});
+
+		return createMemo(() => {
+			return labeledItems.map((item) => item());
 		});
 	});
 };
@@ -153,9 +155,7 @@ export const createSelectItems = (selectField: SelectField): Accessor<readonly S
 		const { items, itemset } = selectField.definition.bodyElement;
 
 		if (itemset == null) {
-			const staticItems = buildStaticSelectItems(selectField, items);
-
-			return () => staticItems;
+			return createTranslatedStaticSelectItems(selectField, items);
 		}
 
 		return createItemset(selectField, itemset);

--- a/packages/xforms-engine/test/lib/reactivity/createSelectItems.test.ts
+++ b/packages/xforms-engine/test/lib/reactivity/createSelectItems.test.ts
@@ -1,0 +1,279 @@
+import { UpsertableMap } from '@odk-web-forms/common/lib/collections/UpsertableMap.ts';
+import type { HtmlXFormsElement } from '@odk-web-forms/common/test/fixtures/xform-dsl/HtmlXFormsElement.ts';
+import {
+	body,
+	head,
+	html,
+	instance,
+	mainInstance,
+	model,
+	select1,
+	select1Dynamic,
+	t,
+	title,
+} from '@odk-web-forms/common/test/fixtures/xform-dsl/index.ts';
+import { describe, expect, it } from 'vitest';
+import { initializeForm } from '../../../src/index.ts';
+import type { SelectField } from '../../../src/instance/SelectField.ts';
+import type { createSelectItems } from '../../../src/lib/reactivity/createSelectItems.ts';
+import { reactiveTestScope } from '../../helpers/reactive/internal.ts';
+
+/**
+ * @todo Consider these alternative testing strategies:
+ *
+ * - Reducing tests of reactive internals like {@link createSelectItems} to more
+ *   conventional unit tests: If there's a reasonable way to do that, it would
+ *   probably begin (especially in this case) with relaxing the
+ *   {@link createSelectItems} signature to accept something more minimal than a
+ *   {@link SelectField}. However, after some reflection on the efforts to port
+ *   JavaRosa tests, there's quite a lot of value in form-level integration
+ *   tests. We might benefit instead from...
+ *
+ * - Expanding the API of our ported `Scenario` class, itself now a full-fledged
+ *   client of the engine, to support a more generalized approach to integration
+ *   tests of the reactive aspects of our engline/client interface.
+ *
+ * The tests introduced in this suite are focused on both:
+ *
+ * 1. Testing the specific bugs reported in
+ *    {@link https://github.com/getodk/web-forms/issues/83 | #83}, in support of
+ *    the fixes that will accompany these tests.
+ *
+ * 2. Exploring some aspects of what we might want to consider if we move toward
+ *    testing reactivity in the `scenario` integration test client package.
+ */
+describe('createSelectItems - reactive `<select>`/`<select1>` items and itemsets', () => {
+	interface LabelTranslationSuite {
+		readonly description: string;
+		readonly fixture: HtmlXFormsElement;
+	}
+
+	/**
+	 * Note that this test fixture is copied (with slight modification,
+	 * disambiguating the primary instance root's `id` attribute) from a
+	 * `scenario` integration test. We may want to consider strategies for sharing
+	 * DSL-defined fixtures (even if it's just a matter of exporting and then
+	 * importing them from some appropriate shared space). In considering that,
+	 * let's also consider how that might integrate with dev and demo
+	 * environments. We'd definitely benefit from a more direct mechanism to
+	 * interact with, and inspect, test form fixtures within a UI client.
+	 */
+	const itemsetFixture = html(
+		head(
+			title('Multilingual dynamic select'),
+			model(
+				t(
+					'itext',
+					t(
+						"translation lang='fr'",
+						t("text id='choices-0'", t('value', 'A (fr)')),
+						t("text id='choices-1'", t('value', 'B (fr)')),
+						t("text id='choices-2'", t('value', 'C (fr)'))
+					),
+					t(
+						"translation lang='en'",
+						t("text id='choices-0'", t('value', 'A (en)')),
+						t("text id='choices-1'", t('value', 'B (en)')),
+						t("text id='choices-2'", t('value', 'C (en)'))
+					)
+				),
+				mainInstance(t("data id='multilingual-dynamic-select'", t('select'))),
+
+				instance(
+					'choices',
+					t('item', t('itextId', 'choices-0'), t('name', 'a')),
+					t('item', t('itextId', 'choices-1'), t('name', 'b')),
+					t('item', t('itextId', 'choices-2'), t('name', 'c'))
+				)
+			)
+		),
+		body(
+			select1Dynamic('/data/select', "instance('choices')/root/item", 'name', 'jr:itext(itextId)')
+		)
+	);
+
+	const itemsFixture = html(
+		head(
+			title('Multilingual static select'),
+			model(
+				t(
+					'itext',
+					t(
+						"translation lang='fr'",
+						t("text id='choices-0'", t('value', 'A (fr)')),
+						t("text id='choices-1'", t('value', 'B (fr)')),
+						t("text id='choices-2'", t('value', 'C (fr)'))
+					),
+					t(
+						"translation lang='en'",
+						t("text id='choices-0'", t('value', 'A (en)')),
+						t("text id='choices-1'", t('value', 'B (en)')),
+						t("text id='choices-2'", t('value', 'C (en)'))
+					)
+				),
+				mainInstance(t("data id='multilingual-static-select'", t('select')))
+			)
+		),
+		body(
+			select1(
+				'/data/select',
+				t('item', t('value', 'a'), t('label ref="jr:itext(\'choices-0\')"')),
+				t('item', t('value', 'b'), t('label ref="jr:itext(\'choices-1\')"')),
+				t('item', t('value', 'c'), t('label ref="jr:itext(\'choices-2\')"'))
+			)
+		)
+	);
+
+	describe.each<LabelTranslationSuite>([
+		{
+			description: 'dynamic `<itemset>` label translations',
+			fixture: itemsetFixture,
+		},
+		{
+			description: 'static `<item>` label translations',
+			fixture: itemsFixture,
+		},
+	])('$description', ({ fixture }) => {
+		type TestLanguage = 'en' | 'fr';
+
+		/**
+		 * @todo What would a generalization of this pattern look like, if we were to
+		 * add reactive testing to `scenario`?
+		 *
+		 * These immediately come to mind:
+		 *
+		 * 1. Can {@link act} be declarative? Can we specify a series of generic
+		 *    action steps to be taken against a form, in a relatively uniform way,
+		 *    and apply that format to arbitrary form fixtures?
+		 *
+		 * 2. Can {@link assert} be made more generic as some sort of expected
+		 *    reactive event log?
+		 *
+		 * 3. Could we interleave these. It's likely we'd want to be able to step
+		 *    through a series of {@link act} steps, and perform an {@link assert}
+		 *    check associated with that step, to make it clearer which observed state
+		 *    is (expected to be) produced by each state change action.
+		 */
+		interface TranslatedItemLabelTestCase {
+			readonly description: string;
+
+			readonly act: {
+				readonly setLanguage: readonly TestLanguage[];
+			};
+
+			readonly assert: {
+				readonly observedLabels: {
+					readonly a: readonly string[];
+					readonly b: readonly string[];
+					readonly c: readonly string[];
+				};
+			};
+		}
+
+		it.each<TranslatedItemLabelTestCase>([
+			{
+				description: 'default labels on init',
+				act: {
+					setLanguage: [],
+				},
+				assert: {
+					observedLabels: {
+						a: ['A (fr)'],
+						b: ['B (fr)'],
+						c: ['C (fr)'],
+					},
+				},
+			},
+			{
+				description: 'alternate between languages',
+				act: {
+					setLanguage: ['en', 'fr', 'en'],
+				},
+				assert: {
+					observedLabels: {
+						a: ['A (fr)', 'A (en)', 'A (fr)', 'A (en)'],
+						b: ['B (fr)', 'B (en)', 'B (fr)', 'B (en)'],
+						c: ['C (fr)', 'C (en)', 'C (fr)', 'C (en)'],
+					},
+				},
+			},
+			{
+				description: 'redundant language selection is reactive no-op',
+				act: {
+					setLanguage: ['fr', 'fr', 'fr', 'en', 'en', 'en'],
+				},
+				assert: {
+					observedLabels: {
+						a: ['A (fr)', 'A (en)'],
+						b: ['B (fr)', 'B (en)'],
+						c: ['C (fr)', 'C (en)'],
+					},
+				},
+			},
+		])('triggers translated select label - $description', async ({ act, assert }) => {
+			const labelStatesByValue = await reactiveTestScope(async ({ effect, mutable }) => {
+				const root = await initializeForm(fixture.asXml(), {
+					config: {
+						stateFactory: mutable,
+					},
+				});
+				const [fr, en, ...restLanguages] = root.languages;
+
+				if (fr.language !== 'fr') {
+					expect.fail(`Unexpected default language: ${fr.language}`);
+				}
+
+				if (en == null || en.language !== 'en') {
+					expect.fail(`Unexpected alternate language: ${en?.language}`);
+				}
+
+				expect(restLanguages).toEqual([]);
+
+				const select = root.currentState.children[0];
+
+				if (
+					select == null ||
+					select.nodeType !== 'select' ||
+					select.currentState.reference !== '/data/select'
+				) {
+					expect.fail('Failed to find select for testing its reactive label translations');
+				}
+
+				expect(select.currentState.reference).toBe('/data/select');
+
+				const observedLabelStatesByValue = new UpsertableMap<string, string[]>();
+
+				// Note: with current internal test reactivity, this should be run
+				// eagerly; the initial label state (in "French") should be observed
+				// immediately upon its definition.
+				effect(() => {
+					select.currentState.valueOptions.forEach((option) => {
+						const { label, value } = option;
+						const labelStates = observedLabelStatesByValue.upsert(value, () => []);
+
+						if (label == null) {
+							expect.fail(`Select item with value ${value} has no label`);
+						}
+
+						labelStates.push(label.asString);
+					});
+				});
+
+				const languages = {
+					fr,
+					en,
+				} as const;
+
+				act.setLanguage.forEach((languageKey) => {
+					const language = languages[languageKey];
+
+					root.setLanguage(language);
+				});
+
+				return Object.fromEntries(observedLabelStatesByValue);
+			});
+
+			expect(labelStatesByValue).toEqual(assert.observedLabels);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #83.

Supersedes and closes #102 as well. Differences from that PR:

- Breaks the fixes for these (related, but) distinct bugs into separate commits:

  - Translated _dynamic select itemset labels_ (e.g. `<select1><itemset nodeset="instance('choices')/root/item"><label ref="jr:itext(itextId)"/>…`) are not client-reactive.

  - Translated labels of _static select items_ (e.g. `<select><item><label ref="jr:itext('foo')"/>…`) are **also** not client-reactive.

  The distinction is discussed in #83. I expect having separate commits could be helpful in the future, whenever we need to reason about the slight differences in how each case flows through the engine's reactive internals.

- Adds tests for both bugs, exercising reactivity of these scenarios:

  - Trigger an effect on load, reflecting initial state. This behavior would vary depending on the client's reactive factory and scheduling particulars; we want to be sure it's possible to achieve (even if a client may opt not to exercise it), so it's a distinct test case.

  - Trigger an effect on each change to the form's active language, for each translated label, reflecting the appropriate translation after each update.

  - Do not trigger an effect on repeated reassignment of the currently active language. This is/should be a reactive no-op, both internally and for clients. There's nothing special happening in this PR to achieve that, it relies on the behavior implemented in `createSharedNodeState`. While there are more general ways we could (and maybe should) test that generalization, it felt appropriate to test here because unnecessary translation reactivity is an area that could easily slow down **client performance** across a wide variety of larger forms.

- While the fixes are conceptually quite similar, I think there's some improvement to clarity in where/how some internal-reactive accessors are called. In particular I think it's important to preserve the separation between setup of reactive accessors, and their subsequent/downstream calls.

---

Also in this PR, CI checks that were used to skip certain jobs based on a branch's changes are removed (at least temporarily). In the past we've tolerated CI running seemingly **extraneous jobs**. But in this case, it was observed that no jobs were run for any package downstream from the change. That's risky enough that I think it's appropriate to address in the same PR. If we think it's important to reintroduce such change-based filtering (which we may not!), I'd recommend we file a separate issue so we can discuss how to do it right.
