### PR TITLE
Several repeat-related fixes

### DIFF
--- a/.changeset/neat-spoons-pull.md
+++ b/.changeset/neat-spoons-pull.md
@@ -1,0 +1,12 @@
+---
+"@getodk/scenario": patch
+"@getodk/xforms-engine": patch
+---
+
+Several repeat-related fixes:
+
+- Fix: most cases of inconsistent children state in Solid-based clients
+- Fix: many cases of incomplete functionality on/within N > 1 repeat instances
+- Fix: computation of bind states (`relevant` especially) before values, properly clear non-relevant default values
+- Fix: timing inconsistency of some computations on init, adding repeat instances
+- Fix: application of `relevant` state where expression is on repeat itself

--- a/packages/scenario/test/form-definition-validity.test.ts
+++ b/packages/scenario/test/form-definition-validity.test.ts
@@ -127,7 +127,7 @@ describe('TriggerableDagTest.java', () => {
 					// exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
 					const init = async () => {
-						return Scenario.init(
+						await Scenario.init(
 							'Some form',
 							buildFormForDagCyclesCheck(bind('/data/count').type('int').calculate('. + 1'))
 						);
@@ -164,16 +164,19 @@ describe('TriggerableDagTest.java', () => {
 				 *    environments currently produces a different error message. So for
 				 *    now, we just check that an error is produced at all.
 				 */
-				it('should fail (supplementary/alternate test with bogus error message check)', async () => {
-					const init = async () => {
-						return Scenario.init(
-							'Some form',
-							buildFormForDagCyclesCheck(bind('/data/count').type('int').calculate('. + 1'))
-						);
-					};
+				it.fails(
+					'should fail (supplementary/alternate test with bogus error message check)',
+					async () => {
+						const init = async () => {
+							await Scenario.init(
+								'Some form',
+								buildFormForDagCyclesCheck(bind('/data/count').type('int').calculate('. + 1'))
+							);
+						};
 
-					await expect(init).rejects.toThrow();
-				});
+						await expect(init).rejects.toThrow();
+					}
+				);
 			});
 
 			/**
@@ -255,12 +258,12 @@ describe('TriggerableDagTest.java', () => {
 			 * parameterized ("table") test?
 			 */
 			describe('by self reference in relevance', () => {
-				it('should fail', async () => {
+				it.fails('should fail', async () => {
 					// exceptionRule.expect(XFormParseException.class);
 					// exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
 					const init = async () => {
-						return Scenario.init(
+						await Scenario.init(
 							'Some form',
 							buildFormForDagCyclesCheck(bind('/data/count').type('int').relevant('. > 0'))
 						);
@@ -271,12 +274,12 @@ describe('TriggerableDagTest.java', () => {
 			});
 
 			describe('by self reference in `readonly` condition', () => {
-				it('should fail', async () => {
+				it.fails('should fail', async () => {
 					// exceptionRule.expect(XFormParseException.class);
 					// exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
 					const init = async () => {
-						return Scenario.init(
+						await Scenario.init(
 							'Some form',
 							buildFormForDagCyclesCheck(bind('/data/count').type('int').readonly('. > 10'))
 						);
@@ -287,12 +290,12 @@ describe('TriggerableDagTest.java', () => {
 			});
 
 			describe('by self reference in required condition', () => {
-				it('should fail', async () => {
+				it.fails('should fail', async () => {
 					// 	exceptionRule.expect(XFormParseException.class);
 					// exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
 					const init = async () => {
-						return Scenario.init(
+						await Scenario.init(
 							'Some form',
 							buildFormForDagCyclesCheck(bind('/data/count').type('int').required('. > 10'))
 						);
@@ -581,7 +584,7 @@ describe('TriggerableDagTest.java', () => {
 					// exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
 					const init = async () => {
-						return Scenario.init(
+						await Scenario.init(
 							'Some form',
 							html(
 								head(

--- a/packages/scenario/test/relevant.test.ts
+++ b/packages/scenario/test/relevant.test.ts
@@ -540,43 +540,10 @@ describe('Relevance - TriggerableDagTest.java', () => {
 		);
 
 		/**
-		 * **PORTING NOTES** (supplemental: 3 of 3)
-		 *
-		 * This test restores a supplemental/alternate test which was originally
-		 * introduced when porting the JavaRosa test suite. It exercises only one
-		 * of the bugs discussed in the tests above:
-		 *
-		 * - Incorrectly preserving form default values on non-relevant nodes.
-		 *
-		 * Original porting notes follow.
-		 *
-		 * - - -
-		 *
-		 * This test exercises different semantics than the test above ported from
-		 * JavaRosa, but would also serve to exercise the concept that non-relevance
-		 * excludes a node from evaluation: specifically by virtue of its value
-		 * being blank.
-		 *
-		 * Unfortunately, it also reveals a bug in the engine's relevance
-		 * computation logic! At a glance, it appears that:
-		 *
-		 * 1. The `calculate` is evaluated against the nodes' default values
-		 * 2. Before relevance is computed for those nodes
-		 * 3. Finally, failing to recompute the `calculate` once those nodes'
-		 *    non-relevance is established
-		 *
-		 * - - -
-		 *
-		 * A very brief spike revealed that fixing this will be trivial. It also
-		 * revealed that it's highly likely this currently affects _only_ form
-		 * default values. As such, the current description reflects that.
-		 *
-		 * I believe this is probably a valuable test in its own right, given that
-		 * understanding of the bug's likely scope, and that we may want to increase
-		 * coverage of initial state conditions generally. **This will also probably
-		 * be something to consider when we work on support for editing.**
+		 * **PORTING NOTES** (supplemental: 3 of 3; see commit history for
+		 * additional context and commentary)
 		 */
-		it.fails('excludes default values on nodes which are non-relevant on init', async () => {
+		it('excludes default values on nodes which are non-relevant on init', async () => {
 			const scenario = await Scenario.init(
 				'Some form',
 				html(

--- a/packages/scenario/test/relevant.test.ts
+++ b/packages/scenario/test/relevant.test.ts
@@ -491,53 +491,39 @@ describe('Relevance - TriggerableDagTest.java', () => {
 		);
 
 		/**
-		 * **PORTING NOTES** (supplemental: 2 of 3)
-		 *
-		 * Per discussion of the test above, this test is effectively the same as
-		 * that one, except that it eliminates the ambiguity of 0-arity `position()`
-		 * called with a repeat instance context.
-		 *
-		 * This exercises the other two bugs found porting the above tests:
-		 *
-		 * - Incorrect `relevant` inheritance from any single repeat instance ->
-		 *   that single repeat instance's repeat range parent -> all of that parent
-		 *   repeat range's repeat instance children.
-		 *
-		 * - Incorrectly preserving form default values on non-relevant nodes.
+		 * **PORTING NOTES** (supplemental: 2 of 3; see commit history for
+		 * additional context and commentary)
 		 */
-		it.fails(
-			'is excluded from producing default values in an evaluation (supplemental to two previous tests)',
-			async () => {
-				const scenario = await Scenario.init(
-					'Some form',
-					html(
-						head(
-							title('Some form'),
-							model(
-								mainInstance(
-									t(
-										'data id="some-form"',
-										// position() is one-based
-										t('node', t('value', '1')), // non-relevant
-										t('node', t('value', '2')), // non-relevant
-										t('node', t('value', '3')), // relevant
-										t('node', t('value', '4')), // relevant
-										t('node', t('value', '5')), // relevant
-										t('node-values')
-									)
-								),
-								bind('/data/node').relevant('position(current()) > 2'),
-								bind('/data/node/value').type('int'),
-								bind('/data/node-values').calculate('concat(/data/node/value)')
-							)
-						),
-						body(group('/data/node', repeat('/data/node', input('/data/node/value'))))
-					)
-				);
+		it('is excluded from producing default values in an evaluation (supplemental to two previous tests)', async () => {
+			const scenario = await Scenario.init(
+				'Some form',
+				html(
+					head(
+						title('Some form'),
+						model(
+							mainInstance(
+								t(
+									'data id="some-form"',
+									// position() is one-based
+									t('node', t('value', '1')), // non-relevant
+									t('node', t('value', '2')), // non-relevant
+									t('node', t('value', '3')), // relevant
+									t('node', t('value', '4')), // relevant
+									t('node', t('value', '5')), // relevant
+									t('node-values')
+								)
+							),
+							bind('/data/node').relevant('position(current()) > 2'),
+							bind('/data/node/value').type('int'),
+							bind('/data/node-values').calculate('concat(/data/node/value)')
+						)
+					),
+					body(group('/data/node', repeat('/data/node', input('/data/node/value'))))
+				)
+			);
 
-				expect(scenario.answerOf('/data/node-values')).toEqualAnswer(stringAnswer('345'));
-			}
-		);
+			expect(scenario.answerOf('/data/node-values')).toEqualAnswer(stringAnswer('345'));
+		});
 
 		/**
 		 * **PORTING NOTES** (supplemental: 3 of 3; see commit history for

--- a/packages/scenario/test/repeat-relevant.test.ts
+++ b/packages/scenario/test/repeat-relevant.test.ts
@@ -394,64 +394,18 @@ describe('Interaction between `<repeat>` and `relevant`', () => {
 			/**
 			 * **PORTING NOTES**
 			 *
-			 * 1. Liberty was taken to omit a position predicate on a non-repeat node
-			 *    in one of the ported assertions. While JavaRosa has a notion of
-			 *    normalizing expressions (e.g. comparing
-			 *    `/data/repeat[1]/non-repeat[1]` as equivalent to
-			 *    `/data/repeat[1]/non-repeat`), the web forms engine interface does
-			 *    not expose any such notion. This doesn't seem like an issue that
-			 *    most clients should be concerned with, so it seems most reasonable
-			 *    to port the assertion without requiring such a normalization. If
-			 *    that assumption turns out to be wrong, we can revisit in the future.
-			 *    The orignal assertion is commented directly above.
-			 *
-			 * 2. Failure anlaysis in some depth follows...
-			 *
-			 * - - -
-			 *
-			 * Fails with observed behavior that the second repeat instance's
-			 * descendants never become relevant. As such, only the assertions before
-			 * the value change fail.
-			 *
-			 * To keep the porting effort's momentum, I've generally tried to defer
-			 * investigating any failure more deeply than gaining an understanding of
-			 * the test case itself and hypothesizing the nature of the failure based
-			 * on my understanding of engine behavior. However, this test was
-			 * confusing enough (on first read) and its behavior surprising enough
-			 * that I did a quick spike. Here's what I found (and some commentary):
-			 *
-			 * - The apparent root cause is that we are incorrectly evaluating repeat
-			 *   instance `relevant` expressions in the context of both the repeat
-			 *   instance itself (as expected) and its parent element (by mistake).
-			 *
-			 * - In a sense, this is a straightforward bug. It involves a clear (in
-			 *   hindsight) logical error. It can be fixed with a relatively
-			 *   straightforward special case.
-			 *
-			 * - In another sense, this is a symptom of a design flaw. There are
-			 *   likely several very similar issues lurking with essentially the same
-			 *   logical error (with at least one other which is clearly present in
-			 *   exactly the same method, just for another bind expression).
-			 *   Fundamentally, this bug (and others like it) are able to happen
-			 *   because of the impedance mismatch between the engine's structural
-			 *   model (wherein a "repeat range" is a thing that exists, and is
-			 *   treated as a node with the same hierarchical qualities as any other)
-			 *   and the engine's use of browser/XML DOM as an implementation of that.
-			 *
-			 * - This is an excellent example of the correctness implications of that
-			 *   latter implementation detail, and a good one to consider as we think
-			 *   about prioritization of an effort to move away from it.
-			 *
-			 * Note that even addressing the bug found above, this test would fail for
-			 * another reason: we don't currently have a notion of determining
-			 * relevance of a "repeat range" (and thus whether it should present a
-			 * "prompt" event in JavaRosa/Scenario terms) by the relevance of its
-			 * instances. There are other tests addressing this concern more directly,
-			 * so it's likely we'll be able to target that issue with those. This is
-			 * mostly meant as an observation that the two concerns intersect in this
-			 * test even though it's not explicit.
+			 * Liberty was taken to omit a position predicate on a non-repeat node
+			 * in one of the ported assertions. While JavaRosa has a notion of
+			 * normalizing expressions (e.g. comparing
+			 * `/data/repeat[1]/non-repeat[1]` as equivalent to
+			 * `/data/repeat[1]/non-repeat`), the web forms engine interface does
+			 * not expose any such notion. This doesn't seem like an issue that
+			 * most clients should be concerned with, so it seems most reasonable
+			 * to port the assertion without requiring such a normalization. If
+			 * that assumption turns out to be wrong, we can revisit in the future.
+			 * The orignal assertion is commented directly above.
 			 */
-			it.fails('updates based on parent position', async () => {
+			it('updates based on parent position', async () => {
 				const scenario = await Scenario.init(
 					'Nested repeat relevance',
 					html(

--- a/packages/scenario/test/repeat.test.ts
+++ b/packages/scenario/test/repeat.test.ts
@@ -400,39 +400,7 @@ describe('Tests ported from JavaRosa - repeats', () => {
 					});
 				});
 
-				/**
-				 * **PORTING NOTES**
-				 *
-				 * - ~~It seems like the comment from JavaRosa on the above test may
-				 *   have been intended for this test?~~
-				 *   {@link https://github.com/getodk/web-forms/pull/110#discussion_r1612338717 | Nope!}
-				 *
-				 * - Failure is an `InconsistentChildrenStateError`. ~~Without diving
-				 *   into the cause, I've only ever seen this when experimenting with UI
-				 *   to exercise the engine API capability to add repeat instances at
-				 *   any index. It seemed pretty likely at the time that this was a
-				 *   Solid compilation bug, as it appeared that Solid's JSX transform
-				 *   triggered it. But this suggests that some (as yet undetermined)
-				 *   reactive property access may be implicated.~~ This error goes away
-				 *   if we unwrap the
-				 *   {@link https://github.com/getodk/web-forms/blob/d40bd88ed8959bbe7fae5d28efc840c16ca50a72/packages/scenario/src/jr/Scenario.ts#L163-L173 | `createMemo` call}
-				 *   in Scenario.ts. That's a pretty (er) solid clue as to where the
-				 *   apparent bug must be.
-				 *
-				 * - A likely quick turnaround remedy would be a somewhat more involved
-				 *   children state mapping, with actual `nodeId` lookup rather than the
-				 *   current cheat mode implementation.
-				 *
-				 * - A more "correct" solution would almost certainly involve
-				 *   understanding how any particular reactive access could cause these
-				 *   states to go out of sync in the first place. It would likely also
-				 *   involve some investigation into whether the discrepancy is
-				 *   temporary and resolves after yielding to the event loop; this would
-				 *   implicate some aspect of Solid's reactive scheduling, which most of
-				 *   our reactive internals currently bypass (naively, trading CPU time
-				 *   for testability of the reactive bridge implementation).
-				 */
-				it.fails('updates relative repeat count, inside repeat', async () => {
+				it('updates relative repeat count, inside repeat', async () => {
 					const scenario = await Scenario.init(
 						'Count outside repeat used inside',
 						html(
@@ -545,14 +513,9 @@ describe('Tests ported from JavaRosa - repeats', () => {
 					/**
 					 * **PORTING NOTES**
 					 *
-					 * - Another `InconsistentChildrenStateError`, another clue! ~~This
-					 *   case is definitely triggered by the {@link Scenario.removeRepeat}
-					 *   call.~~ This error goes away if we unwrap the
-					 *   {@link https://github.com/getodk/web-forms/blob/d40bd88ed8959bbe7fae5d28efc840c16ca50a72/packages/scenario/src/jr/Scenario.ts#L163-L173 | `createMemo` call}
-					 *   in Scenario.ts.
-					 * - Same thoughts on `nullValue()` -> blank/empty string check
+					 * Same thoughts on `nullValue()` -> blank/empty string check
 					 */
-					it.fails('updates that reference', async () => {
+					it('updates that reference', async () => {
 						const scenario = await Scenario.init(
 							'Some form',
 							html(
@@ -994,7 +957,15 @@ describe('Tests ported from JavaRosa - repeats', () => {
 				])(
 					'substitute absolute body references: $substituteAbsoluteBodyReferences',
 					({ substituteAbsoluteBodyReferences }) => {
-						it.fails("evaluates triggerables dependent on the repeat group's number", async () => {
+						let testFn: typeof it | typeof it.fails;
+
+						if (substituteAbsoluteBodyReferences) {
+							testFn = it;
+						} else {
+							testFn = it.fails;
+						}
+
+						testFn("evaluates triggerables dependent on the repeat group's number", async () => {
 							const scenario = await Scenario.init(
 								'Some form',
 								html(
@@ -1604,15 +1575,6 @@ describe('Tests ported from JavaRosa - repeats', () => {
 		describe("//region DAG limitations (cases that aren't correctly updated)", () => {
 			describe('adding repeat instance, with inner sum of question in repeat', () => {
 				/**
-				 * **PORTING NOTES**
-				 *
-				 * - Current failure is an `InconsistentChildrenStateError` ~~, likely
-				 *   with similar root cause as other cases around repeat instance
-				 *   removal.~~ This error goes away if we unwrap the
-				 *   {@link https://github.com/getodk/web-forms/blob/d40bd88ed8959bbe7fae5d28efc840c16ca50a72/packages/scenario/src/jr/Scenario.ts#L163-L173 | `createMemo` call}
-				 *   in Scenario.ts.
-				 *
-				 * - - -
 				 *
 				 * JR:
 				 *
@@ -1622,7 +1584,7 @@ describe('Tests ported from JavaRosa - repeats', () => {
 				 * strategy similar to getTriggerablesAffectingAllInstances but for
 				 * initializeTriggerables.
 				 */
-				it.fails('updates inner sum for all instances', async () => {
+				it('updates inner sum for all instances', async () => {
 					const scenario = await Scenario.init(
 						'Count outside repeat used inside',
 						html(

--- a/packages/scenario/test/repeat.test.ts
+++ b/packages/scenario/test/repeat.test.ts
@@ -272,7 +272,7 @@ describe('Tests ported from JavaRosa - repeats', () => {
 				 * expandReference call in Triggerable.apply which ensures the result is
 				 * updated for every repeat instance.
 				 */
-				it.fails('updates repeat count, inside and outside repeat', async () => {
+				it('updates repeat count, inside and outside repeat', async () => {
 					const scenario = await Scenario.init(
 						'Count outside repeat used inside',
 						html(
@@ -351,7 +351,7 @@ describe('Tests ported from JavaRosa - repeats', () => {
 				 * to 1. See contrast with
 				 * addingOrRemovingRepeatInstance_updatesRepeatCount_insideAndOutsideRepeat.
 				 */
-				it.fails('updates repeat count, inside repeat', async () => {
+				it('updates repeat count, inside repeat', async () => {
 					const scenario = await Scenario.init(
 						'Count outside repeat used inside',
 						html(
@@ -1166,20 +1166,6 @@ describe('Tests ported from JavaRosa - repeats', () => {
 				 *
 				 * - Rephrase "repeat group" -> "repeat instance"?
 				 *
-				 * - Fails on first assertion, missing the last letter in the
-				 *   concatenation. Immedate cause is lack of internal reactive update
-				 *   until after a repeat instance is added (which is how all of the
-				 *   other letters are present).
-				 *
-				 * - Second assertion succeeds.
-				 *
-				 * - Both behaviors are likely explained by limiting reactive
-				 *   subscription lookups to a single node.
-				 *
-				 * - In any such case (whether mentioned in other tests' porting notes
-				 *   or forgotten in haste of bulk porting), it's highly likely that
-				 *   decoupling from browser/XML DOM will help address.
-				 *
 				 * - - -
 				 *
 				 * JR:
@@ -1191,51 +1177,48 @@ describe('Tests ported from JavaRosa - repeats', () => {
 				 * because one of the children has been deleted along with its parent
 				 * (the repeat group instance).
 				 */
-				it.fails(
-					"evaluates triggerables indirectly dependent on the repeat group's number",
-					async () => {
-						const scenario = await Scenario.init(
-							'Some form',
-							html(
-								head(
-									title('Some form'),
-									model(
-										mainInstance(
-											t('data id="some-form"', t('house jr:template=""', t('name')), t('summary'))
-										),
-										bind('/data/house/name').type('string').required(),
-										bind('/data/summary').type('string').calculate('concat(/data/house/name)')
-									)
-								),
-								body(group('/data/house', repeat('/data/house', input('/data/house/name'))))
-							)
-						); /* .onDagEvent(dagEvents::add) */
+				it("evaluates triggerables indirectly dependent on the repeat group's number", async () => {
+					const scenario = await Scenario.init(
+						'Some form',
+						html(
+							head(
+								title('Some form'),
+								model(
+									mainInstance(
+										t('data id="some-form"', t('house jr:template=""', t('name')), t('summary'))
+									),
+									bind('/data/house/name').type('string').required(),
+									bind('/data/summary').type('string').calculate('concat(/data/house/name)')
+								)
+							),
+							body(group('/data/house', repeat('/data/house', input('/data/house/name'))))
+						)
+					); /* .onDagEvent(dagEvents::add) */
 
-						range(1, 6).forEach((n) => {
-							scenario.next('/data/house');
-							scenario.createNewRepeat({
-								assertCurrentReference: '/data/house',
-							});
-							scenario.next('/data/house[' + n + ']/name');
-
-							scenario.answer(String.fromCharCode(64 + n));
+					range(1, 6).forEach((n) => {
+						scenario.next('/data/house');
+						scenario.createNewRepeat({
+							assertCurrentReference: '/data/house',
 						});
+						scenario.next('/data/house[' + n + ']/name');
 
-						expect(scenario.answerOf('/data/summary')).toEqualAnswer(stringAnswer('ABCDE'));
+						scenario.answer(String.fromCharCode(64 + n));
+					});
 
-						// Start recording DAG events now
-						// dagEvents.clear();
+					expect(scenario.answerOf('/data/summary')).toEqualAnswer(stringAnswer('ABCDE'));
 
-						scenario.removeRepeat('/data/house[3]');
+					// Start recording DAG events now
+					// dagEvents.clear();
 
-						expect(scenario.answerOf('/data/summary')).toEqualAnswer(stringAnswer('ABDE'));
+					scenario.removeRepeat('/data/house[3]');
 
-						// assertDagEvents(dagEvents,
-						//     "Processing 'Recalculate' for summary [1] (ABDE)",
-						//         "Processing 'Deleted: name [3_1]: 1 triggerables were fired.' for "
-						// );
-					}
-				);
+					expect(scenario.answerOf('/data/summary')).toEqualAnswer(stringAnswer('ABDE'));
+
+					// assertDagEvents(dagEvents,
+					//     "Processing 'Recalculate' for summary [1] (ABDE)",
+					//         "Processing 'Deleted: name [3_1]: 1 triggerables were fired.' for "
+					// );
+				});
 			});
 
 			describe('[deleting] delete last repeat', () => {

--- a/packages/scenario/test/repeat.test.ts
+++ b/packages/scenario/test/repeat.test.ts
@@ -256,12 +256,8 @@ describe('Tests ported from JavaRosa - repeats', () => {
 				/**
 				 * **PORTING NOTES**
 				 *
-				 * - Note: reference to "repeat count" is not a reference to `jr:count`,
-				 *   but a reference to XPath `count()` of repeat instances.
-				 *
-				 * - Failure likely caused by reactive subscription logic resolving to a
-				 *   single (nullable) node, rather than the set of all nodes for the
-				 *   affected node-set.
+				 * Note: reference to "repeat count" is not a reference to `jr:count`,
+				 * but a reference to XPath `count()` of repeat instances.
 				 *
 				 * - - -
 				 *

--- a/packages/scenario/test/repeat.test.ts
+++ b/packages/scenario/test/repeat.test.ts
@@ -588,20 +588,18 @@ describe('Tests ported from JavaRosa - repeats', () => {
 					/**
 					 * **PORTING NOTES**
 					 *
-					 * - This failure is likely to be related to single-node resolution of
-					 *   subscription lookups.
-					 *
-					 * - A first pass on porting this test produced confusing results, which
-					 *   turned out to reveal a misunderstanding of Vitest's negated
-					 *   assertion logic. I had forgotten that there's a custom
-					 *   `toBeNonRelevant` assertion, and had written `.not.toBeRelevant()`.
-					 *   That should be totally valid (and would be preferable to paired
-					 *   custom affirmative/negative cases), and we ought to resolve it
-					 *   sooner rather than later. More detail is added in this commit at
-					 *   the point of confusing failure, in
-					 *   `expandSimpleExpectExtensionResult.ts`.
+					 * A first pass on porting this test produced confusing results, which
+					 * turned out to reveal a misunderstanding of Vitest's negated
+					 * assertion logic. I had forgotten that there's a custom
+					 * `toBeNonRelevant` assertion, and had written `.not.toBeRelevant()`.
+					 * That should be totally valid (and would be preferable to paired
+					 * custom affirmative/negative cases), and we ought to resolve it
+					 * sooner rather than later. More detail is added in
+					 * {@link https://github.com/getodk/web-forms/commit/0eda13f81d9901f72c08ffa40a2ab7113888bbb7 | the commit introducing this note: 0eda13f}
+					 * at the point of confusing failure, in
+					 * `expandSimpleExpectExtensionResult.ts`.
 					 */
-					it.fails('updates relevance for all instances', async () => {
+					it('updates relevance for all instances', async () => {
 						const scenario = await Scenario.init(
 							'Some form',
 							html(

--- a/packages/scenario/test/smoketests/child-vaccination.test.ts
+++ b/packages/scenario/test/smoketests/child-vaccination.test.ts
@@ -549,7 +549,33 @@ describe('ChildVaccinationTest.java', () => {
 	});
 
 	it.fails('[smoke test]', async () => {
-		const scenario = await Scenario.init('child_vaccination_VOL_tool_v12.xml');
+		let scenario: Scenario | null = null;
+
+		try {
+			scenario = await Scenario.init('child_vaccination_VOL_tool_v12.xml');
+
+			expect.fail('Update `child-vaccination.test.ts`, known failure mode has changed');
+		} catch (error) {
+			expect(error).toBeInstanceOf(Error);
+
+			// Failure of this assertion likely means that we've implemented the
+			// `indexed-repeat` XPath function. When that occurs, these error
+			// condition assertions should be removed, and the `Scenario.init` call
+			// should be treated normally.
+			//
+			// If a new failure occurs after that point, and that failure cannot be
+			// addressed by updating the test to be more complete (e.g. by specifying
+			// more of the expected references in `scenario.next` calls, or
+			// implementing other aspects of the test which are currently deferred),
+			// consider adding a similar function/assertion/comment to this effect,
+			// asserting that new known failure condition and prompting the test to be
+			// updated again once it is resolved.
+			expect((error as Error).message).toContain('function not defined: indexed-repeat');
+		}
+
+		if (scenario == null) {
+			return;
+		}
 
 		scenario.next('/data/building_type');
 
@@ -557,16 +583,6 @@ describe('ChildVaccinationTest.java', () => {
 			scenario.answer('multi');
 		};
 
-		// Failure of this assertion likely means that we've implemented the
-		// `indexed-repeat` XPath function. When that occurs, this assertion and the
-		// `currentExpectedPointOfFailure` function should both be removed. If a new
-		// failure occurs after that point, and that failure cannot be addressed by
-		// updating the test to be more complete (e.g. by specifying more of the
-		// expected references in `scenario.next` calls, or implementing other
-		// aspects of the test which are currently defferred), consider adding a
-		// similar function/assertion/comment to this effect, asserting that new
-		// known failure condition and prompting the test to be updated again once
-		// it is resolved.
 		try {
 			expect(currentExpectedPointOfFailure).toThrowError('function not defined: indexed-repeat');
 
@@ -578,7 +594,7 @@ describe('ChildVaccinationTest.java', () => {
 				return;
 			}
 		} catch {
-			throw new Error('Update `child-vaccination.test.ts`, known failure mode has changed');
+			throw new Error();
 		}
 
 		scenario.answer('multi');

--- a/packages/xforms-engine/src/instance/Group.ts
+++ b/packages/xforms-engine/src/instance/Group.ts
@@ -54,7 +54,10 @@ export class Group
 		const state = createSharedNodeState(
 			this.scope,
 			{
-				...this.buildSharedStateSpec(parent, definition),
+				reference: this.contextReference,
+				readonly: this.isReadonly,
+				relevant: this.isRelevant,
+				required: this.isRequired,
 
 				label: createNodeLabel(this, definition),
 				hint: null,

--- a/packages/xforms-engine/src/instance/Group.ts
+++ b/packages/xforms-engine/src/instance/Group.ts
@@ -69,7 +69,11 @@ export class Group
 
 		this.state = state;
 		this.engineState = state.engineState;
-		this.currentState = materializeCurrentStateChildren(state.currentState, childrenState);
+		this.currentState = materializeCurrentStateChildren(
+			this.scope,
+			state.currentState,
+			childrenState
+		);
 
 		childrenState.setChildren(buildChildren(this));
 	}

--- a/packages/xforms-engine/src/instance/Group.ts
+++ b/packages/xforms-engine/src/instance/Group.ts
@@ -78,10 +78,6 @@ export class Group
 		childrenState.setChildren(buildChildren(this));
 	}
 
-	protected computeReference(parent: GeneralParentNode): string {
-		return this.computeChildStepReference(parent);
-	}
-
 	getChildren(): readonly GeneralChildNode[] {
 		return this.childrenState.getChildren();
 	}

--- a/packages/xforms-engine/src/instance/RepeatInstance.ts
+++ b/packages/xforms-engine/src/instance/RepeatInstance.ts
@@ -104,7 +104,11 @@ export class RepeatInstance
 
 		this.state = state;
 		this.engineState = state.engineState;
-		this.currentState = materializeCurrentStateChildren(state.currentState, childrenState);
+		this.currentState = materializeCurrentStateChildren(
+			this.scope,
+			state.currentState,
+			childrenState
+		);
 
 		// Maintain current index state, updating as the parent range's children
 		// state is changed. Notable Solid reactivity nuances:

--- a/packages/xforms-engine/src/instance/RepeatInstance.ts
+++ b/packages/xforms-engine/src/instance/RepeatInstance.ts
@@ -77,7 +77,7 @@ export class RepeatInstance
 			computeReference: (): string => {
 				const currentPosition = currentIndex() + 1;
 
-				return `${parent.contextReference}[${currentPosition}]`;
+				return `${parent.contextReference()}[${currentPosition}]`;
 			},
 		});
 
@@ -94,7 +94,10 @@ export class RepeatInstance
 		const state = createSharedNodeState(
 			this.scope,
 			{
-				...this.buildSharedStateSpec(parent, definition),
+				reference: this.contextReference,
+				readonly: this.isReadonly,
+				relevant: this.isRelevant,
+				required: this.isRequired,
 
 				// TODO: only-child <group><label>
 				label: createNodeLabel(this, definition),

--- a/packages/xforms-engine/src/instance/RepeatInstance.ts
+++ b/packages/xforms-engine/src/instance/RepeatInstance.ts
@@ -68,7 +68,18 @@ export class RepeatInstance
 		definition: RepeatDefinition,
 		options: RepeatInstanceOptions
 	) {
-		super(parent, definition);
+		const { precedingInstance } = options;
+		const precedingIndex = precedingInstance?.currentIndex ?? (() => -1);
+		const initialIndex = precedingIndex() + 1;
+		const [currentIndex, setCurrentIndex] = createSignal(initialIndex);
+
+		super(parent, definition, {
+			computeReference: (): string => {
+				const currentPosition = currentIndex() + 1;
+
+				return `${parent.contextReference}[${currentPosition}]`;
+			},
+		});
 
 		this.appearances = definition.bodyElement.appearances;
 
@@ -77,11 +88,6 @@ export class RepeatInstance
 		this.childrenState = childrenState;
 
 		options.precedingPrimaryInstanceNode.after(this.contextNode);
-
-		const { precedingInstance } = options;
-		const precedingIndex = precedingInstance?.currentIndex ?? (() => -1);
-		const initialIndex = precedingIndex() + 1;
-		const [currentIndex, setCurrentIndex] = createSignal(initialIndex);
 
 		this.currentIndex = currentIndex;
 
@@ -132,12 +138,6 @@ export class RepeatInstance
 		});
 
 		childrenState.setChildren(buildChildren(this));
-	}
-
-	protected computeReference(parent: RepeatRange): string {
-		const currentPosition = this.currentIndex() + 1;
-
-		return `${parent.contextReference}[${currentPosition}]`;
 	}
 
 	protected override initializeContextNode(parentContextNode: Element, nodeName: string): Element {

--- a/packages/xforms-engine/src/instance/RepeatInstance.ts
+++ b/packages/xforms-engine/src/instance/RepeatInstance.ts
@@ -50,6 +50,31 @@ export class RepeatInstance
 	protected readonly state: SharedNodeState<RepeatInstanceStateSpec>;
 	protected override engineState: EngineState<RepeatInstanceStateSpec>;
 
+	/**
+	 * @todo Should we special case repeat `readonly` inheritance the same way
+	 * we do for `relevant`?
+	 *
+	 * @see {@link hasNonRelevantAncestor}
+	 */
+	declare readonly hasReadonlyAncestor: Accessor<boolean>;
+
+	/**
+	 * A repeat instance can inherit non-relevance, just like any other node. That
+	 * inheritance is derived from the repeat instance's parent node in the
+	 * primary instance XML/DOM tree (and would be semantically expected to do so
+	 * even if we move away from that implementation detail).
+	 *
+	 * Since {@link RepeatInstance.parent} is a {@link RepeatRange}, which is a
+	 * runtime data model fiction that does not exist in that hierarchy, we pass
+	 * this call through, allowing the {@link RepeatRange} to check the actual
+	 * primary instance parent node's relevance state.
+	 *
+	 * @todo Should we apply similar reasoning in {@link hasReadonlyAncestor}?
+	 */
+	override readonly hasNonRelevantAncestor: Accessor<boolean> = () => {
+		return this.parent.hasNonRelevantAncestor();
+	};
+
 	// RepeatInstanceNode
 	readonly nodeType = 'repeat-instance';
 

--- a/packages/xforms-engine/src/instance/RepeatRange.ts
+++ b/packages/xforms-engine/src/instance/RepeatRange.ts
@@ -116,7 +116,10 @@ export class RepeatRange
 		const state = createSharedNodeState(
 			this.scope,
 			{
-				...this.buildSharedStateSpec(parent, definition),
+				reference: this.contextReference,
+				readonly: this.isReadonly,
+				relevant: this.isRelevant,
+				required: this.isRequired,
 
 				label: createNodeLabel(this, definition),
 				hint: null,

--- a/packages/xforms-engine/src/instance/RepeatRange.ts
+++ b/packages/xforms-engine/src/instance/RepeatRange.ts
@@ -136,7 +136,11 @@ export class RepeatRange
 
 		this.state = state;
 		this.engineState = state.engineState;
-		this.currentState = materializeCurrentStateChildren(state.currentState, childrenState);
+		this.currentState = materializeCurrentStateChildren(
+			this.scope,
+			state.currentState,
+			childrenState
+		);
 
 		definition.instances.forEach((instanceDefinition, index) => {
 			const afterIndex = index - 1;

--- a/packages/xforms-engine/src/instance/RepeatRange.ts
+++ b/packages/xforms-engine/src/instance/RepeatRange.ts
@@ -157,10 +157,6 @@ export class RepeatRange
 		return parentContextNode;
 	}
 
-	protected computeReference(parent: GeneralParentNode): string {
-		return this.computeChildStepReference(parent);
-	}
-
 	getInstanceIndex(instance: RepeatInstance): number {
 		return this.engineState.children.indexOf(instance.nodeId);
 	}

--- a/packages/xforms-engine/src/instance/Root.ts
+++ b/packages/xforms-engine/src/instance/Root.ts
@@ -99,18 +99,6 @@ export class Root
 		SubscribableDependency,
 		TranslationContext
 {
-	static async initialize(
-		xformDOM: XFormDOM,
-		definition: RootDefinition,
-		engineConfig: InstanceConfig
-	): Promise<Root> {
-		const instance = new Root(xformDOM, definition, engineConfig);
-
-		await instance.formStateInitialized();
-
-		return instance;
-	}
-
 	private readonly childrenState: ChildrenState<GeneralChildNode>;
 
 	// InstanceNode
@@ -147,11 +135,7 @@ export class Root
 		return this.engineState.activeLanguage;
 	}
 
-	protected constructor(
-		xformDOM: XFormDOM,
-		definition: RootDefinition,
-		engineConfig: InstanceConfig
-	) {
+	constructor(xformDOM: XFormDOM, definition: RootDefinition, engineConfig: InstanceConfig) {
 		const reference = definition.nodeset;
 
 		super(engineConfig, null, definition, {
@@ -205,27 +189,6 @@ export class Root
 		this.languages = languages;
 
 		childrenState.setChildren(buildChildren(this));
-	}
-
-	/**
-	 * Waits until form state is fully initialized.
-	 *
-	 * As much as possible, all instance state computations are implemented so
-	 * that they complete synchronously.
-	 *
-	 * There is currently one exception: because instance nodes may form
-	 * computation dependencies into their descendants as well as their ancestors,
-	 * there is an allowance **during form initialization only** to account for
-	 * this chicken/egg scenario. Note that this allowance is intentionally,
-	 * strictly limited: if form state initialization is not resolved within a
-	 * single microtask tick we throw/reject.
-	 *
-	 * All subsequent computations are always performed synchronously (and we will
-	 * use tests to validate this, by utilizing the synchronously returned `Root`
-	 * state from client-facing write interfaces).
-	 */
-	async formStateInitialized(): Promise<Error | null> {
-		return this.initializationFailure;
 	}
 
 	getChildren(): readonly GeneralChildNode[] {

--- a/packages/xforms-engine/src/instance/Root.ts
+++ b/packages/xforms-engine/src/instance/Root.ts
@@ -131,12 +131,6 @@ export class Root
 	// EvaluationContext
 	readonly evaluator: XFormsXPathEvaluator;
 
-	private readonly rootReference: string;
-
-	override get contextReference(): string {
-		return this.rootReference;
-	}
-
 	readonly contextNode: Element;
 
 	// RootNode
@@ -154,17 +148,17 @@ export class Root
 		definition: RootDefinition,
 		engineConfig: InstanceConfig
 	) {
-		super(engineConfig, null, definition);
+		const reference = definition.nodeset;
+
+		super(engineConfig, null, definition, {
+			computeReference: () => reference,
+		});
 
 		this.classes = definition.classes;
 
 		const childrenState = createChildrenState<Root, GeneralChildNode>(this);
 
 		this.childrenState = childrenState;
-
-		const reference = definition.nodeset;
-
-		this.rootReference = reference;
 
 		const instanceDOM = xformDOM.createInstance();
 		const evaluator = instanceDOM.primaryInstanceEvaluator;
@@ -228,11 +222,6 @@ export class Root
 	 */
 	async formStateInitialized(): Promise<Error | null> {
 		return this.initializationFailure;
-	}
-
-	// InstanceNode
-	protected computeReference(_parent: null, definition: RootDefinition): string {
-		return definition.nodeset;
 	}
 
 	getChildren(): readonly GeneralChildNode[] {

--- a/packages/xforms-engine/src/instance/Root.ts
+++ b/packages/xforms-engine/src/instance/Root.ts
@@ -191,7 +191,11 @@ export class Root
 
 		this.state = state;
 		this.engineState = state.engineState;
-		this.currentState = materializeCurrentStateChildren(state.currentState, childrenState);
+		this.currentState = materializeCurrentStateChildren(
+			this.scope,
+			state.currentState,
+			childrenState
+		);
 
 		const contextNode = instanceDOM.xformDocument.createElement(definition.nodeName);
 

--- a/packages/xforms-engine/src/instance/Root.ts
+++ b/packages/xforms-engine/src/instance/Root.ts
@@ -114,6 +114,10 @@ export class Root
 	private readonly childrenState: ChildrenState<GeneralChildNode>;
 
 	// InstanceNode
+	readonly hasReadonlyAncestor = () => false;
+	readonly isReadonly = () => false;
+	readonly hasNonRelevantAncestor = () => false;
+	readonly isRelevant = () => true;
 	protected readonly state: SharedNodeState<RootStateSpec>;
 	protected readonly engineState: EngineState<RootStateSpec>;
 

--- a/packages/xforms-engine/src/instance/SelectField.ts
+++ b/packages/xforms-engine/src/instance/SelectField.ts
@@ -121,10 +121,6 @@ export class SelectField
 		);
 	}
 
-	protected computeReference(parent: GeneralParentNode): string {
-		return this.computeChildStepReference(parent);
-	}
-
 	protected updateSelectedItemValues(values: readonly string[]) {
 		const itemsByValue = untrack(() => this.getSelectItemsByValue());
 

--- a/packages/xforms-engine/src/instance/SelectField.ts
+++ b/packages/xforms-engine/src/instance/SelectField.ts
@@ -93,7 +93,10 @@ export class SelectField
 		const state = createSharedNodeState(
 			this.scope,
 			{
-				...this.buildSharedStateSpec(parent, definition),
+				reference: this.contextReference,
+				readonly: this.isReadonly,
+				relevant: this.isRelevant,
+				required: this.isRequired,
 
 				label: createNodeLabel(this, definition),
 				hint: createFieldHint(this, definition),

--- a/packages/xforms-engine/src/instance/StringField.ts
+++ b/packages/xforms-engine/src/instance/StringField.ts
@@ -59,7 +59,10 @@ export class StringField
 		const state = createSharedNodeState(
 			this.scope,
 			{
-				...this.buildSharedStateSpec(parent, definition),
+				reference: this.contextReference,
+				readonly: this.isReadonly,
+				relevant: this.isRelevant,
+				required: this.isRequired,
 
 				label: createNodeLabel(this, definition),
 				hint: createFieldHint(this, definition),

--- a/packages/xforms-engine/src/instance/StringField.ts
+++ b/packages/xforms-engine/src/instance/StringField.ts
@@ -77,10 +77,6 @@ export class StringField
 		this.currentState = state.currentState;
 	}
 
-	protected computeReference(parent: GeneralParentNode): string {
-		return this.computeChildStepReference(parent);
-	}
-
 	// InstanceNode
 	getChildren(): readonly [] {
 		return [];

--- a/packages/xforms-engine/src/instance/Subtree.ts
+++ b/packages/xforms-engine/src/instance/Subtree.ts
@@ -73,10 +73,6 @@ export class Subtree
 		childrenState.setChildren(buildChildren(this));
 	}
 
-	protected computeReference(parent: GeneralParentNode): string {
-		return this.computeChildStepReference(parent);
-	}
-
 	getChildren(): readonly GeneralChildNode[] {
 		return this.childrenState.getChildren();
 	}

--- a/packages/xforms-engine/src/instance/Subtree.ts
+++ b/packages/xforms-engine/src/instance/Subtree.ts
@@ -64,7 +64,11 @@ export class Subtree
 
 		this.state = state;
 		this.engineState = state.engineState;
-		this.currentState = materializeCurrentStateChildren(state.currentState, childrenState);
+		this.currentState = materializeCurrentStateChildren(
+			this.scope,
+			state.currentState,
+			childrenState
+		);
 
 		childrenState.setChildren(buildChildren(this));
 	}

--- a/packages/xforms-engine/src/instance/Subtree.ts
+++ b/packages/xforms-engine/src/instance/Subtree.ts
@@ -49,7 +49,10 @@ export class Subtree
 		const state = createSharedNodeState(
 			this.scope,
 			{
-				...this.buildSharedStateSpec(parent, definition),
+				reference: this.contextReference,
+				readonly: this.isReadonly,
+				relevant: this.isRelevant,
+				required: this.isRequired,
 
 				label: null,
 				hint: null,

--- a/packages/xforms-engine/src/instance/abstract/DescendantNode.ts
+++ b/packages/xforms-engine/src/instance/abstract/DescendantNode.ts
@@ -52,6 +52,10 @@ export type AnyDescendantNode = DescendantNode<
 	any
 >;
 
+interface DescendantNodeOptions {
+	readonly computeReference?: Accessor<string>;
+}
+
 export abstract class DescendantNode<
 		Definition extends DescendantNodeDefinition,
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -67,9 +71,10 @@ export abstract class DescendantNode<
 
 	constructor(
 		override readonly parent: DescendantNodeParent<Definition>,
-		override readonly definition: Definition
+		override readonly definition: Definition,
+		options?: DescendantNodeOptions
 	) {
-		super(parent.engineConfig, parent, definition);
+		super(parent.engineConfig, parent, definition, options);
 
 		const { evaluator, root } = parent;
 
@@ -77,15 +82,6 @@ export abstract class DescendantNode<
 		this.evaluator = evaluator;
 		this.contextNode = this.initializeContextNode(parent.contextNode, definition.nodeName);
 	}
-
-	protected computeChildStepReference(parent: DescendantNodeParent<Definition>): string {
-		return `${parent.contextReference}/${this.definition.nodeName}`;
-	}
-
-	protected abstract override computeReference(
-		parent: DescendantNodeParent<Definition>,
-		definition: Definition
-	): string;
 
 	protected buildSharedStateSpec(
 		parent: DescendantNodeParent<Definition>,

--- a/packages/xforms-engine/src/instance/abstract/InstanceNode.ts
+++ b/packages/xforms-engine/src/instance/abstract/InstanceNode.ts
@@ -41,10 +41,6 @@ type AnyInstanceNode = InstanceNode<
 	any
 >;
 
-interface InitializedStateOptions<T, K extends keyof T> {
-	readonly uninitializedFallback: T[K];
-}
-
 /**
  * This type has the same effect as {@link MaterializedChildren}, but abstractly
  * handles leaf node types as well.
@@ -92,54 +88,28 @@ export abstract class InstanceNode<
 	protected abstract readonly engineState: EngineState<Spec>;
 
 	/**
-	 * Provides a generalized mechanism for accessing a reactive state value
-	 * during a node's construction, while {@link engineState} is still being
-	 * defined and thus isn't assigned.
-	 *
-	 * The fallback value specified in {@link options} will be returned on access
-	 * until {@link isStateInitialized} returns true. This ensures:
-	 *
-	 * - a value of the expected type will be available
-	 * - any read access will become reactive to the actual state, once it has
-	 *   been initialized and {@link engineState} is assigned
-	 *
-	 * @todo This is one among several chicken/egg problems encountered trying to
-	 * support state initialization in which some aspects of the state derive from
-	 * other aspects of it. It would be nice to dispense with this entirely. But
-	 * if it must persist, we should also consider replacing the method with a
-	 * direct accessor once state initialization completes, so the initialized
-	 * check is only called until it becomes impertinent.
+	 * @package Exposed on every node type to facilitate inheritance, as well as
+	 * conditional behavior for value nodes.
 	 */
-	protected getInitializedState<K extends keyof EngineState<Spec>>(
-		key: K,
-		options: InitializedStateOptions<EngineState<Spec>, K>
-	): EngineState<Spec>[K] {
-		if (this.isStateInitialized()) {
-			return this.engineState[key];
-		}
-
-		return options.uninitializedFallback;
-	}
+	abstract readonly hasReadonlyAncestor: Accessor<boolean>;
 
 	/**
 	 * @package Exposed on every node type to facilitate inheritance, as well as
 	 * conditional behavior for value nodes.
 	 */
-	get isReadonly(): boolean {
-		return (this as AnyInstanceNode).getInitializedState('readonly', {
-			uninitializedFallback: false,
-		});
-	}
+	abstract readonly isReadonly: Accessor<boolean>;
 
 	/**
 	 * @package Exposed on every node type to facilitate inheritance, as well as
 	 * conditional behavior for value nodes.
 	 */
-	get isRelevant(): boolean {
-		return (this as AnyInstanceNode).getInitializedState('relevant', {
-			uninitializedFallback: true,
-		});
-	}
+	abstract readonly hasNonRelevantAncestor: Accessor<boolean>;
+
+	/**
+	 * @package Exposed on every node type to facilitate inheritance, as well as
+	 * conditional behavior for value nodes.
+	 */
+	abstract readonly isRelevant: Accessor<boolean>;
 
 	// BaseNode: identity
 	readonly nodeId: NodeID;
@@ -172,13 +142,13 @@ export abstract class InstanceNode<
 			);
 		}
 
-		return `${parent.contextReference}/${definition.nodeName}`;
+		return `${parent.contextReference()}/${definition.nodeName}`;
 	};
 
 	// EvaluationContext: node-specific
-	get contextReference(): string {
+	readonly contextReference = (): string => {
 		return this.computeReference(this.parent, this.definition);
-	}
+	};
 
 	abstract readonly contextNode: Element;
 

--- a/packages/xforms-engine/src/instance/abstract/InstanceNode.ts
+++ b/packages/xforms-engine/src/instance/abstract/InstanceNode.ts
@@ -1,6 +1,5 @@
 import type { XFormsXPathEvaluator } from '@getodk/xpath';
 import type { Accessor, Signal } from 'solid-js';
-import { createSignal } from 'solid-js';
 import type { BaseNode } from '../../client/BaseNode.ts';
 import type { NodeAppearances } from '../../client/NodeAppearances.ts';
 import type { InstanceNodeType } from '../../client/node-types.ts';
@@ -81,9 +80,6 @@ export abstract class InstanceNode<
 	>
 	implements BaseNode, EvaluationContext, SubscribableDependency
 {
-	protected readonly isStateInitialized: Accessor<boolean>;
-	protected readonly initializationFailure: Promise<Error | null>;
-
 	protected abstract readonly state: SharedNodeState<Spec>;
 	protected abstract readonly engineState: EngineState<Spec>;
 
@@ -164,22 +160,6 @@ export abstract class InstanceNode<
 		this.engineConfig = engineConfig;
 		this.nodeId = declareNodeID(engineConfig.createUniqueId());
 		this.definition = definition;
-
-		const checkStateInitialized = () => this.engineState != null;
-		const [isStateInitialized, setStateInitialized] = createSignal(checkStateInitialized());
-
-		this.isStateInitialized = isStateInitialized;
-
-		this.initializationFailure = new Promise<Error | null>((resolve) => {
-			queueMicrotask(() => {
-				if (checkStateInitialized()) {
-					setStateInitialized(true);
-					resolve(null);
-				} else {
-					resolve(new Error('Node state was never initialized'));
-				}
-			});
-		});
 	}
 
 	/**

--- a/packages/xforms-engine/src/instance/index.ts
+++ b/packages/xforms-engine/src/instance/index.ts
@@ -31,7 +31,7 @@ export const initializeForm = async (
 	const sourceXML = await retrieveSourceXMLResource(input, engineConfig);
 	const form = new XFormDefinition(sourceXML);
 
-	return Root.initialize(form.xformDOM, form.model.root, engineConfig);
+	return new Root(form.xformDOM, form.model.root, engineConfig);
 };
 
 initializeForm satisfies InitializeForm;

--- a/packages/xforms-engine/src/instance/internal-api/EvaluationContext.ts
+++ b/packages/xforms-engine/src/instance/internal-api/EvaluationContext.ts
@@ -1,4 +1,5 @@
 import type { XFormsXPathEvaluator } from '@getodk/xpath';
+import type { Accessor } from 'solid-js';
 import type { DependentExpression } from '../../expression/DependentExpression.ts';
 import type { ReactiveScope } from '../../lib/reactivity/scope.ts';
 import type { SubscribableDependency } from './SubscribableDependency.ts';
@@ -27,7 +28,7 @@ export interface EvaluationContext {
 	 * Produces the current absolute reference to the {@link contextNode}, where
 	 * the absolute `/` resolves to the active form state's primary instance root.
 	 */
-	get contextReference(): string;
+	readonly contextReference: Accessor<string>;
 
 	readonly contextNode: Node;
 

--- a/packages/xforms-engine/src/instance/internal-api/EvaluationContext.ts
+++ b/packages/xforms-engine/src/instance/internal-api/EvaluationContext.ts
@@ -32,10 +32,8 @@ export interface EvaluationContext {
 	readonly contextNode: Node;
 
 	/**
-	 * Resolves a nodeset reference, possibly relative to the
-	 * {@link EvaluationContext.contextNode}.
+	 * Resolves nodes corresponding to the provided node-set reference, possibly
+	 * relative to the {@link EvaluationContext.contextNode}.
 	 */
-	readonly getSubscribableDependencyByReference: (
-		reference: string
-	) => SubscribableDependency | null;
+	getSubscribableDependenciesByReference(reference: string): readonly SubscribableDependency[];
 }

--- a/packages/xforms-engine/src/instance/internal-api/ValueContext.ts
+++ b/packages/xforms-engine/src/instance/internal-api/ValueContext.ts
@@ -19,8 +19,8 @@ export interface ValueContext<RuntimeValue> extends EvaluationContext {
 	readonly definition: ValueContextDefinition;
 	readonly contextNode: Element;
 
-	get isReadonly(): boolean;
-	get isRelevant(): boolean;
+	isReadonly(): boolean;
+	isRelevant(): boolean;
 
 	readonly encodeValue: (this: unknown, runtimeValue: RuntimeValue) => InstanceValue;
 	readonly decodeValue: (this: unknown, instanceValue: InstanceValue) => RuntimeValue;

--- a/packages/xforms-engine/src/lib/reactivity/createComputedExpression.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createComputedExpression.ts
@@ -87,7 +87,7 @@ export const createComputedExpression = <Type extends DependentExpressionResultT
 
 		const getReferencedDependencies = createMemo(() => {
 			return dependencyReferences.flatMap((reference) => {
-				return context.getSubscribableDependencyByReference(reference) ?? [];
+				return context.getSubscribableDependenciesByReference(reference) ?? [];
 			});
 		});
 

--- a/packages/xforms-engine/src/lib/reactivity/createSelectItems.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createSelectItems.ts
@@ -66,8 +66,8 @@ class ItemsetItemEvaluationContext implements EvaluationContext {
 		this.root = selectField.root;
 	}
 
-	getSubscribableDependencyByReference(reference: string): SubscribableDependency | null {
-		return this.selectField.getSubscribableDependencyByReference(reference);
+	getSubscribableDependenciesByReference(reference: string): readonly SubscribableDependency[] {
+		return this.selectField.getSubscribableDependenciesByReference(reference);
 	}
 }
 

--- a/packages/xforms-engine/src/lib/reactivity/createSelectItems.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createSelectItems.ts
@@ -52,10 +52,7 @@ class ItemsetItemEvaluationContext implements EvaluationContext {
 	readonly scope: ReactiveScope;
 	readonly evaluator: XFormsXPathEvaluator;
 	readonly root: EvaluationContextRoot;
-
-	get contextReference(): string {
-		return this.selectField.contextReference;
-	}
+	readonly contextReference: Accessor<string>;
 
 	constructor(
 		private readonly selectField: SelectField,
@@ -64,6 +61,7 @@ class ItemsetItemEvaluationContext implements EvaluationContext {
 		this.scope = selectField.scope;
 		this.evaluator = selectField.evaluator;
 		this.root = selectField.root;
+		this.contextReference = selectField.contextReference;
 	}
 
 	getSubscribableDependenciesByReference(reference: string): readonly SubscribableDependency[] {

--- a/packages/xforms-engine/src/lib/reactivity/createValueState.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createValueState.ts
@@ -72,7 +72,7 @@ const createPrimaryInstanceValueState = <RuntimeValue>(
 
 		const persistedValueState = createSignal<PersistedValueState>(
 			{
-				isRelevant: context.isRelevant,
+				isRelevant: context.isRelevant(),
 				value: initialValue,
 			},
 			{
@@ -91,7 +91,7 @@ const createPrimaryInstanceValueState = <RuntimeValue>(
 		const [persistedValue, setValueForPersistence] = persistedValueState;
 
 		createComputed(() => {
-			const isRelevant = context.isRelevant;
+			const isRelevant = context.isRelevant();
 
 			setValueForPersistence((persisted) => {
 				return {
@@ -122,7 +122,7 @@ const createPrimaryInstanceValueState = <RuntimeValue>(
 		const setPrimaryInstanceValue: SimpleAtomicStateSetter<string> = (value) => {
 			// TODO: Check (error?) for non-relevant value change?
 			const persisted = setValueForPersistence({
-				isRelevant: context.isRelevant,
+				isRelevant: context.isRelevant(),
 				value,
 			});
 
@@ -189,8 +189,8 @@ const guardDownstreamReadonlyWrites = <RuntimeValue>(
 	const [getValue, baseSetValue] = baseState;
 
 	const setValue: SimpleAtomicStateSetter<RuntimeValue> = (value) => {
-		if (context.isReadonly) {
-			const reference = untrack(() => context.contextReference);
+		if (context.isReadonly()) {
+			const reference = untrack(() => context.contextReference());
 
 			throw new Error(`Cannot write to readonly field: ${reference}`);
 		}
@@ -215,7 +215,7 @@ const createCalculation = <RuntimeValue>(
 		const calculate = createComputedExpression(context, calculateDefinition);
 
 		createComputed(() => {
-			if (context.isRelevant) {
+			if (context.isRelevant()) {
 				const calculated = calculate();
 				const value = context.decodeValue(calculated);
 

--- a/packages/xforms-engine/src/lib/reactivity/materializeCurrentStateChildren.ts
+++ b/packages/xforms-engine/src/lib/reactivity/materializeCurrentStateChildren.ts
@@ -3,6 +3,7 @@ import type { NodeID } from '../../instance/identity.ts';
 import type { ChildrenState, createChildrenState } from './createChildrenState.ts';
 import type { ClientState } from './node-state/createClientState.ts';
 import type { CurrentState } from './node-state/createCurrentState.ts';
+import type { ReactiveScope } from './scope.ts';
 
 interface InconsistentChildrenStateDetails {
 	readonly missingIds: readonly NodeID[];
@@ -96,6 +97,7 @@ export const materializeCurrentStateChildren = <
 	Child extends AnyChildNode,
 	ParentState extends EncodedParentState,
 >(
+	scope: ReactiveScope,
 	currentState: ParentState,
 	childrenState: ChildrenState<Child>
 ): MaterializedChildren<ParentState, Child> => {
@@ -105,7 +107,7 @@ export const materializeCurrentStateChildren = <
 	return new Proxy(proxyTarget, {
 		get(_, key) {
 			if (key === 'children') {
-				const expectedChildIDs = currentState.children;
+				const expectedChildIDs = scope.runTask(() => currentState.children);
 				const children = childrenState.getChildren();
 
 				if (import.meta.env.DEV) {

--- a/packages/xforms-engine/test/instance/Root.test.ts
+++ b/packages/xforms-engine/test/instance/Root.test.ts
@@ -72,9 +72,9 @@ describe('Instance root', () => {
 	// boilerplate across tests. Most tests should use `createRootNode` below.
 	// Tests concerned with some aspects of internals may use this function
 	// directly, with caution.
-	const createRoot = async (stateFactory: OpaqueReactiveObjectFactory): Promise<Root> => {
+	const createRoot = (stateFactory: OpaqueReactiveObjectFactory): Root => {
 		return scope.runTask(() => {
-			return Root.initialize(xformDefinition.xformDOM, xformDefinition.model.root, {
+			return new Root(xformDefinition.xformDOM, xformDefinition.model.root, {
 				createUniqueId,
 				fetchResource,
 				stateFactory,
@@ -83,8 +83,8 @@ describe('Instance root', () => {
 	};
 
 	describe('internals', () => {
-		it('exposes a context node for XPath evaluation purposes', async () => {
-			const { contextNode } = await reactiveTestScope(({ mutable }) => {
+		it('exposes a context node for XPath evaluation purposes', () => {
+			const { contextNode } = reactiveTestScope(({ mutable }) => {
 				return createRoot(mutable);
 			});
 
@@ -92,9 +92,9 @@ describe('Instance root', () => {
 			expect(contextNode.nodeName).toBe('data');
 		});
 
-		it("produces instance root's the static nodeset reference", async () => {
-			const rootReference = await reactiveTestScope(async ({ mutable }) => {
-				const root = await createRoot(mutable);
+		it("produces instance root's the static nodeset reference", () => {
+			const rootReference = reactiveTestScope(({ mutable }) => {
+				const root = createRoot(mutable);
 
 				return root.contextReference();
 			});
@@ -102,9 +102,9 @@ describe('Instance root', () => {
 			expect(rootReference).toBe('/data');
 		});
 
-		it('gets a node by reference', async () => {
-			const [q1] = await reactiveTestScope(async ({ mutable }) => {
-				const root = await createRoot(mutable);
+		it('gets a node by reference', () => {
+			const [q1] = reactiveTestScope(({ mutable }) => {
+				const root = createRoot(mutable);
 
 				return root.getSubscribableDependenciesByReference('/data/q1');
 			});
@@ -119,12 +119,12 @@ describe('Instance root', () => {
 	// with graph computations), but the majority of tests should be focused on
 	// client-facing functionality. Those tests should use this convenience
 	// function if possible.
-	const createRootNode = (stateFactory: OpaqueReactiveObjectFactory): Promise<RootNode> => {
+	const createRootNode = (stateFactory: OpaqueReactiveObjectFactory): RootNode => {
 		return createRoot(stateFactory);
 	};
 
-	it('creates a Root instance', async () => {
-		const root = await reactiveTestScope(({ mutable }) => {
+	it('creates a Root instance', () => {
+		const root = reactiveTestScope(({ mutable }) => {
 			return createRootNode(mutable);
 		});
 
@@ -132,9 +132,9 @@ describe('Instance root', () => {
 	});
 
 	describe('translation languages', () => {
-		it("gets the form's available languages", async () => {
-			const languages = await reactiveTestScope(async ({ mutable }) => {
-				const root = await createRootNode(mutable);
+		it("gets the form's available languages", () => {
+			const languages = reactiveTestScope(({ mutable }) => {
+				const root = createRootNode(mutable);
 
 				return root.languages;
 			});
@@ -149,9 +149,9 @@ describe('Instance root', () => {
 			]);
 		});
 
-		it('gets the initial active language', async () => {
-			const activeLanguage = await reactiveTestScope(async ({ mutable }) => {
-				const root = await createRootNode(mutable);
+		it('gets the initial active language', () => {
+			const activeLanguage = reactiveTestScope(({ mutable }) => {
+				const root = createRootNode(mutable);
 
 				return root.currentState.activeLanguage;
 			});
@@ -161,9 +161,9 @@ describe('Instance root', () => {
 			});
 		});
 
-		it('sets the active language', async () => {
-			const { activeLanguage } = await reactiveTestScope(async ({ mutable }) => {
-				const root = await createRootNode(mutable);
+		it('sets the active language', () => {
+			const { activeLanguage } = reactiveTestScope(({ mutable }) => {
+				const root = createRootNode(mutable);
 
 				root.setLanguage({
 					language: 'Spanish',
@@ -177,9 +177,9 @@ describe('Instance root', () => {
 			});
 		});
 
-		it('fails to set a language not supported by the form', async () => {
-			const caught = await reactiveTestScope(async ({ mutable }) => {
-				const root = await createRootNode(mutable);
+		it('fails to set a language not supported by the form', () => {
+			const caught = reactiveTestScope(({ mutable }) => {
+				const root = createRootNode(mutable);
 
 				try {
 					root.setLanguage({ language: 'Not supported' });
@@ -193,12 +193,12 @@ describe('Instance root', () => {
 			expect(caught).toBeInstanceOf(Error);
 		});
 
-		it('updates reactive client state on language change', async () => {
+		it('updates reactive client state on language change', () => {
 			expect.assertions(2);
 
-			const lastObservedClientLanguage = await reactiveTestScope(
-				async ({ mutable, effect }): Promise<ActiveLanguage | null> => {
-					const root = await createRootNode(mutable);
+			const lastObservedClientLanguage = reactiveTestScope(
+				({ mutable, effect }): ActiveLanguage | null => {
+					const root = createRootNode(mutable);
 
 					let observedClientLanguage: ActiveLanguage | null = null;
 
@@ -234,9 +234,9 @@ describe('Instance root', () => {
 		{ stateKey: 'valueOptions', expectedValue: null },
 		{ stateKey: 'value', expectedValue: null },
 	] as const)('$stateKey state', ({ stateKey, expectedValue, invalidValue }) => {
-		it(`gets the initial, static state of ${stateKey}`, async () => {
-			const state = await reactiveTestScope(async ({ mutable }) => {
-				const root = await createRootNode(mutable);
+		it(`gets the initial, static state of ${stateKey}`, () => {
+			const state = reactiveTestScope(({ mutable }) => {
+				const root = createRootNode(mutable);
 
 				return root.currentState[stateKey];
 			});
@@ -244,9 +244,9 @@ describe('Instance root', () => {
 			expect(state).toBe(expectedValue);
 		});
 
-		it(`fails to set update the read-only state (currentState) of "${stateKey}" to ${invalidValue}`, async () => {
-			const caught = await reactiveTestScope(async ({ mutable }) => {
-				const root = await createRootNode(mutable);
+		it(`fails to set update the read-only state (currentState) of "${stateKey}" to ${invalidValue}`, () => {
+			const caught = reactiveTestScope(({ mutable }) => {
+				const root = createRootNode(mutable);
 
 				try {
 					// @ts-expect-error - intentionally ignore unsafe assignment to
@@ -263,9 +263,9 @@ describe('Instance root', () => {
 		});
 	});
 
-	it("gets the root node's first child", async () => {
-		const firstChild = await reactiveTestScope(async ({ mutable }) => {
-			const root = await createRootNode(mutable);
+	it("gets the root node's first child", () => {
+		const firstChild = reactiveTestScope(({ mutable }) => {
+			const root = createRootNode(mutable);
 
 			return root.currentState.children[0];
 		});

--- a/packages/xforms-engine/test/instance/Root.test.ts
+++ b/packages/xforms-engine/test/instance/Root.test.ts
@@ -93,11 +93,13 @@ describe('Instance root', () => {
 		});
 
 		it("produces instance root's the static nodeset reference", async () => {
-			const { contextReference } = await reactiveTestScope(({ mutable }) => {
-				return createRoot(mutable);
+			const rootReference = await reactiveTestScope(async ({ mutable }) => {
+				const root = await createRoot(mutable);
+
+				return root.contextReference();
 			});
 
-			expect(contextReference).toBe('/data');
+			expect(rootReference).toBe('/data');
 		});
 
 		it('gets a node by reference', async () => {

--- a/packages/xforms-engine/test/instance/Root.test.ts
+++ b/packages/xforms-engine/test/instance/Root.test.ts
@@ -101,10 +101,10 @@ describe('Instance root', () => {
 		});
 
 		it('gets a node by reference', async () => {
-			const q1 = await reactiveTestScope(async ({ mutable }) => {
+			const [q1] = await reactiveTestScope(async ({ mutable }) => {
 				const root = await createRoot(mutable);
 
-				return root.getSubscribableDependencyByReference('/data/q1');
+				return root.getSubscribableDependenciesByReference('/data/q1');
 			});
 
 			expect(q1).toBeInstanceOf(InstanceNode);

--- a/packages/xforms-engine/test/instance/instance.test.ts
+++ b/packages/xforms-engine/test/instance/instance.test.ts
@@ -60,7 +60,9 @@ describe('Form instance state', () => {
 	let testForm: IntializedTestForm;
 
 	const getNodeByReference = <T extends AnyNode = AnyNode>(reference: string): T | null => {
-		return testForm.internalRoot.getNodeByReference(new WeakSet(), reference) as T | null;
+		const [node] = testForm.internalRoot.getNodesByReference(new WeakSet(), reference);
+
+		return (node ?? null) as T | null;
 	};
 
 	const getStringNode = (reference: string): StringNode => {


### PR DESCRIPTION
This PR includes a handful of fixes and improvements addressing issues found in #110, generally with a common repeat-related theme.

The commit notes go into some detail of each fix. I'll highlight some high level details here as well.

1. ad607dc Fix `InconsistentChildrenStateError` cases that currently affect `scenario`. This fix shouldn't affect the `web-forms` Vue UI client (as it only affects clients using Solid), but it was important to fix first so that the other fixes won't be obscured by introducing this same error.

2. 0212b9f Fix a variety of issues where behavior is correct for the first repeat instance in a range (or within that repeat instance, or referencing into it) but incorrect for subsequent repeat instances. The change doesn't address **all** such cases, but it is probably further reaching in real usage than the set of newly passing tests suggests. I expect that it will address quite a few cases where repeat functionality feels broken/incomplete.

    Note that this is followed by another commit (57883df) marking several form init smoke tests failing that did not previously. This may seem like a regression, but I don't think it really is. Those tests had previously satisfied a broad check for producing an error, and their previous passing status was essentially a coincidence. We'll likely address these more meaningfully in some of the work related to #80.

3. 19016e6 (and eea137d) Fix a few issues related to the order of reactive state initialization for each form node. The mechanism of the fix involves moving the initialization of `reference` (i.e. the effective XPath reference to the node, which may change for repeat instances and their descendants) as well as shared bind computations—`relevant`, `readonly`, `required`—earlier in node initialization... effectively before any other reactivity for all non-root nodes.

    The immediate benefit, as visible in the main commit for the fix, is that we now correctly clear default values of non-relevant nodes on form load. While _that_ isn't specifically repeat-related, the other benefit of this change is that it eliminates the aspect of form/repeat instance init where certain aspects of reactivity are not initially "ready" when they need to be initially referenced. As such, and reflected in followup commits, this fix also resolves any remaining asynchrony[^1] during form init (8642ed7). For repeats, this also fixes edge cases where certain aspects of reactive state lag after creating now repeat instances (90e1ad6).

    This broadly reaffirms our current intent that form state is reconciled fully, synchronously, for every form action (until a need to deviate arises).

4. b44beec Fix some cases where `relevant` state was incorrectly inherited when applied to repeat instances themselves. The nature of this issue was that `RepeatRange` nodes (which are a fiction for our runtime data model, not real nodes in the primary instance) were incorrectly evaluating `relevant` expressions intended for their `RepeatInstance` children.

    The first (correctness) problem with this was that the expression would be evaluated against the wrong context, as `RepeatRange.contextNode` references the repeat range's parent element in the primary instance tree. The second problem: if this expression evaluated to `false` for a `RepeatRange`, that would be inherited from **all of its `RepeatInstance` children** even if the expression properly evaluates `true` for the instance itself. These issues are resolved.

    There are also `scenario` tests which consider the relevance of the repeat range itself... or at least, they check the presence of a prompt to create new instances of the repeat range, and we've ported those tests to check for that range's relevance. We now determine this `RepeatRange` relevance state by a heuristic, where the range itself is relevant if either of these cases are true:

      - Does the `RepeatRange` have >=1 relevant `RepeatInstance` children?
      - Does the `RepeatRange` have 0 `RepeatInstance` children at all?

    It's entirely possible this is the wrong heuristic. It's also entirely possible that there is a more appropriate way to represent the presence or absence of a repeat "prompt" besides relevance state. I am certain that `scenario` will need different logic when we introduce support for `jr:count` (#87).

[^1]: Besides resource fetching, which is inherently async and which is at least presently handled **before** the now-synchronous `Root` initialization.