### PR TITLE
fix: include css in the built js file

### DIFF
--- a/.changeset/swift-ducks-divide.md
+++ b/.changeset/swift-ducks-divide.md
@@ -1,0 +1,5 @@
+---
+"@getodk/web-forms": patch
+---
+
+fix: include css in the built js file, test build to prevent repeat regressions

--- a/packages/web-forms/build-preview/index.html
+++ b/packages/web-forms/build-preview/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>ODK Web Forms: Test Build</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module">
+			/** Basic form definition, to load for validation of build product */
+			const formXml = /* xml */ `<?xml version="1.0"?>
+				<h:html xmlns="http://www.w3.org/2002/xforms"
+					xmlns:ev="http://www.w3.org/2001/xml-events"
+					xmlns:h="http://www.w3.org/1999/xhtml"
+					xmlns:jr="http://openrosa.org/javarosa"
+					xmlns:orx="http://openrosa.org/xforms/"
+					xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<h:head>
+						<h:title>Calculate (simple)</h:title>
+						<model>
+							<instance>
+								<root id="calculate-simple">
+									<first-question>1</first-question>
+									<second-question/>
+									<meta>
+										<instanceID/>
+									</meta>
+								</root>
+							</instance>
+							<bind nodeset="/root/first-question"/>
+							<bind nodeset="/root/second-question" calculate="/root/first-question * 2"/>
+							<bind nodeset="/root/meta/instanceID" type="string"/>
+						</model>
+					</h:head>
+					<h:body>
+						<input ref="/root/first-question">
+							<label>1. Default value is 1</label>
+						</input>
+						<input ref="/root/second-question">
+							<label>2. Calculates #1 × 2</label>
+						</input>
+					</h:body>
+				</h:html>`;
+
+			/**
+			 * Partially based on
+			 * {@link https://github.com/getodk/central-frontend/blob/74f2d9529cca53316ffa7a723ee1da4fdd70c1a7/src/components/form/preview.vue | central-frontend's initial `@getodk/web-forms` integration}.
+			 */
+
+			import { createApp, defineOptions, getCurrentInstance, h } from 'vue';
+			import { OdkWebForm, webFormsPlugin } from '../dist/index.js';
+
+			const vnode = h(OdkWebForm, {
+				formXml,
+				onSubmit: () => {
+					console.log('onSubmit');
+				},
+			});
+			console.log('vnode', vnode);
+
+			// Install WebFormsPlugin in the component instead of installing it at the
+			// application level so that @getodk/web-forms package is not loaded for every
+			// page, thus increasing the initial bundle
+			const app = createApp({
+				render: () => vnode,
+			});
+
+			app.use(webFormsPlugin);
+
+			defineOptions({
+				name: 'FormPreview',
+			});
+
+			app.mount('#app');
+		</script>
+		<style id="build-preview-global-styles">
+			:root,
+			body {
+				padding: 0;
+				margin: 0;
+			}
+		</style>
+	</body>
+</html>

--- a/packages/web-forms/e2e/build/style.test.ts
+++ b/packages/web-forms/e2e/build/style.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+test('Build includes component-defined styles', async ({ page }) => {
+	await page.goto('http://localhost:5174/');
+
+	// This ensures that the application is loaded before proceeding forward.
+	await expect(page.getByText('Calculate (simple)').first()).toBeVisible();
+
+	// Get the (Sass-defined) large breakpoint size
+	// [In theory, if we can get this and it's not a number, we've already validated styles. Below expands on that to leave some breadcrumbs]
+	const breakpointLg = await page.locator('html').evaluate((pageRoot) => {
+		return getComputedStyle(pageRoot).getPropertyValue('--breakpoint-lg');
+	});
+	const largeViewportSize = parseInt(breakpointLg, 10);
+
+	// Technically, this assertion passing is already assurance that styles are
+	// effective in the build.
+	//
+	// The remainder of the test action/assertions leave some additional
+	// breadcrumbs in case we want to expand on style testing, e.g. to guard
+	// against regressions in specific presentation aspects.
+	expect(Number.isNaN(largeViewportSize)).toBe(false);
+
+	// Setting viewport to `$lg` breakpoint ensures the `--gray-200` background
+	// color is effective for `body`.
+	await page.setViewportSize({
+		width: largeViewportSize,
+		height: largeViewportSize,
+	});
+
+	// Assign several colors to `--gray-200`, checking that the color is
+	// (initially) **not** the body's effective background color, and then that it
+	// is once assigned to that custom property.
+	//
+	// This is effectively testing the application of that style, using that
+	// variable, in OdkWebForm.vue.
+	const colors = ['rgb(255, 0, 0)', 'rgb(0, 255, 0)', 'rgb(0, 0, 255)'];
+
+	for await (const color of colors) {
+		await expect(page.locator('body')).not.toHaveCSS('background-color', color);
+
+		await page.locator('html').evaluate((pageRoot, gray200) => {
+			pageRoot.style.setProperty('--gray-200', gray200);
+		}, color);
+
+		await expect(page.locator('body')).toHaveCSS('background-color', color);
+	}
+});

--- a/packages/web-forms/e2e/vue.test.ts
+++ b/packages/web-forms/e2e/vue.test.ts
@@ -10,7 +10,7 @@ test('All forms are rendered and there is no console error', async ({ page, brow
 		}
 	});
 
-	await page.goto('/');
+	await page.goto('http://localhost:5173');
 
 	// this ensures that Vue application is loaded before proceeding forward.
 	await expect(page.getByText('Demo Forms')).toBeVisible();

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -61,6 +61,7 @@
     "ramda": "^0.30.0",
     "sass": "^1.77.2",
     "vite": "^5.2.11",
+    "vite-plugin-css-injected-by-js": "^3.5.1",
     "vitest": "^1.6.0",
     "vue": "3.3.4"
   },

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -30,6 +30,7 @@
     "build": "npm-run-all -nl build:*",
     "build:clean": "rimraf dist/",
     "build:js": "vite build",
+    "build-preview": "yarn build && yarn vite serve build-preview --port 5174",
     "dev": "vite",
     "test": "npm-run-all -nl test:*",
     "test:e2e": "playwright test",

--- a/packages/web-forms/playwright.config.ts
+++ b/packages/web-forms/playwright.config.ts
@@ -97,14 +97,24 @@ export default defineConfig({
 	// outputDir: 'test-results/',
 
 	/* Run your local dev server before starting the tests */
-	webServer: {
+	webServer: [
 		/**
-		 * Always use the dev server because build output of this package is a library.
-		 * E2e tests are performed against demo application i.e. (index.html, OdkWebFormDemo.vue)
-		 * Playwright will re-use the local server if there is already a dev-server running.
+		 * Serve dev mode: for testing with demo/fixtures
 		 */
-		command: 'npx vite dev',
-		port: 5173,
-		reuseExistingServer: !process.env.CI,
-	},
+		{
+			command: 'yarn vite dev',
+			port: 5173,
+			reuseExistingServer: !process.env.CI,
+		},
+
+		/**
+		 * Serve minimal integration of build product: for testing styles, any other
+		 * aspects of build product we wish to validate.
+		 */
+		{
+			command: 'yarn vite build-preview',
+			port: 5174,
+			reuseExistingServer: false,
+		},
+	],
 });

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -24,8 +24,6 @@ initializeForm(props.formXml, {
 const handleSubmit = () => {
 	emit('submit');
 }
-
-
 </script>
 
 <template>
@@ -51,7 +49,7 @@ const handleSubmit = () => {
 	</div>
 </template>
 
-<style scoped lang="scss"> 
+<style scoped lang="scss">
 @import 'primeflex/core/_variables.scss';
 
 .odk-form {
@@ -97,7 +95,7 @@ const handleSubmit = () => {
 		.form-wrapper {
 			max-width: unset;
 			padding-top: unset;
-			
+
 			.questions-card {
 				border-radius: unset;
 				box-shadow: unset;
@@ -116,6 +114,10 @@ const handleSubmit = () => {
 
 <style lang="scss">
 @import 'primeflex/core/_variables.scss';
+:root {
+	--breakpoint-lg: #{$lg};
+}
+
 body {
 	background: var(--gray-200);
 }

--- a/packages/web-forms/src/index.ts
+++ b/packages/web-forms/src/index.ts
@@ -1,17 +1,10 @@
 import { webFormsPlugin } from './WebFormsPlugin';
 import OdkWebForm from './components/OdkWebForm.vue';
 
-import icomoon from './assets/css/icomoon.css?inline';
-import theme from './themes/2024-light/theme.scss?inline';
+import './assets/css/icomoon.css';
+import './themes/2024-light/theme.scss';
 
 // TODO/sk: Purge it - using postcss-purgecss
-import primeflex from 'primeflex/primeflex.css?inline';
-
-const styles = [icomoon, theme, primeflex].join('\n\n');
-const stylesheet = new CSSStyleSheet();
-
-stylesheet.replaceSync(styles);
-
-document.adoptedStyleSheets.push(stylesheet);
+import 'primeflex/primeflex.css';
 
 export { OdkWebForm, webFormsPlugin };

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -3,9 +3,10 @@ import vueJsx from '@vitejs/plugin-vue-jsx';
 import { fileURLToPath, URL } from 'node:url';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 
 export default defineConfig({
-	plugins: [vue(), vueJsx()],
+	plugins: [vue(), vueJsx(), cssInjectedByJsPlugin()],
 	resolve: {
 		alias: {
 			'@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/packages/web-forms/vitest.config.ts
+++ b/packages/web-forms/vitest.config.ts
@@ -39,7 +39,7 @@ export default mergeConfig(
 				headless: true,
 			},
 			environment: TEST_ENVIRONMENT,
-			exclude: [...configDefaults.exclude, 'e2e/*'],
+			exclude: [...configDefaults.exclude, 'e2e/**'],
 			root: fileURLToPath(new URL('./', import.meta.url)),
 			// Suppress the console error log about parsing CSS stylesheet
 			// This is an open issue of jsdom

--- a/yarn.lock
+++ b/yarn.lock
@@ -6740,6 +6740,11 @@ vite-plugin-babel@^1.2.0:
   resolved "https://registry.yarnpkg.com/vite-plugin-babel/-/vite-plugin-babel-1.2.0.tgz#0d803d489c2a7e63ceb93e37533de298e1537c71"
   integrity sha512-ltAnq535Ubf9sDbVCkztAdkwx5aQbNrwPFs+iZTJ5FaAhTdxjqmLGpxsAaRfJWEKBJ/kFf9KwMoTdArm0IRUUw==
 
+vite-plugin-css-injected-by-js@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.1.tgz#b9c568c21b131d08e31aa6d368ee39c9d6c1b6c1"
+  integrity sha512-9ioqwDuEBxW55gNoWFEDhfLTrVKXEEZgl5adhWmmqa88EQGKfTmexy4v1Rh0pAS6RhKQs2bUYQArprB32JpUZQ==
+
 vite-plugin-dts@^3.9.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-3.9.1.tgz#625ad388ec3956708ccec7960550a7b0a8e8909e"


### PR DESCRIPTION
After decomposing styles from theme.scss into SFC in #113, build process started generated separate css file instead of generating just a single `index.js` file. Because styles defined in SFC file scan't be accessed in `index.ts` as we do for other style files, I ended up using a plugin that post-processes styles and adds them in index.js file as `IIFE` that adds `<style>` tags in the document head. If we prefer `document.adoptedStyleSheets` instead I can use `injectCodeFunction ` of the plugin.