### PR TITLE
Fix/vitest flakiness

### DIFF
--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
 			},
 		},
 	},
+	optimizeDeps: {
+		// Without this flag, `test:e2e` fails for every other execution
+		force: true,
+	},
 	css: {
 		postcss: {
 			plugins: [


### PR DESCRIPTION
On main branch when I run e2e tests, they work for every other execution. So run the test with `--ui` to have an opportunity to see what's happening. With that I saw `[504 (Outdated Optimize Dep)]` in browser console, google that error and found this https://stackoverflow.com/questions/75883720/504-outdated-optimize-dep-while-using-react-vite and https://vitejs.dev/guide/dep-pre-bundling.html#browser-cache

So I added `--force` to playwright.config.ts in webServer.command, which fixed the e2e tests. 

That gave me a clue that issue in component tests for webkit could also be because of vite's optimizer, so tried disabling that with `optimizeDeps.noDiscover` in vitest.config.ts. That solved the problem locally and in CI as well, as many times I have tried.

I have also reversed `sleep` and double execution of test-browser:webkit that introduced in [#d1d31ea](https://github.com/getodk/web-forms/commit/7e787086829c7d1007407fda59fc3cb6a9399203)