### PR TITLE
Fix: reactive aggregation of validation violations from selects

### DIFF
--- a/.changeset/breezy-sheep-play.md
+++ b/.changeset/breezy-sheep-play.md
@@ -1,0 +1,5 @@
+---
+'@getodk/xforms-engine': patch
+---
+
+Fix: reactive aggregation of validation violations from selects

--- a/packages/xforms-engine/src/instance/SelectField.ts
+++ b/packages/xforms-engine/src/instance/SelectField.ts
@@ -128,12 +128,7 @@ export class SelectField
 	}
 
 	getViolation(): AnyViolation | null {
-		// Read engine state to ensure reactivity in engine, Solid-based clients
-		this.validation.engineState.violation;
-
-		// Read/return client state to ensure client reactivity, regardless of
-		// client's reactive implementation
-		return this.validationState.violation;
+		return this.validation.engineState.violation;
 	}
 
 	protected getSelectItemsByValue(


### PR DESCRIPTION
Fixes #170. Not quite as small a change as #169, but pretty close 😄

The exact same change had been made for `StringField`, and should've been made for `SelectField` then. A compelling exhibit in favor of DRY, and thinking of other ways we could compose behavior common across node types!