### PR TITLE
Fix: updated gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text eol=lf
+*.png -text
 
 packages/tree-sitter-xpath/src/*.json linguist-generated
 packages/tree-sitter-xpath/src/parser.c linguist-generated


### PR DESCRIPTION
so that it doesn't treat png files as text and apply eol filters.

Without this change, whenever I checkout `odk-logo.png` file (fresh clone or reset) I see line ending of the logo file changed:

```diff
% git diff --text | cat -v
warning: in the working copy of 'packages/ui-solid/assets/odk-logo.png', CRLF will be replaced by LF the next time Git touches it
diff --git a/packages/ui-solid/assets/odk-logo.png b/packages/ui-solid/assets/odk-logo.png
index 071bd09..326454e 100644
--- a/packages/ui-solid/assets/odk-logo.png
+++ b/packages/ui-solid/assets/odk-logo.png
@@ -1,4 +1,4 @@
-M-^IPNG^M
+M-^IPNG
 ^Z
 ^@^@^@^MIHDR^@^@^@M-^T^@^@^@P^H^F^@^@^@�E\v^@^@^L?iCCPICC Profile^@^@HM-^IM-^UW^GXS�^VM-^^[R!^D^H  %�&M-^H�^@RBh^A�^W�FH^BM-^D^Rc ���E^E�."`CWE^T; v�΢��bAEY^W^Kv�M
 躯|o�o���M-^_3�9s�̽w^@�^_�I$��&^@y�^Bi\h stJ*M-^S�^TM-^P^A^A�M-^A1^X���K�11M-^Q^@M-^VM-^A����uM-^@��+M-^Nr�^?��ע%^P��^A@b N^W��� �^O^@^�M-^WH^K^@ �yM-^K�^E^R9M-^F^U�HaM-^@^P/M-^P�L%�M-^V�t%ޭ�IM-^H�@�
```