### PR TITLE
Add PR template

### DIFF
--- a/.changeset/wise-colts-thank.md
+++ b/.changeset/wise-colts-thank.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Add PR template

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+Closes #
+
+## I have verified this PR works in these browsers (latest versions):
+
+- [ ] Chrome
+- [ ] Firefox
+- [ ] Safari (macOS)
+- [ ] Safari (iOS)
+- [ ] Not applicable
+
+## What else has been done to verify that this works as intended?
+
+## Why is this the best possible solution? Were any other approaches considered?
+
+## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
+
+## Do we need any specific form for testing your changes? If so, please attach one.
+
+## What's changed


### PR DESCRIPTION
This is roughly based on the templates from:

- getodk/central
- enketo/enketo

It specifically adds a browser checklist, as that discussion is what prompted us to add this.

- - -

Before we merge this, I would like to consider adding:

- A section to describe the PR's changes. This is something I'm trying to make an effort to do on at least non-trivial/non-obvious changes, and would like to encourage as it's really helpful to look back and find context for changes as they occur. This could be really basic, or could encourage specific kinds of details (e.g. things to look out for, things that were intentionally deferred, aspects of approach of particular interest/warranting particular scrutiny). If the latter, there may be overlap with the _best solution_ section.
- Either checkboxes for adding/skipping a changeset, or at least a text reminder. I'm hoping this will become more habitual over time, but for now it seems like it might be good to have the extra prompt.