### PR TITLE
Temporarily skip child-vaccination smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ defaults:
 
 env:
   TZ: 'America/Phoenix'
+  GITHUB_ACTIONS_RUN_ATTEMPT: ${{ github.run_attempt }}
 
 jobs:
   install-and-build:

--- a/packages/scenario/test/smoketests/child-vaccination.test.ts
+++ b/packages/scenario/test/smoketests/child-vaccination.test.ts
@@ -580,7 +580,15 @@ const answerHousehold = (
 	scenario.trace('END CHILDREN');
 };
 
-describe('ChildVaccinationTest.java', () => {
+const TEMPORARY_SKIP_START = new Date('2024-08-28T19:19:22.237Z');
+/** Update this to extend the temporary skip clock! */
+const TEMPORARY_SKIP_DURATION_DAYS = 14;
+const TEMPORARY_SKIP_DURATION = TEMPORARY_SKIP_DURATION_DAYS * 24 * 60 * 60 * 1000;
+const TEMPORARY_SKIP_END = new Date(TEMPORARY_SKIP_START.getTime() + TEMPORARY_SKIP_DURATION);
+const IS_TEMPORARILY_SKIPPED = Date.now() < TEMPORARY_SKIP_END.getTime();
+const IS_CI_RERUN = (GITHUB_ACTIONS_RUN_ATTEMPT ?? 0) > 1;
+
+describe.skipIf(IS_TEMPORARILY_SKIPPED || IS_CI_RERUN)('ChildVaccinationTest.java', () => {
 	afterEach(() => {
 		refSingletons.clear();
 	});

--- a/packages/scenario/vite-env.d.ts
+++ b/packages/scenario/vite-env.d.ts
@@ -2,3 +2,6 @@
 /// <reference types="vitest" />
 /// <reference path="../../vendor-types/vitest/index.d.ts" />
 /// <reference path="./src/vitest/setup.ts" />
+
+// eslint-disable-next-line no-var
+declare var GITHUB_ACTIONS_RUN_ATTEMPT: number | undefined;

--- a/packages/scenario/vitest.config.ts
+++ b/packages/scenario/vitest.config.ts
@@ -43,10 +43,14 @@ export default defineConfig(({ mode }) => {
 
 	const BROWSER_ENABLED = BROWSER_NAME != null;
 	const TEST_ENVIRONMENT = BROWSER_ENABLED ? 'node' : 'jsdom';
+	const GITHUB_ACTIONS_RUN_ATTEMPT = process.env.GITHUB_ACTIONS_RUN_ATTEMPT ?? '0';
 
 	return {
 		build: {
 			target: false as const,
+		},
+		define: {
+			GITHUB_ACTIONS_RUN_ATTEMPT,
 		},
 		esbuild: {
 			sourcemap: true,


### PR DESCRIPTION
Part of #205.

I really don't want to risk forgetting that this test is skipped. So I've conditioned the skip to be within a two week window, which we can easily extend as needed. I also included a non-code escape hatch to quickly unblock CI if rerun.