### PR TITLE
Stub unsupported control nodes: `range`, `odk:rank`, `trigger`, `upload`

### DIFF
--- a/.changeset/nice-bags-sneeze.md
+++ b/.changeset/nice-bags-sneeze.md
@@ -1,0 +1,8 @@
+---
+"@getodk/scenario": patch
+"@getodk/web-forms": patch
+"@getodk/xforms-engine": patch
+---
+
+- Fix: unsupported controls treated as `ModelValueNode`
+- Stub unsupported control nodes: `range`, `odk:rank`, `trigger`, `upload`

--- a/packages/scenario/src/answer/UnsupportedControlNodeAnswer.ts
+++ b/packages/scenario/src/answer/UnsupportedControlNodeAnswer.ts
@@ -1,0 +1,14 @@
+import type { AnyUnsupportedControlNode } from '@getodk/xforms-engine';
+import { ValueNodeAnswer } from './ValueNodeAnswer.ts';
+
+export class UnsupportedControlNodeAnswer extends ValueNodeAnswer<AnyUnsupportedControlNode> {
+	get stringValue(): string {
+		const { value } = this.node.currentState;
+
+		if (typeof value === 'string') {
+			return value;
+		}
+
+		throw new Error(`Cannot get string value for node (type: ${this.node.nodeType})`);
+	}
+}

--- a/packages/scenario/src/client/traversal.ts
+++ b/packages/scenario/src/client/traversal.ts
@@ -28,6 +28,10 @@ export const collectFlatNodeList = (currentNode: AnyNode): readonly AnyNode[] =>
 		case 'note':
 		case 'select':
 		case 'string':
+		case 'range':
+		case 'rank':
+		case 'trigger':
+		case 'upload':
 			return [currentNode];
 
 		default:
@@ -60,6 +64,10 @@ export const getClosestRepeatRange = (currentNode: AnyNode): RepeatRangeNode | n
 		case 'note':
 		case 'string':
 		case 'select':
+		case 'range':
+		case 'rank':
+		case 'trigger':
+		case 'upload':
 			return getClosestRepeatRange(currentNode.parent);
 
 		default:

--- a/packages/scenario/src/jr/event/PositionalEvent.ts
+++ b/packages/scenario/src/jr/event/PositionalEvent.ts
@@ -1,5 +1,6 @@
 import { assertInstanceType } from '@getodk/common/lib/runtime-types/instance-predicates.ts';
 import type {
+	AnyUnsupportedControlNode,
 	GroupNode,
 	NoteNode,
 	RepeatInstanceNode,
@@ -10,9 +11,17 @@ import type {
 } from '@getodk/xforms-engine';
 import type { Scenario } from '../Scenario.ts';
 
+// prettier-ignore
+export type QuestionPositionalEventNode =
+	// eslint-disable-next-line @typescript-eslint/sort-type-constituents
+	| NoteNode
+	| SelectNode
+	| StringNode
+	| AnyUnsupportedControlNode;
+
 export interface PositionalEventTypeMapping {
 	readonly BEGINNING_OF_FORM: RootNode;
-	readonly QUESTION: NoteNode | SelectNode | StringNode;
+	readonly QUESTION: QuestionPositionalEventNode;
 	readonly GROUP: GroupNode;
 	readonly REPEAT: RepeatInstanceNode;
 	readonly REPEAT_JUNCTURE: never; // per @lognaturel: this can be ignored

--- a/packages/scenario/src/jr/event/UnsupportedControlQuestionEvent.ts
+++ b/packages/scenario/src/jr/event/UnsupportedControlQuestionEvent.ts
@@ -1,0 +1,16 @@
+import type { AnyUnsupportedControlNode } from '@getodk/xforms-engine';
+import { UnsupportedControlNodeAnswer } from '../../answer/UnsupportedControlNodeAnswer.ts';
+import type { ValueNodeAnswer } from '../../answer/ValueNodeAnswer.ts';
+import { QuestionEvent } from './QuestionEvent.ts';
+
+type UnsupportedControlQuestionType = AnyUnsupportedControlNode['nodeType'];
+
+export class UnsupportedControlQuestionEvent extends QuestionEvent<UnsupportedControlQuestionType> {
+	getAnswer(): UnsupportedControlNodeAnswer {
+		return new UnsupportedControlNodeAnswer(this.node);
+	}
+
+	answerQuestion(_: unknown): ValueNodeAnswer {
+		throw new Error(`Setting value of node not supported (type:${this.node.nodeType})`);
+	}
+}

--- a/packages/scenario/src/jr/event/getPositionalEvents.ts
+++ b/packages/scenario/src/jr/event/getPositionalEvents.ts
@@ -9,12 +9,14 @@ import { PromptNewRepeatEvent } from './PromptNewRepeatEvent.ts';
 import { RepeatInstanceEvent } from './RepeatInstanceEvent.ts';
 import { SelectQuestionEvent } from './SelectQuestionEvent.ts';
 import { StringInputQuestionEvent } from './StringInputQuestionEvent.ts';
+import { UnsupportedControlQuestionEvent } from './UnsupportedControlQuestionEvent.ts';
 
 // prettier-ignore
 export type AnyQuestionEvent =
 	| NoteQuestionEvent
 	| SelectQuestionEvent
-	| StringInputQuestionEvent;
+	| StringInputQuestionEvent
+	| UnsupportedControlQuestionEvent;
 
 // prettier-ignore
 export type NonTerminalPositionalEvent =
@@ -78,6 +80,12 @@ export const getPositionalEvents = (instanceRoot: RootNode): PositionalEvents =>
 
 				case 'string':
 					return StringInputQuestionEvent.from(node);
+
+				case 'range':
+				case 'rank':
+				case 'trigger':
+				case 'upload':
+					return UnsupportedControlQuestionEvent.from(node);
 
 				default:
 					throw new UnreachableError(node);

--- a/packages/web-forms/src/components/FormQuestion.vue
+++ b/packages/web-forms/src/components/FormQuestion.vue
@@ -1,16 +1,24 @@
 <script setup lang="ts">
-import type { AnyControlNode, NoteNode, SelectNode, StringNode } from '@getodk/xforms-engine';
+import type {
+	AnyControlNode,
+	AnyUnsupportedControlNode,
+	NoteNode,
+	SelectNode,
+	StringNode,
+} from '@getodk/xforms-engine';
 import { inject } from 'vue';
 import InputText from './controls/InputText.vue';
 import NoteControl from './controls/NoteControl.vue';
 import SelectControl from './controls/SelectControl.vue';
 import UnsupportedControl from './controls/UnsupportedControl.vue';
 
-defineProps<{ question: AnyControlNode }>();
+type ControlNode = AnyControlNode | AnyUnsupportedControlNode;
 
-const isStringNode = (n: AnyControlNode): n is StringNode => n.nodeType === 'string';
-const isSelectNode = (n: AnyControlNode): n is SelectNode => n.nodeType === 'select';
-const isNoteNode = (n: AnyControlNode): n is NoteNode => n.nodeType === 'note';
+defineProps<{ question: ControlNode }>();
+
+const isStringNode = (n: ControlNode): n is StringNode => n.nodeType === 'string';
+const isSelectNode = (n: ControlNode): n is SelectNode => n.nodeType === 'select';
+const isNoteNode = (n: ControlNode): n is NoteNode => n.nodeType === 'note';
 
 const submitPressed = inject('submitPressed');
 </script>

--- a/packages/web-forms/src/components/QuestionList.vue
+++ b/packages/web-forms/src/components/QuestionList.vue
@@ -2,18 +2,15 @@
 import type {
 	GeneralChildNode,
 	GroupNode,
-	AnyControlNode as QuestionNode,
+	ModelValueNode,
 	RepeatRangeNode,
+	SubtreeNode,
 } from '@getodk/xforms-engine';
 import FormGroup from './FormGroup.vue';
 import FormQuestion from './FormQuestion.vue';
 import RepeatRange from './RepeatRange.vue';
 
 defineProps<{ nodes: readonly GeneralChildNode[] }>();
-
-const isQuestionNode = (node: GeneralChildNode): node is QuestionNode => {
-	return node.nodeType === 'string' || node.nodeType === 'select' || node.nodeType == 'note';
-};
 
 const isGroupNode = (node: GeneralChildNode): node is GroupNode => {
 	return node.nodeType === 'group';
@@ -24,19 +21,24 @@ const isRepeatRangeNode = (node: GeneralChildNode): node is RepeatRangeNode => {
 		node.nodeType === 'repeat-range:controlled' || node.nodeType === 'repeat-range:uncontrolled'
 	);
 };
+
+const isModelOnlyNode = (node: GeneralChildNode): node is ModelValueNode | SubtreeNode => {
+	return node.nodeType === 'model-value' || node.nodeType === 'subtree';
+};
 </script>
 
 <template>
 	<template v-for="node in nodes" :key="node.nodeId">
 		<template v-if="node.currentState.relevant">
-			<!-- Render leaf nodes like string, select, etc -->
-			<FormQuestion v-if="isQuestionNode(node)" :question="node" />
-
 			<!-- Render group nodes -->
 			<FormGroup v-if="isGroupNode(node)" :node="node" />
 
 			<!-- Render repeat nodes -->
-			<RepeatRange v-if="isRepeatRangeNode(node)" :node="node" />
+			<RepeatRange v-else-if="isRepeatRangeNode(node)" :node="node" />
+
+
+			<!-- Render leaf nodes like string, select, etc -->
+			<FormQuestion v-else-if="!isModelOnlyNode(node)" :question="node" />
 		</template>
 	</template>
 </template>

--- a/packages/web-forms/src/components/controls/UnsupportedControl.vue
+++ b/packages/web-forms/src/components/controls/UnsupportedControl.vue
@@ -1,14 +1,11 @@
 <script setup lang="ts">
-import type { AnyControlNode } from '@getodk/xforms-engine';
+import type { AnyUnsupportedControlNode } from '@getodk/xforms-engine';
 
-defineProps<{ question: AnyControlNode }>();
-
-const isDev = () => {
-	return import.meta.env.DEV;
-};
+defineProps<{ question: AnyUnsupportedControlNode }>();
 </script>
+
 <template>
-	<div v-if="isDev()">
+	<div>
 		Unsupported field {<strong>{{ question.nodeType }}</strong>} in the form definition.
 	</div>
 </template>

--- a/packages/xforms-engine/src/client/hierarchy.ts
+++ b/packages/xforms-engine/src/client/hierarchy.ts
@@ -9,6 +9,17 @@ import type { RootNode } from './RootNode.ts';
 import type { SelectNode } from './SelectNode.ts';
 import type { StringNode } from './StringNode.ts';
 import type { SubtreeNode } from './SubtreeNode.ts';
+import type { RangeNode } from './unsupported/RangeNode.ts';
+import type { RankNode } from './unsupported/RankNode.ts';
+import type { TriggerNode } from './unsupported/TriggerNode.ts';
+import type { UploadNode } from './unsupported/UploadNode.ts';
+
+// prettier-ignore
+export type AnyUnsupportedControlNode =
+	| RangeNode
+	| RankNode
+	| TriggerNode
+	| UploadNode;
 
 // prettier-ignore
 export type AnyControlNode =
@@ -19,6 +30,7 @@ export type AnyControlNode =
 // prettier-ignore
 export type AnyLeafNode =
 	| AnyControlNode
+	| AnyUnsupportedControlNode
 	| ModelValueNode;
 
 // prettier-ignore

--- a/packages/xforms-engine/src/client/node-types.ts
+++ b/packages/xforms-engine/src/client/node-types.ts
@@ -1,4 +1,11 @@
 // prettier-ignore
+export type UnsupportedControlNodeType =
+	| 'range'
+	| 'rank'
+	| 'trigger'
+	| 'upload';
+
+// prettier-ignore
 export type RepeatRangeNodeType =
 	| 'repeat-range:controlled'
 	| 'repeat-range:uncontrolled'
@@ -14,4 +21,5 @@ export type InstanceNodeType =
 	| 'model-value'
 	| 'note'
 	| 'select'
-	| 'string';
+	| 'string'
+	| UnsupportedControlNodeType;

--- a/packages/xforms-engine/src/client/unsupported/RangeNode.ts
+++ b/packages/xforms-engine/src/client/unsupported/RangeNode.ts
@@ -1,0 +1,14 @@
+import type { RangeControlDefinition } from '../../parse/body/control/RangeControlDefinition.ts';
+import type {
+	UnsupportedControlDefinition,
+	UnsupportedControlNode,
+} from './UnsupportedControlNode.ts';
+
+export interface RangeNodeDefinition extends UnsupportedControlDefinition {
+	readonly bodyElement: RangeControlDefinition;
+}
+
+export interface RangeNode extends UnsupportedControlNode {
+	readonly nodeType: 'range';
+	readonly definition: RangeNodeDefinition;
+}

--- a/packages/xforms-engine/src/client/unsupported/RankNode.ts
+++ b/packages/xforms-engine/src/client/unsupported/RankNode.ts
@@ -1,0 +1,14 @@
+import type { RankControlDefinition } from '../../parse/body/control/RankControlDefinition.ts';
+import type {
+	UnsupportedControlDefinition,
+	UnsupportedControlNode,
+} from './UnsupportedControlNode.ts';
+
+export interface RankNodeDefinition extends UnsupportedControlDefinition {
+	readonly bodyElement: RankControlDefinition;
+}
+
+export interface RankNode extends UnsupportedControlNode {
+	readonly nodeType: 'rank';
+	readonly definition: RankNodeDefinition;
+}

--- a/packages/xforms-engine/src/client/unsupported/TriggerNode.ts
+++ b/packages/xforms-engine/src/client/unsupported/TriggerNode.ts
@@ -1,0 +1,14 @@
+import type { TriggerControlDefinition } from '../../parse/body/control/TriggerControlDefinition.ts';
+import type {
+	UnsupportedControlDefinition,
+	UnsupportedControlNode,
+} from './UnsupportedControlNode.ts';
+
+export interface TriggerNodeDefinition extends UnsupportedControlDefinition {
+	readonly bodyElement: TriggerControlDefinition;
+}
+
+export interface TriggerNode extends UnsupportedControlNode {
+	readonly nodeType: 'trigger';
+	readonly definition: TriggerNodeDefinition;
+}

--- a/packages/xforms-engine/src/client/unsupported/UnsupportedControlNode.ts
+++ b/packages/xforms-engine/src/client/unsupported/UnsupportedControlNode.ts
@@ -1,0 +1,42 @@
+import type { UnknownAppearanceDefinition } from '../../parse/body/appearance/unknownAppearanceParser.ts';
+import type { RangeControlDefinition } from '../../parse/body/control/RangeControlDefinition.ts';
+import type { RankControlDefinition } from '../../parse/body/control/RankControlDefinition.ts';
+import type { TriggerControlDefinition } from '../../parse/body/control/TriggerControlDefinition.ts';
+import type { UploadControlDefinition } from '../../parse/body/control/UploadControlDefinition.ts';
+import type { LeafNodeDefinition } from '../../parse/model/LeafNodeDefinition.ts';
+import type { BaseNode, BaseNodeState } from '../BaseNode.ts';
+import type { RootNode } from '../RootNode.ts';
+import type { GeneralParentNode } from '../hierarchy.ts';
+import type { UnsupportedControlNodeType } from '../node-types.ts';
+import type { LeafNodeValidationState } from '../validation.ts';
+
+export interface UnsupportedControlNodeState extends BaseNodeState {
+	get children(): null;
+	get valueOptions(): unknown;
+	get value(): unknown;
+}
+
+export type UnsupportedControlElementDefinition =
+	| RangeControlDefinition
+	| RankControlDefinition
+	| TriggerControlDefinition
+	| UploadControlDefinition;
+
+export interface UnsupportedControlDefinition extends LeafNodeDefinition {
+	readonly bodyElement: UnsupportedControlElementDefinition;
+}
+
+/**
+ * Stub node, for form controls pending further engine support.
+ */
+export interface UnsupportedControlNode extends BaseNode {
+	readonly nodeType: UnsupportedControlNodeType;
+	readonly appearances: UnknownAppearanceDefinition;
+	readonly definition: UnsupportedControlDefinition;
+	readonly root: RootNode;
+	readonly parent: GeneralParentNode;
+	readonly currentState: UnsupportedControlNodeState;
+	readonly validationState: LeafNodeValidationState;
+
+	setValue?(value: never): never;
+}

--- a/packages/xforms-engine/src/client/unsupported/UploadNode.ts
+++ b/packages/xforms-engine/src/client/unsupported/UploadNode.ts
@@ -1,0 +1,14 @@
+import type { UploadControlDefinition } from '../../parse/body/control/UploadControlDefinition.ts';
+import type {
+	UnsupportedControlDefinition,
+	UnsupportedControlNode,
+} from './UnsupportedControlNode.ts';
+
+export interface UploadNodeDefinition extends UnsupportedControlDefinition {
+	readonly bodyElement: UploadControlDefinition;
+}
+
+export interface UploadNode extends UnsupportedControlNode {
+	readonly nodeType: 'upload';
+	readonly definition: UploadNodeDefinition;
+}

--- a/packages/xforms-engine/src/index.ts
+++ b/packages/xforms-engine/src/index.ts
@@ -13,6 +13,7 @@ export type {
 	AnyLeafNode,
 	AnyNode,
 	AnyParentNode,
+	AnyUnsupportedControlNode,
 	GeneralChildNode,
 	GeneralParentNode,
 	RepeatRangeNode,
@@ -29,6 +30,10 @@ export type * from './client/SelectNode.ts';
 export type * from './client/StringNode.ts';
 export type * from './client/SubtreeNode.ts';
 export type * from './client/TextRange.ts';
+export type * from './client/unsupported/RangeNode.ts';
+export type * from './client/unsupported/RankNode.ts';
+export type * from './client/unsupported/TriggerNode.ts';
+export type * from './client/unsupported/UploadNode.ts';
 export type * from './client/validation.ts';
 
 // TODO: notwithstanding potential conflicts with parallel work on `web-forms`

--- a/packages/xforms-engine/src/instance/ModelValue.ts
+++ b/packages/xforms-engine/src/instance/ModelValue.ts
@@ -88,11 +88,11 @@ export class ModelValue
 		this.validation = createValidationState(this, sharedStateOptions);
 	}
 
+	// ValidationContext
 	getViolation(): AnyViolation | null {
 		return this.validation.engineState.violation;
 	}
 
-	// ValidationContext
 	isBlank(): boolean {
 		return this.engineState.value === '';
 	}

--- a/packages/xforms-engine/src/instance/Note.ts
+++ b/packages/xforms-engine/src/instance/Note.ts
@@ -126,11 +126,11 @@ export class Note
 		this.validation = createValidationState(this, sharedStateOptions);
 	}
 
+	// ValidationContext
 	getViolation(): AnyViolation | null {
 		return this.validation.engineState.violation;
 	}
 
-	// ValidationContext
 	isBlank(): boolean {
 		return this.engineState.value === '';
 	}

--- a/packages/xforms-engine/src/instance/SelectField.ts
+++ b/packages/xforms-engine/src/instance/SelectField.ts
@@ -127,10 +127,6 @@ export class SelectField
 		this.validation = createValidationState(this, sharedStateOptions);
 	}
 
-	getViolation(): AnyViolation | null {
-		return this.validation.engineState.violation;
-	}
-
 	protected getSelectItemsByValue(
 		valueOptions: readonly SelectItem[] = this.getValueOptions()
 	): ReadonlyMap<string, SelectItem> {
@@ -220,6 +216,10 @@ export class SelectField
 	}
 
 	// ValidationContext
+	getViolation(): AnyViolation | null {
+		return this.validation.engineState.violation;
+	}
+
 	isBlank(): boolean {
 		return this.engineState.value.length === 0;
 	}

--- a/packages/xforms-engine/src/instance/StringField.ts
+++ b/packages/xforms-engine/src/instance/StringField.ts
@@ -97,11 +97,11 @@ export class StringField
 		this.validation = createValidationState(this, sharedStateOptions);
 	}
 
+	// ValidationContext
 	getViolation(): AnyViolation | null {
 		return this.validation.engineState.violation;
 	}
 
-	// ValidationContext
 	isBlank(): boolean {
 		return this.engineState.value === '';
 	}

--- a/packages/xforms-engine/src/instance/abstract/UnsupportedControl.ts
+++ b/packages/xforms-engine/src/instance/abstract/UnsupportedControl.ts
@@ -1,0 +1,151 @@
+import { identity } from '@getodk/common/lib/identity.ts';
+import type { Accessor } from 'solid-js';
+import type { UnsupportedControlNodeType } from '../../client/node-types.ts';
+import type { TextRange } from '../../client/TextRange.ts';
+import type {
+	UnsupportedControlDefinition,
+	UnsupportedControlElementDefinition,
+	UnsupportedControlNode,
+} from '../../client/unsupported/UnsupportedControlNode.ts';
+import type { AnyViolation, LeafNodeValidationState } from '../../client/validation.ts';
+import { createValueState } from '../../lib/reactivity/createValueState.ts';
+import type { CurrentState } from '../../lib/reactivity/node-state/createCurrentState.ts';
+import type { EngineState } from '../../lib/reactivity/node-state/createEngineState.ts';
+import {
+	createSharedNodeState,
+	type SharedNodeState,
+} from '../../lib/reactivity/node-state/createSharedNodeState.ts';
+import { createFieldHint } from '../../lib/reactivity/text/createFieldHint.ts';
+import { createNodeLabel } from '../../lib/reactivity/text/createNodeLabel.ts';
+import type { SimpleAtomicState } from '../../lib/reactivity/types.ts';
+import {
+	createValidationState,
+	type SharedValidationState,
+} from '../../lib/reactivity/validation/createValidation.ts';
+import type { UnknownAppearanceDefinition } from '../../parse/body/appearance/unknownAppearanceParser.ts';
+import type { GeneralParentNode } from '../hierarchy.ts';
+import type { EvaluationContext } from '../internal-api/EvaluationContext.ts';
+import type { SubscribableDependency } from '../internal-api/SubscribableDependency.ts';
+import type { ValidationContext } from '../internal-api/ValidationContext.ts';
+import type { ValueContext } from '../internal-api/ValueContext.ts';
+import { DescendantNode, type DescendantNodeStateSpec } from './DescendantNode.ts';
+
+type TypedUnsupportedControlElementDefinition<Type extends UnsupportedControlNodeType> = Extract<
+	UnsupportedControlElementDefinition,
+	{ readonly type: Type }
+>;
+
+interface TypedUnsupportedControlDefinition<Type extends UnsupportedControlNodeType>
+	extends UnsupportedControlDefinition {
+	readonly bodyElement: TypedUnsupportedControlElementDefinition<Type>;
+}
+
+interface UnsupportedControlStateSpec extends DescendantNodeStateSpec<unknown> {
+	readonly label: Accessor<TextRange<'label'> | null>;
+	readonly hint: Accessor<TextRange<'hint'> | null>;
+	readonly children: null;
+	readonly value: SimpleAtomicState<unknown>;
+	readonly valueOptions: never;
+}
+
+class UnsupportedControlValueEncodeError extends Error {
+	constructor(type: UnsupportedControlNodeType) {
+		super(`Cannot encode state for node (type: ${type}) - not implemented`);
+	}
+}
+
+class UnsupportedControlWriteError extends Error {
+	constructor(type: UnsupportedControlNodeType) {
+		super(`Cannot write state for node (type: ${type}) - not implemented`);
+	}
+}
+
+export abstract class UnsupportedControl<Type extends UnsupportedControlNodeType>
+	extends DescendantNode<TypedUnsupportedControlDefinition<Type>, UnsupportedControlStateSpec, null>
+	implements
+		UnsupportedControlNode,
+		EvaluationContext,
+		SubscribableDependency,
+		ValidationContext,
+		ValueContext<unknown>
+{
+	private readonly validation: SharedValidationState;
+	protected readonly state: SharedNodeState<UnsupportedControlStateSpec>;
+
+	// InstanceNode
+	protected readonly engineState: EngineState<UnsupportedControlStateSpec>;
+
+	// UnsupportedControlNode
+	abstract override readonly nodeType: Type;
+
+	readonly appearances: UnknownAppearanceDefinition;
+	readonly currentState: CurrentState<UnsupportedControlStateSpec>;
+
+	get validationState(): LeafNodeValidationState {
+		return this.validation.currentState;
+	}
+
+	// ValueContext
+	readonly encodeValue = (instanceValue: unknown): string => {
+		const encoded = instanceValue;
+
+		if (typeof encoded === 'string') {
+			return encoded;
+		}
+
+		throw new UnsupportedControlValueEncodeError(this.nodeType);
+	};
+
+	readonly decodeValue = (instanceValue: unknown): unknown => {
+		return identity(instanceValue);
+	};
+
+	constructor(parent: GeneralParentNode, definition: TypedUnsupportedControlDefinition<Type>) {
+		super(parent, definition);
+
+		this.appearances = definition.bodyElement.appearances;
+
+		const sharedStateOptions = {
+			clientStateFactory: this.engineConfig.stateFactory,
+		};
+
+		const stateSpec: UnsupportedControlStateSpec = {
+			reference: this.contextReference,
+			readonly: this.isReadonly,
+			relevant: this.isRelevant,
+			required: this.isRequired,
+
+			label: createNodeLabel(this, definition),
+			hint: createFieldHint(this, definition),
+			children: null,
+			valueOptions: null as never,
+			value: createValueState<unknown>(this),
+		};
+
+		const state = createSharedNodeState(this.scope, stateSpec, sharedStateOptions);
+
+		this.state = state;
+		this.engineState = state.engineState;
+		this.currentState = state.currentState;
+		this.validation = createValidationState(this, sharedStateOptions);
+	}
+
+	// ValidationContext
+	getViolation(): AnyViolation | null {
+		return this.validation.engineState.violation;
+	}
+
+	isBlank(): boolean {
+		return this.engineState.value === '';
+	}
+
+	// InstanceNode
+	getChildren(): readonly [] {
+		return [];
+	}
+
+	// UnsupportedControlNode
+	setValue(_: never): never {
+		throw new UnsupportedControlWriteError(this.nodeType);
+	}
+}

--- a/packages/xforms-engine/src/instance/hierarchy.ts
+++ b/packages/xforms-engine/src/instance/hierarchy.ts
@@ -8,8 +8,19 @@ import type { Root } from './Root.ts';
 import type { SelectField } from './SelectField.ts';
 import type { StringField } from './StringField.ts';
 import type { Subtree } from './Subtree.ts';
+import type { RangeControl } from './unsupported/RangeControl.ts';
+import type { RankControl } from './unsupported/RankControl.ts';
+import type { TriggerControl } from './unsupported/TriggerControl.ts';
+import type { UploadControl } from './unsupported/UploadControl.ts';
 
 export type RepeatRange = RepeatRangeControlled | RepeatRangeUncontrolled;
+
+// prettier-ignore
+export type UnsupportedControl =
+	| RangeControl
+	| RankControl
+	| TriggerControl
+	| UploadControl;
 
 // prettier-ignore
 export type AnyNode =
@@ -22,7 +33,8 @@ export type AnyNode =
 	| Note
 	| ModelValue
 	| StringField
-	| SelectField;
+	| SelectField
+	| UnsupportedControl;
 
 // prettier-ignore
 export type AnyParentNode =
@@ -51,7 +63,8 @@ export type AnyChildNode =
 	| ModelValue
 	| Note
 	| StringField
-	| SelectField;
+	| SelectField
+	| UnsupportedControl;
 
 // prettier-ignore
 export type GeneralChildNode =
@@ -62,7 +75,8 @@ export type GeneralChildNode =
 	| ModelValue
 	| Note
 	| StringField
-	| SelectField;
+	| SelectField
+	| UnsupportedControl;
 
 // prettier-ignore
 export type AnyValueNode =
@@ -70,4 +84,5 @@ export type AnyValueNode =
 	| ModelValue
 	| Note
 	| StringField
-	| SelectField;
+	| SelectField
+	| UnsupportedControl;

--- a/packages/xforms-engine/src/instance/internal-api/ValidationContext.ts
+++ b/packages/xforms-engine/src/instance/internal-api/ValidationContext.ts
@@ -1,7 +1,13 @@
+import type { AnyViolation } from '../../client/validation.ts';
 import type { BindComputationExpression } from '../../parse/expression/BindComputationExpression.ts';
 import type { MessageDefinition } from '../../parse/text/MessageDefinition.ts';
+import type { NodeID } from '../identity.ts';
 import type { EvaluationContext } from './EvaluationContext.ts';
 import type { SubscribableDependency } from './SubscribableDependency.ts';
+
+interface ValidationContextCurrentState {
+	get reference(): string;
+}
 
 interface ValidationContextDefinitionBind {
 	readonly constraint: BindComputationExpression<'constraint'>;
@@ -15,8 +21,11 @@ interface ValidationContextDefinition {
 }
 
 export interface ValidationContext extends EvaluationContext, SubscribableDependency {
+	readonly nodeId: NodeID;
 	readonly definition: ValidationContextDefinition;
+	readonly currentState: ValidationContextCurrentState;
 
+	getViolation(): AnyViolation | null;
 	isRelevant(): boolean;
 	isRequired(): boolean;
 	isBlank(): boolean;

--- a/packages/xforms-engine/src/instance/unsupported/RangeControl.ts
+++ b/packages/xforms-engine/src/instance/unsupported/RangeControl.ts
@@ -1,0 +1,5 @@
+import { UnsupportedControl } from '../abstract/UnsupportedControl.ts';
+
+export class RangeControl extends UnsupportedControl<'range'> {
+	readonly nodeType = 'range';
+}

--- a/packages/xforms-engine/src/instance/unsupported/RankControl.ts
+++ b/packages/xforms-engine/src/instance/unsupported/RankControl.ts
@@ -1,0 +1,5 @@
+import { UnsupportedControl } from '../abstract/UnsupportedControl.ts';
+
+export class RankControl extends UnsupportedControl<'rank'> {
+	readonly nodeType = 'rank';
+}

--- a/packages/xforms-engine/src/instance/unsupported/TriggerControl.ts
+++ b/packages/xforms-engine/src/instance/unsupported/TriggerControl.ts
@@ -1,0 +1,5 @@
+import { UnsupportedControl } from '../abstract/UnsupportedControl.ts';
+
+export class TriggerControl extends UnsupportedControl<'trigger'> {
+	readonly nodeType = 'trigger';
+}

--- a/packages/xforms-engine/src/instance/unsupported/UploadControl.ts
+++ b/packages/xforms-engine/src/instance/unsupported/UploadControl.ts
@@ -1,0 +1,5 @@
+import { UnsupportedControl } from '../abstract/UnsupportedControl.ts';
+
+export class UploadControl extends UnsupportedControl<'upload'> {
+	readonly nodeType = 'upload';
+}

--- a/packages/xforms-engine/src/lib/TokenListParser.ts
+++ b/packages/xforms-engine/src/lib/TokenListParser.ts
@@ -11,16 +11,20 @@ type TokenListIterator<CanonicalToken extends string> = IterableIterator<
 	PartiallyKnownString<CanonicalToken>
 >;
 
+type PassthroughTokenList = Readonly<Record<string, boolean>>;
+
 /**
  * @see {@link TokenListParser}
  */
 // prettier-ignore
-export type TokenList<CanonicalToken extends string = string> = {
-	readonly [Key in TokenListKey<CanonicalToken>]:
-		Key extends SymbolIterator
-			? () => TokenListIterator<CanonicalToken>
-			: boolean;
-};
+export type TokenList<CanonicalToken extends string = string> =
+	& PassthroughTokenList
+	& {
+		readonly [Key in TokenListKey<CanonicalToken>]:
+			Key extends SymbolIterator
+				? () => TokenListIterator<CanonicalToken>
+				: boolean;
+	};
 
 interface TokenListAlias<CanonicalToken extends string> {
 	readonly fromAlias: string;
@@ -101,7 +105,7 @@ export class TokenListParser<
 	private readonly aliases: ReadonlyMap<string, CanonicalToken>;
 
 	constructor(
-		readonly canonicalTokens: readonly CanonicalToken[],
+		readonly canonicalTokens: readonly CanonicalToken[] = [],
 		options?: TokenListParserOptions<TokenAlias>
 	) {
 		this.aliases = new Map(

--- a/packages/xforms-engine/src/lib/reactivity/validation/createAggregatedViolations.ts
+++ b/packages/xforms-engine/src/lib/reactivity/validation/createAggregatedViolations.ts
@@ -4,10 +4,11 @@ import type {
 	AncestorNodeValidationState,
 	DescendantNodeViolationReference,
 } from '../../../client/validation.ts';
-import type { AnyParentNode, AnyValueNode } from '../../../instance/hierarchy.ts';
+import type { AnyParentNode } from '../../../instance/hierarchy.ts';
+import type { ValidationContext } from '../../../instance/internal-api/ValidationContext.ts';
 import { createSharedNodeState } from '../node-state/createSharedNodeState.ts';
 
-const violationReference = (node: AnyValueNode): DescendantNodeViolationReference | null => {
+const violationReference = (node: ValidationContext): DescendantNodeViolationReference | null => {
 	const violation = node.getViolation();
 
 	if (violation == null) {
@@ -33,7 +34,11 @@ const collectViolationReferences = (
 			case 'model-value':
 			case 'note':
 			case 'string':
-			case 'select': {
+			case 'select':
+			case 'range':
+			case 'rank':
+			case 'trigger':
+			case 'upload': {
 				const reference = violationReference(child);
 
 				if (reference == null) {

--- a/packages/xforms-engine/src/parse/body/BodyDefinition.ts
+++ b/packages/xforms-engine/src/parse/body/BodyDefinition.ts
@@ -4,8 +4,12 @@ import type { XFormDefinition } from '../../parse/XFormDefinition.ts';
 import { DependencyContext } from '../expression/abstract/DependencyContext.ts';
 import { ControlDefinition } from './control/ControlDefinition.ts';
 import { InputDefinition } from './control/InputDefinition.ts';
+import { RangeControlDefinition } from './control/RangeControlDefinition.ts';
+import { RankControlDefinition } from './control/RankControlDefinition.ts';
 import type { AnySelectDefinition } from './control/select/SelectDefinition.ts';
 import { SelectDefinition } from './control/select/SelectDefinition.ts';
+import { TriggerControlDefinition } from './control/TriggerControlDefinition.ts';
+import { UploadControlDefinition } from './control/UploadControlDefinition.ts';
 import { LogicalGroupDefinition } from './group/LogicalGroupDefinition.ts';
 import { PresentationGroupDefinition } from './group/PresentationGroupDefinition.ts';
 import { StructuralGroupDefinition } from './group/StructuralGroupDefinition.ts';
@@ -21,7 +25,11 @@ export interface BodyElementParentContext {
 // prettier-ignore
 export type ControlElementDefinition =
 	| AnySelectDefinition
-	| InputDefinition;
+	| InputDefinition
+	| RangeControlDefinition
+	| RankControlDefinition
+	| TriggerControlDefinition
+	| UploadControlDefinition;
 
 type SupportedBodyElementDefinition =
 	// eslint-disable-next-line @typescript-eslint/sort-type-constituents
@@ -41,6 +49,10 @@ const BodyElementDefinitionConstructors = [
 	StructuralGroupDefinition,
 	InputDefinition,
 	SelectDefinition,
+	RangeControlDefinition,
+	RankControlDefinition,
+	TriggerControlDefinition,
+	UploadControlDefinition,
 ] as const satisfies readonly BodyElementDefinitionConstructor[];
 
 export type AnyBodyElementDefinition =

--- a/packages/xforms-engine/src/parse/body/appearance/unknownAppearanceParser.ts
+++ b/packages/xforms-engine/src/parse/body/appearance/unknownAppearanceParser.ts
@@ -1,0 +1,5 @@
+import { TokenListParser, type ParsedTokenList } from '../../../lib/TokenListParser.ts';
+
+export const unknownAppearanceParser = new TokenListParser();
+
+export type UnknownAppearanceDefinition = ParsedTokenList<typeof unknownAppearanceParser>;

--- a/packages/xforms-engine/src/parse/body/control/RangeControlDefinition.ts
+++ b/packages/xforms-engine/src/parse/body/control/RangeControlDefinition.ts
@@ -1,0 +1,26 @@
+import type { XFormDefinition } from '../../XFormDefinition.ts';
+import {
+	unknownAppearanceParser,
+	type UnknownAppearanceDefinition,
+} from '../appearance/unknownAppearanceParser.ts';
+import type { BodyElementParentContext } from '../BodyDefinition.ts';
+import { ControlDefinition } from './ControlDefinition.ts';
+
+export class RangeControlDefinition extends ControlDefinition<'range'> {
+	static override isCompatible(localName: string): boolean {
+		return localName === 'range';
+	}
+
+	readonly type = 'range';
+	readonly appearances: UnknownAppearanceDefinition;
+
+	constructor(form: XFormDefinition, parent: BodyElementParentContext, element: Element) {
+		super(form, parent, element);
+
+		this.appearances = unknownAppearanceParser.parseFrom(element, 'appearance');
+	}
+
+	override toJSON(): object {
+		return {};
+	}
+}

--- a/packages/xforms-engine/src/parse/body/control/RankControlDefinition.ts
+++ b/packages/xforms-engine/src/parse/body/control/RankControlDefinition.ts
@@ -1,0 +1,27 @@
+import { ODK_NAMESPACE_URI } from '@getodk/common/constants/xmlns.ts';
+import type { XFormDefinition } from '../../XFormDefinition.ts';
+import {
+	unknownAppearanceParser,
+	type UnknownAppearanceDefinition,
+} from '../appearance/unknownAppearanceParser.ts';
+import type { BodyElementParentContext } from '../BodyDefinition.ts';
+import { ControlDefinition } from './ControlDefinition.ts';
+
+export class RankControlDefinition extends ControlDefinition<'rank'> {
+	static override isCompatible(localName: string, element: Element): boolean {
+		return localName === 'rank' && element.namespaceURI === ODK_NAMESPACE_URI;
+	}
+
+	readonly type = 'rank';
+	readonly appearances: UnknownAppearanceDefinition;
+
+	constructor(form: XFormDefinition, parent: BodyElementParentContext, element: Element) {
+		super(form, parent, element);
+
+		this.appearances = unknownAppearanceParser.parseFrom(element, 'appearance');
+	}
+
+	override toJSON(): object {
+		return {};
+	}
+}

--- a/packages/xforms-engine/src/parse/body/control/TriggerControlDefinition.ts
+++ b/packages/xforms-engine/src/parse/body/control/TriggerControlDefinition.ts
@@ -1,0 +1,26 @@
+import type { XFormDefinition } from '../../XFormDefinition.ts';
+import {
+	unknownAppearanceParser,
+	type UnknownAppearanceDefinition,
+} from '../appearance/unknownAppearanceParser.ts';
+import type { BodyElementParentContext } from '../BodyDefinition.ts';
+import { ControlDefinition } from './ControlDefinition.ts';
+
+export class TriggerControlDefinition extends ControlDefinition<'trigger'> {
+	static override isCompatible(localName: string): boolean {
+		return localName === 'trigger';
+	}
+
+	readonly type = 'trigger';
+	readonly appearances: UnknownAppearanceDefinition;
+
+	constructor(form: XFormDefinition, parent: BodyElementParentContext, element: Element) {
+		super(form, parent, element);
+
+		this.appearances = unknownAppearanceParser.parseFrom(element, 'appearance');
+	}
+
+	override toJSON(): object {
+		return {};
+	}
+}

--- a/packages/xforms-engine/src/parse/body/control/UploadControlDefinition.ts
+++ b/packages/xforms-engine/src/parse/body/control/UploadControlDefinition.ts
@@ -1,0 +1,26 @@
+import type { XFormDefinition } from '../../XFormDefinition.ts';
+import {
+	unknownAppearanceParser,
+	type UnknownAppearanceDefinition,
+} from '../appearance/unknownAppearanceParser.ts';
+import type { BodyElementParentContext } from '../BodyDefinition.ts';
+import { ControlDefinition } from './ControlDefinition.ts';
+
+export class UploadControlDefinition extends ControlDefinition<'upload'> {
+	static override isCompatible(localName: string): boolean {
+		return localName === 'upload';
+	}
+
+	readonly type = 'upload';
+	readonly appearances: UnknownAppearanceDefinition;
+
+	constructor(form: XFormDefinition, parent: BodyElementParentContext, element: Element) {
+		super(form, parent, element);
+
+		this.appearances = unknownAppearanceParser.parseFrom(element, 'appearance');
+	}
+
+	override toJSON(): object {
+		return {};
+	}
+}

--- a/packages/xforms-engine/src/parse/body/control/select/SelectDefinition.ts
+++ b/packages/xforms-engine/src/parse/body/control/select/SelectDefinition.ts
@@ -9,15 +9,7 @@ import { ControlDefinition } from '../ControlDefinition.ts';
 import { ItemDefinition } from './ItemDefinition.ts';
 import { ItemsetDefinition } from './ItemsetDefinition.ts';
 
-/**
- * @todo We were previously a bit overzealous about introducing `<rank>` support
- * here. It'll likely still fit, but we should approach it with more intention.
- *
- * @todo `<trigger>` is *almost* reasonable to support here too. The main
- * hesitation is that its single, implicit "item" does not have a distinct
- * <label>, and presumably has different UX **and translation** considerations.
- */
-const selectLocalNames = new Set([/* 'rank', */ 'select', 'select1'] as const);
+const selectLocalNames = new Set(['select', 'select1'] as const);
 
 export type SelectType = CollectionValues<typeof selectLocalNames>;
 


### PR DESCRIPTION
Closes #214.

## I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable

I would be shocked if there are any cross browser implications to this change.

## What else has been done to verify that this works as intended?

The vast majority of it was guided by:

- Type checking
- Existing tests

**Note:** I have not added any _new tests_. I am certainly open to it. If there's interest, the tests I think would be most valuable would be engine-level unit-ish tests verifying that all of the stubbed node types:

- exist
- have the expected `nodeType` (i.e. not `'model-value'`, reported as a bug in #214)

I think that testing beyond that would ultimately have negative value: anything else we would be inclined to test will definitely change when we implement real support for these node types.

## Why is this the best possible solution? Were any other approaches considered?

I briefly considered actually implementing engine support for `<trigger>`, since that lack of support was also what prompted this work. But I think this is a good unit of work, and I believe it would be trivial to follow up with that additional (now even more trivial) change.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

## Do we need any specific form for testing your changes? If so, please attach one.

Any form with any of the following controls should now present those nodes as unsupported in the `web-forms` UI:

- `<range>`
- `<odk:rank>`
- `<trigger>`
- `<upload>`

## What's changed

Anything I'd add here would be redundant to notes on each commit.