### PR TITLE
Fix: name of upload node is upload not range

### DIFF
--- a/.changeset/stale-actors-learn.md
+++ b/.changeset/stale-actors-learn.md
@@ -1,0 +1,5 @@
+---
+"@getodk/xforms-engine": patch
+---
+
+Fixed the name of upload node for parsing the Form

--- a/packages/xforms-engine/src/instance/children.ts
+++ b/packages/xforms-engine/src/instance/children.ts
@@ -85,7 +85,7 @@ const isTriggerNodeDefinition = (
 const isUploadNodeDefinition = (
 	definition: ControlNodeDefinition
 ): definition is UploadNodeDefinition => {
-	return definition.bodyElement.type === 'range';
+	return definition.bodyElement.type === 'upload';
 };
 
 export const buildChildren = (parent: GeneralParentNode): GeneralChildNode[] => {


### PR DESCRIPTION
Closes: NA

## I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable

## What else has been done to verify that this works as intended?

All tests pass. 
Tried previewing a Form with `upload`, it renders correctly 

## Why is this the best possible solution? Were any other approaches considered?

NA

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There's no regression risk.

## Do we need any specific form for testing your changes? If so, please attach one.

http://xlsform-online.sadiqkhoja.com/downloads/acd96076c01a4facb65111b038b9adf64jj09j3z/PhilSA%20Disaster%20Incidence.xml

## What's changed

- Corrected the bodyElement type of `upload` node