### PR TITLE
Update the feature matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This section is auto generated. Please update `feature-matrix.json` and then run
   <summary>
 
 <!-- prettier-ignore -->
-  #####  $\texttt{Appearances\hspace{41mm}\color{green}███\color{LightGray}████████████ \color{initial} 21\\%}$
+  #####  $\texttt{Appearances\hspace{41mm}\color{green}███\color{LightGray}████████████ \color{initial} 24\\%}$
 
   </summary>
   <br/>
@@ -131,13 +131,12 @@ This section is auto generated. Please update `feature-matrix.json` and then run
 | columns-n                  |    ✅    |
 | no-buttons                 |    ✅    |
 | image-map                  |          |
-| likert                     |          |
+| likert                     |    ✅    |
 | map                        |          |
 | field-list                 |    ✅    |
 | label                      |    ✅    |
 | list-nolabel               |    ✅    |
 | list                       |    ✅    |
-| table-list                 |          |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Here are some of our high-level priorities to get to a production-ready state:
 - Implement all types and appearances defined in [XLSForm](https://xlsform.org/en/ref-table/)
 - Define a thoughtful interface for host applications that balances ease of use and flexibility
 
-Here is the feature matrix and the progress we have made so far:
+### Feature matrix
 
-<!-- Following section is auto generated. Please update the `feature-matrix.json` as more features are implemented and then run `yarn feature-matrix` from the repository's root to regenerate this section. -->
+This section is auto generated. Please update `feature-matrix.json` and then run `yarn feature-matrix` from the repository's root to update it.
 
 <!-- autogen: feature-matrix -->
 
@@ -73,7 +73,7 @@ Here is the feature matrix and the progress we have made so far:
 | datetime                   |          |
 | rank                       |          |
 | csv-external               |          |
-| acknowledge                |          |
+| acknowledge                |    🚧    |
 | start                      |          |
 | end                        |          |
 | today                      |          |
@@ -182,7 +182,7 @@ Here is the feature matrix and the progress we have made so far:
 | custom constraint          |    ✅    |
 | constraint message         |    ✅    |
 | read only                  |    ✅    |
-| trigger                    |    🚧    |
+| trigger                    |          |
 | choice filter              |    ✅    |
 | default                    |    ✅    |
 | query parameter            |          |

--- a/feature-matrix.json
+++ b/feature-matrix.json
@@ -24,7 +24,7 @@
     "datetime": "",
     "rank": "",
     "csv-external": "",
-    "acknowledge": "",
+    "acknowledge": "🚧",
     "start": "",
     "end": "",
     "today": "",
@@ -70,13 +70,12 @@
     "columns-n": "✅",
     "no-buttons": "✅",
     "image-map": "",
-    "likert": "",
+    "likert": "✅",
     "map": "",
     "field-list": "✅",
     "label": "✅",
     "list-nolabel": "✅",
-    "list": "✅",
-    "table-list": ""
+    "list": "✅"
   },
   "Parameters": {
     "randomize": "✅",
@@ -97,7 +96,7 @@
     "custom constraint": "✅",
     "constraint message": "✅",
     "read only": "✅",
-    "trigger": "🚧",
+    "trigger": "",
     "choice filter": "✅",
     "default": "✅",
     "query parameter": "",

--- a/scripts/feature-matrix/README.md
+++ b/scripts/feature-matrix/README.md
@@ -1,0 +1,3 @@
+# feature-matrix
+
+Run from top-level with `yarn feature-matrix` to render the contents of `feature-matrix.json` and inject it into the top-level README.


### PR DESCRIPTION
I noticed that XLSForm `trigger` was marked as in progress but that corresponds to XForms `setvalue` which is not yet in progress. ODK XForms `trigger` is exposed in XLSForm as `acknowledge`. I don't know the full history of this weirdness!

While I was there, I also noticed that we do have a full implementation of `likert` and that `table-list` is an XLSForm alias so doesn't need to be here.

I had some trouble figuring out how to run the script so I added a few more breadcrumbs. I also added a section header to try to improve the Github table of contents view.

This doesn't need a changeset because it's not end-user-facing.