### PR TITLE
Basic presentation of form load failures; prepare release: `@getodk/web-forms` 0.5.0

### DIFF
--- a/.changeset/sweet-zebras-boil.md
+++ b/.changeset/sweet-zebras-boil.md
@@ -1,0 +1,6 @@
+---
+'@getodk/web-forms': patch
+'@getodk/common': patch
+---
+
+Basic presentation of form load failures

--- a/.changeset/sweet-zebras-boil.md
+++ b/.changeset/sweet-zebras-boil.md
@@ -1,6 +1,0 @@
----
-'@getodk/web-forms': minor
-'@getodk/common': minor
----
-
-Basic presentation of form load failures

--- a/.changeset/sweet-zebras-boil.md
+++ b/.changeset/sweet-zebras-boil.md
@@ -1,6 +1,6 @@
 ---
-'@getodk/web-forms': patch
-'@getodk/common': patch
+'@getodk/web-forms': minor
+'@getodk/common': minor
 ---
 
 Basic presentation of form load failures

--- a/.changeset/tame-panthers-fetch.md
+++ b/.changeset/tame-panthers-fetch.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": minor
----
-
-Show web-forms version in the footer.

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @getodk/common
 
+## 0.4.0
+
+### Minor Changes
+
+- 27c440d: Basic presentation of form load failures
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getodk/common",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "@getodk/common",
   "type": "module",
   "author": "getodk",

--- a/packages/common/src/fixtures/REAMDE.md
+++ b/packages/common/src/fixtures/REAMDE.md
@@ -18,9 +18,13 @@ The fixtures are structured into a set of sub-directories. These sub-directories
 
 Two of the sub-directories in particular serve an important purpose:
 
-- [`test-javarosa`](./test-javarosa): Fixtures in this directory have been copied directly from JavaRosa, and are referenced by tests in [@getodk/scenario](../../../scenario/) integration test suites. These fixtures and resources should not be modified, except when their counterparts are updated upstream in JavaRosa.
+- [`test-javarosa`](./test-javarosa/): Fixtures in this directory have been copied directly from JavaRosa, and are referenced by tests in [@getodk/scenario](../../../scenario/) integration test suites. These fixtures and resources should not be modified, except when their counterparts are updated upstream in JavaRosa.
 
-- [`test-scenario`](./test-scenario): Fixtures in this directory are _derived from_ those in `test-javarosa`, with a naming convention appending `-alt` as a suffix to their base name. These fixtures are intended to have only minor modifications from their counterparts in the upstream `test-javarosa` directory. They should also not be modified, except to either reflect changes from JavaRosa upstream, or to demonstrate key behavioral differences in the tests referencing them.
+- [`test-scenario`](./test-scenario/): Fixtures in this directory are _derived from_ those in `test-javarosa`, with a naming convention appending `-alt` as a suffix to their base name. These fixtures are intended to have only minor modifications from their counterparts in the upstream `test-javarosa` directory. They should also not be modified, except to either reflect changes from JavaRosa upstream, or to demonstrate key behavioral differences in the tests referencing them.
+
+- [`test-web-forms`](./test-web-forms/): Fixtures in this directory are used for testing UI/UX behavior, as implemented by the [@getodk/web-forms](../../../web-forms/) package. These fixtures are intended to make it easy to manually inspect and interact with the same fixtures used under test.
+
+  **NOTE:** In the future, we may also consider ways to make UI access easier for test fixtures defined in tests inline, using the [XForms DSL](../test/fixtures/xform-dsl/README.md). In which case, we should consider inlining these fixtures as well.
 
 - [`preview-service`](./preview-service/): Fixtures in this directory are used as real world Forms in the Web Form preview service. It contains XLSForms to be serve as downloadable resource from the service. XForms are generated using [pyxform](https://github.com/XLSForm/pyxform) / [xlsform-online](https://getodk.org/xlsform/) service and should not be manually modified. Note: XForm (xml) for WHO Verbal Autopsy is not placed in the `xform` subdirectory as it is already present in the [`smoketests`](./test-javarosa/resources//smoketests/)
 

--- a/packages/common/src/fixtures/test-web-forms/simple-dag-cycle.xml
+++ b/packages/common/src/fixtures/test-web-forms/simple-dag-cycle.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+  xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms"
+  xmlns:orx="http://openrosa.org/xforms">
+  <h:head>
+    <h:title>Form design problem: computation cycle</h:title>
+    <model>
+      <instance>
+        <data id="simple-dag-cycle">
+          <group>
+            <a>1</a>
+          </group>
+        </data>
+      </instance>
+      <bind nodeset="/data/group/a" type="int" calculate="../a + 1" />
+    </model>
+  </h:head>
+  <h:body>
+    <group ref="/data/group">
+      <repeat nodeset="/data/group">
+        <input ref="/data/group/a" />
+      </repeat>
+    </group>
+  </h:body>
+</h:html>

--- a/packages/common/src/fixtures/test-web-forms/xpath-syntax-error.xml
+++ b/packages/common/src/fixtures/test-web-forms/xpath-syntax-error.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+  xmlns:ev="http://www.w3.org/2001/xml-events"
+  xmlns:h="http://www.w3.org/1999/xhtml"
+  xmlns:jr="http://openrosa.org/javarosa"
+  xmlns:orx="http://openrosa.org/xforms/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Form design problem: syntax error</h:title>
+    <model>
+      <instance>
+        <root id="form-design-problem-syntax-error">
+          <first-question>1</first-question>
+          <second-question />
+          <meta>
+            <instanceID />
+          </meta>
+        </root>
+      </instance>
+      <bind nodeset="/root/first-question" />
+      <bind nodeset="/root/second-question" calculate="/root/first-question ? 2" />
+      <bind nodeset="/root/meta/instanceID" type="string" />
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/root/first-question">
+      <label>1. Default value is 1</label>
+    </input>
+    <input ref="/root/second-question">
+      <label>2. Fails to calculate (expression has invalid token: `?`)</label>
+    </input>
+  </h:body>
+</h:html>

--- a/packages/common/src/fixtures/test-web-forms/xpath-unknown-function.xml
+++ b/packages/common/src/fixtures/test-web-forms/xpath-unknown-function.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+  xmlns:ev="http://www.w3.org/2001/xml-events"
+  xmlns:h="http://www.w3.org/1999/xhtml"
+  xmlns:jr="http://openrosa.org/javarosa"
+  xmlns:orx="http://openrosa.org/xforms/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Form design problem: unknown XPath function</h:title>
+    <model>
+      <instance>
+        <root id="xpath-unknown-function">
+          <first-question />
+          <second-question />
+          <meta>
+            <instanceID />
+          </meta>
+        </root>
+      </instance>
+      <bind nodeset="/root/first-question" calculate="nope(1)" />
+      <bind nodeset="/root/meta/instanceID" type="string" />
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/root/first-question">
+      <label>Calculate calls an XPath function `nope`, which does not exist!</label>
+    </input>
+  </h:body>
+</h:html>

--- a/packages/common/src/lib/runtime-types/shared-type-predicates.ts
+++ b/packages/common/src/lib/runtime-types/shared-type-predicates.ts
@@ -1,0 +1,11 @@
+export type UnknownObject = Readonly<Record<PropertyKey, unknown>>;
+
+/**
+ * Checks whether a value's type is `'object'`, and the value is not `null`.
+ * This is useful as a precondition for more specific type-narrowing predicate
+ * and/or assertion functions, allowing inspection of arbitrary properties on
+ * {@link value} without verbose/error prone inline type assertions.
+ */
+export const isUnknownObject = (value: unknown): value is UnknownObject => {
+	return typeof value === 'object' && value != null;
+};

--- a/packages/ui-solid/CHANGELOG.md
+++ b/packages/ui-solid/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @getodk/ui-solid
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies [27c440d]
+  - @getodk/common@0.4.0
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/ui-solid/package.json
+++ b/packages/ui-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/ui-solid",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "Apache-2.0",
   "description": "Solid UI client for ODK Web Forms",
   "type": "module",
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^5.1.0",
-    "@getodk/common": "0.3.0",
+    "@getodk/common": "0.4.0",
     "@getodk/xforms-engine": "0.4.0",
     "@solidjs/router": "^0.14.5",
     "@suid/icons-material": "^0.8.1",

--- a/packages/web-forms/CHANGELOG.md
+++ b/packages/web-forms/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @getodk/web-forms
 
+## 0.5.0
+
+### Minor Changes
+
+- 27c440d: Basic presentation of form load failures
+- 1cae631: Show web-forms version in the footer.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/web-forms",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "description": "ODK Web Forms",
   "author": "getodk",

--- a/packages/web-forms/src/components/Form/FormLoadFailureDialog.vue
+++ b/packages/web-forms/src/components/Form/FormLoadFailureDialog.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import Dialog from 'primevue/dialog';
+import Message from 'primevue/message';
+import { computed } from 'vue';
+import type { InitializeFormFailure } from '../../lib/error/FormLoadFailure.ts';
+
+/**
+ * @todo translations
+ */
+const FORM_LOAD_ERROR_TEXT = {
+	DIALOG_TITLE: 'An error occurred while loading this form',
+	DETAILS_SUMMARY_LABEL: 'Technical error details',
+};
+
+interface FormLoadErrorProps {
+	readonly error: InitializeFormFailure;
+}
+
+const props = defineProps<FormLoadErrorProps>();
+
+interface FormLoadErrorDetail {
+	readonly stack: string | null;
+	readonly unknownCauseDetail: string | null;
+}
+
+const detail = computed((): FormLoadErrorDetail | null => {
+	const { stack = null, unknownCauseDetail } = props.error;
+
+	if (stack == null && unknownCauseDetail == null) {
+		return null;
+	}
+
+	return {
+		stack,
+		unknownCauseDetail,
+	};
+});
+</script>
+
+<template>
+	<Dialog
+		class="form-load-failure-dialog"
+		:visible="detail != null"
+		:header="FORM_LOAD_ERROR_TEXT.DIALOG_TITLE"
+		:closable="false"
+		:draggable="false"
+		:keep-in-viewport="true"
+	>
+		<div class="content">
+			<Message severity="error" class="message" :closable="false">
+				{{ error.message }}
+			</Message>
+
+			<details v-if="detail != null" class="initialize-form-failure-details">
+				<summary>{{ FORM_LOAD_ERROR_TEXT.DETAILS_SUMMARY_LABEL }}</summary>
+
+				<pre v-if="detail.unknownCauseDetail != null">{{
+				detail.unknownCauseDetail
+				}}</pre>
+
+				<pre v-if="detail.stack != null">{{
+				detail.stack
+				}}</pre>
+			</details>
+		</div>
+	</Dialog>
+</template>
+
+<style scoped>
+.form-load-failure-dialog .content {
+	width: calc(100dvw - 6rem) !important;
+}
+
+.form-load-failure-dialog .message {
+	margin-top: 0;
+}
+
+.initialize-form-failure-details {
+	display: block;
+	position: relative;
+	max-width: 100%;
+	overflow: auto;
+}
+
+.initialize-form-failure-details summary {
+	cursor: pointer;
+}
+</style>

--- a/packages/web-forms/src/components/Form/FormLoadFailureDialog.vue
+++ b/packages/web-forms/src/components/Form/FormLoadFailureDialog.vue
@@ -2,7 +2,7 @@
 import Dialog from 'primevue/dialog';
 import Message from 'primevue/message';
 import { computed } from 'vue';
-import type { InitializeFormFailure } from '../../lib/error/FormLoadFailure.ts';
+import type { FormInitializationError } from '../../lib/error/FormInitializationError.ts';
 
 /**
  * @todo translations
@@ -13,7 +13,7 @@ const FORM_LOAD_ERROR_TEXT = {
 };
 
 interface FormLoadErrorProps {
-	readonly error: InitializeFormFailure;
+	readonly error: FormInitializationError;
 }
 
 const props = defineProps<FormLoadErrorProps>();

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -4,7 +4,7 @@ import Button from 'primevue/button';
 import Card from 'primevue/card';
 import PrimeMessage from 'primevue/message';
 import { computed, provide, reactive, ref, watchEffect, type ComponentPublicInstance } from 'vue';
-import { InitializeFormFailure } from '../lib/error/FormLoadFailure.ts';
+import { FormInitializationError } from '../lib/error/FormInitializationError.ts';
 import FormLoadFailureDialog from './Form/FormLoadFailureDialog.vue';
 import FormHeader from './FormHeader.vue';
 import QuestionList from './QuestionList.vue';
@@ -16,7 +16,7 @@ const emit = defineEmits(['submit']);
 
 const odkForm = ref<RootNode>();
 const submitPressed = ref(false);
-const initializeFormError = ref<InitializeFormFailure | null>();
+const initializeFormError = ref<FormInitializationError | null>();
 
 initializeForm(props.formXml, {
 	config: {
@@ -27,7 +27,7 @@ initializeForm(props.formXml, {
 		odkForm.value = f;
 	})
 	.catch((cause) => {
-		initializeFormError.value = new InitializeFormFailure(cause);
+		initializeFormError.value = new FormInitializationError(cause);
 	});
 
 const handleSubmit = () => {

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -4,19 +4,19 @@ import Button from 'primevue/button';
 import Card from 'primevue/card';
 import PrimeMessage from 'primevue/message';
 import { computed, provide, reactive, ref, watchEffect, type ComponentPublicInstance } from 'vue';
+import { InitializeFormFailure } from '../lib/error/FormLoadFailure.ts';
+import FormLoadFailureDialog from './Form/FormLoadFailureDialog.vue';
 import FormHeader from './FormHeader.vue';
-
 import QuestionList from './QuestionList.vue';
 
 const webFormsVersion = __WEB_FORMS_VERSION__;
 
 const props = defineProps<{ formXml: string }>();
+const emit = defineEmits(['submit']);
 
 const odkForm = ref<RootNode>();
-
 const submitPressed = ref(false);
-
-const emit = defineEmits(['submit']);
+const initializeFormError = ref<InitializeFormFailure | null>();
 
 initializeForm(props.formXml, {
 	config: {
@@ -26,9 +26,8 @@ initializeForm(props.formXml, {
 	.then((f) => {
 		odkForm.value = f;
 	})
-	.catch((error) => {
-		// eslint-disable-next-line no-console
-		console.error(error);
+	.catch((cause) => {
+		initializeFormError.value = new InitializeFormFailure(cause);
 	});
 
 const handleSubmit = () => {
@@ -40,11 +39,11 @@ const handleSubmit = () => {
 	}
 };
 
-const errorMessagePopover = ref<ComponentPublicInstance | null>(null);
+const validationErrorMessagePopover = ref<ComponentPublicInstance | null>(null);
 
 provide('submitPressed', submitPressed);
 
-const formErrorMessage = computed(() => {
+const validationErrorMessage = computed(() => {
 	const violationLength = odkForm.value!.validationState.violations.length;
 
 	// TODO: translations
@@ -54,20 +53,37 @@ const formErrorMessage = computed(() => {
 });
 
 watchEffect(() => {
-	if (submitPressed.value && formErrorMessage.value) {
-		(errorMessagePopover.value?.$el as HTMLElement)?.showPopover?.();
+	if (submitPressed.value && validationErrorMessage.value) {
+		(validationErrorMessagePopover.value?.$el as HTMLElement)?.showPopover?.();
 	} else {
-		(errorMessagePopover.value?.$el as HTMLElement)?.hidePopover?.();
+		(validationErrorMessagePopover.value?.$el as HTMLElement)?.hidePopover?.();
 	}
 });
 </script>
-
+<!--
+	TODO: consider handling all template control flow on `<template>` tags! While
+	`v-if` and similar Vue directives are available on HTML and component tags,
+	using `<template>` could help make it much more clear where control flow
+	exists. And it could help make it much more clear what props are actually
+	applicable for usage of a given tag.
+-->
 <template>
-	<div v-if="odkForm" class="odk-form" :class="{ 'submit-pressed': submitPressed }">
+	<template v-if="initializeFormError != null">
+		<FormLoadFailureDialog
+			severity="error"
+			:error="initializeFormError"
+		/>
+	</template>
+
+	<div
+		v-else-if="odkForm"
+		class="odk-form"
+		:class="{ 'submit-pressed': submitPressed }"
+	>
 		<div class="form-wrapper">
-			<div v-show="submitPressed && formErrorMessage" class="error-banner-placeholder" />
-			<PrimeMessage ref="errorMessagePopover" popover="manual" severity="error" icon="icon-error_outline" class="form-error-message" :closable="false">
-				{{ formErrorMessage }}
+			<div v-show="submitPressed && validationErrorMessage" class="error-banner-placeholder" />
+			<PrimeMessage ref="validationErrorMessagePopover" popover="manual" severity="error" icon="icon-error_outline" class="form-error-message" :closable="false">
+				{{ validationErrorMessage }}
 			</PrimeMessage>
 
 			<FormHeader :form="odkForm" />

--- a/packages/web-forms/src/lib/error/FormInitializationError.ts
+++ b/packages/web-forms/src/lib/error/FormInitializationError.ts
@@ -81,8 +81,11 @@ const UNKNOWN_ERROR_MESSAGE = 'Unknown error';
  *   by {@link JSON.stringify}, we assign that serialization to
  *   {@link unknownCauseDetail}, in hopes it will provide further clarification
  *   of unknown failure conditions.
+ *
+ * @todo The name of this class may change soon! It may also move up the stack
+ * to `@getodk/xforms-engine`.
  */
-export class InitializeFormFailure extends Error {
+export class FormInitializationError extends Error {
 	readonly unknownCauseDetail: string | null;
 	readonly stack?: string | undefined;
 

--- a/packages/web-forms/src/lib/error/FormLoadFailure.ts
+++ b/packages/web-forms/src/lib/error/FormLoadFailure.ts
@@ -1,0 +1,127 @@
+import {
+	isUnknownObject,
+	type UnknownObject,
+} from '@getodk/common/lib/runtime-types/shared-type-predicates.ts';
+import type { initializeForm } from '@getodk/xforms-engine';
+
+interface ErrorLikeCause extends UnknownObject {
+	readonly message: string;
+	readonly stack?: string | null;
+}
+
+const isErrorLikeCause = (cause: unknown): cause is ErrorLikeCause => {
+	if (!isUnknownObject(cause)) {
+		return false;
+	}
+
+	const { message, stack } = cause;
+
+	return typeof message === 'string' && (typeof stack === 'string' || stack == null);
+};
+
+/**
+ * @todo translations
+ */
+const UNKNOWN_ERROR_MESSAGE = 'Unknown error';
+
+/**
+ * Provides a minimal, uniform representation of most general, known form load
+ * failure conditions.
+ *
+ * This is a stopgap measure, and it WILL change as we refine the story for
+ * error production within the engine (and its upstream dependencies). The
+ * primary intent is to model enough of the current failure outcomes to provide
+ * more useful feedback to users of the current Web Forms Preview. A secondary
+ * intent is to leave some breadcrumbs (i.e. this JSDoc block; a rough sketch of
+ * failure modes known and/or encountered in this stopgap effort) for that
+ * coming refinement.
+ *
+ * We handle these broad cases, each of which may be produced by a rejected
+ * {@link Promise}, as returned by {@link initializeForm}:
+ *
+ * 1. Promise is rejected with any {@link Error}, or subclass/inheritor thereof,
+ *    as thrown by `@getodk/xforms-engine` or `@getodk/xpath`. These are
+ *    knowable, but they're not stable, documented, or modeled in the type
+ *    system. We defer any specialized handling of these cases to incoming
+ *    improvements on those known gaps.
+ *
+ * 2. Promise is rejected with a string value thrown by `@getodk/xpath`. Sorry!
+ *    We will address all of these soon!
+ *
+ * 3. Promise is rejected with an {@link Error} whose
+ *    {@link Error.message | message} is an empty string. This is the default
+ *    behavior of `new Error()` with no arguments (or of any {@link Error}
+ *    subclass which calls `super()` with no arguments!). We know of one case
+ *    where this occurs: Solid's "possible infinite loop" (i.e. cycle)
+ *    detection, when Solid is bundled for production. Being a default behavior,
+ *    unfortunately we cannot be confident that this is the cause. In the
+ *    future, we may consider inspecting {@link Error.stack} for such purposes.
+ *
+ * 4. Promise is rejected by any upstream external dependency of either
+ *    `@getodk/xforms-engine` or `@getodk/xpath`, or by platform API calls.
+ *    These are much more difficult to model, document, or encode in the type
+ *    system. We will likely make some meaningful effort on this front as well,
+ *    but we accept it will never be exhaustive. Most importantly, we cannot
+ *    truly know what types may be thrown (and then passed through as a
+ *    {@link Promise} rejection by {@link initializeForm}).
+ *
+ * As such where the type of {@link cause} is...
+ *
+ * - {@link Error}: we capture its minimal known details: message and stack.
+ *   Additionally, if its message is a blank string, we fall back to
+ *   {@link UNKNOWN_ERROR_MESSAGE}.
+ *
+ * - any other object with an {@link ErrorLikeCause} shape: we handle the object
+ *   as if it were an instance of {@link Error}.
+ *
+ * - string: we capture that string as if it were an error message.
+ *
+ * - any other value: we treat the cause as an unknown error, with a message of
+ *   {@link UNKNOWN_ERROR_MESSAGE}. Additionally, if the value can be serialized
+ *   by {@link JSON.stringify}, we assign that serialization to
+ *   {@link unknownCauseDetail}, in hopes it will provide further clarification
+ *   of unknown failure conditions.
+ */
+export class InitializeFormFailure extends Error {
+	readonly unknownCauseDetail: string | null;
+	readonly stack?: string | undefined;
+
+	constructor(readonly cause: unknown) {
+		let message: string;
+		let unknownCauseDetail: string | null = null;
+		let stack: string | null = null;
+
+		// If `initializeForm` rejected with an error, we can derive its message and stack
+		if (cause instanceof Error || isErrorLikeCause(cause)) {
+			message = cause.message;
+			stack = cause.stack ?? null;
+		} else if (isUnknownObject(cause) && typeof cause.message === 'string') {
+			message = cause.message;
+		} else if (typeof cause === 'string') {
+			message = cause;
+		} else {
+			message = 'Unknown error';
+
+			try {
+				unknownCauseDetail = JSON.stringify(cause, null, 2);
+			} catch {
+				// Ignore JSON serialization error
+			}
+		}
+
+		// TODO: this occurs when Solid's production build detects a "potential
+		// infinite loop" (i.e. either a form cycle, or potentially a serious bug in
+		// the engine!).
+		if (message === '') {
+			message = 'Unknown error';
+		}
+
+		super(message, { cause });
+
+		this.unknownCauseDetail = unknownCauseDetail;
+
+		if (stack != null) {
+			this.stack = stack;
+		}
+	}
+}

--- a/packages/web-forms/tests/components/OdkWebForm.test.ts
+++ b/packages/web-forms/tests/components/OdkWebForm.test.ts
@@ -142,7 +142,10 @@ describe('OdkWebForm', () => {
 			const formLoadFailureDialog = component.get('.form-load-failure-dialog');
 
 			expect(formLoadFailureDialog.isVisible()).toBe(true);
-			expect(formLoadFailureDialog.text()).toMatch(/\bnope\b/);
+
+			const message = formLoadFailureDialog.get('.message');
+
+			expect(message.text()).toMatch(/\bnope\b/);
 		});
 	});
 });

--- a/packages/web-forms/tests/components/OdkWebForm.test.ts
+++ b/packages/web-forms/tests/components/OdkWebForm.test.ts
@@ -3,17 +3,16 @@ import { flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	getFormXml,
+	getWebFormsTestFixture,
 	globalMountOptions,
 	mockElementPrototypeMethod,
 	type ElementMethodName,
 } from '../helpers';
 
-const mountComponent = async () => {
-	const xform = await getFormXml('2-simple-required.xml');
-
+const mountComponent = (formXML: string) => {
 	const component = mount(OdkWebForm, {
 		props: {
-			formXml: xform,
+			formXml: formXML,
 		},
 		global: globalMountOptions,
 		attachTo: document.body,
@@ -23,9 +22,12 @@ const mountComponent = async () => {
 };
 
 describe('OdkWebForm', () => {
+	let formXML: string;
 	let elementKeysAdded: ElementMethodName[];
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		formXML = await getFormXml('2-simple-required.xml');
+
 		elementKeysAdded = [];
 		mockElementPrototypeMethod('scrollTo', () => {
 			/* Do nothing */
@@ -46,7 +48,7 @@ describe('OdkWebForm', () => {
 	});
 
 	it('shows validation banner and highlights on submit and hide once valid value(s) are set', async () => {
-		const component = await mountComponent();
+		const component = mountComponent(formXML);
 		await flushPromises();
 
 		// Assert no validation banner and no highlighted question
@@ -69,7 +71,7 @@ describe('OdkWebForm', () => {
 	});
 
 	it('shows validation banner and highlights again if any question becomes invalid again', async () => {
-		const component = await mountComponent();
+		const component = mountComponent(formXML);
 		await flushPromises();
 
 		// Assert no validation banner and no highlighted question
@@ -96,5 +98,51 @@ describe('OdkWebForm', () => {
 		// Assert validation banner is visible and question container is highlighted again
 		expect(component.get('.form-error-message').isVisible()).toBe(true);
 		expect(component.get('.question-container').classes().includes('highlight')).toBe(true);
+	});
+
+	describe('form load failure', () => {
+		// TODO: this test uses a fixture which currently causes engine-internal
+		// reactivity (Solid) to produce a "potential infinite loop" error.
+		// Triggering this error is slow: detection uses a heuristic of a hard limit
+		// on the reactive call stack depth. When we reintroduce cycle detection in
+		// the future, we will probably want to remove this timeout option!
+		it(
+			'presents an error message when failing to load a form with a cyclic computation',
+			{ timeout: 5000 },
+			async () => {
+				const dagCycleFormXML = await getWebFormsTestFixture('simple-dag-cycle.xml');
+				const component = mountComponent(dagCycleFormXML);
+
+				await flushPromises();
+
+				expect(component.get('.form-load-failure-dialog').isVisible()).toBe(true);
+			}
+		);
+
+		it('presents an error message when failing to load a form with a computation containing an XPath syntax error', async () => {
+			const xpathSyntaxErrorFormXML = await getWebFormsTestFixture('xpath-syntax-error.xml');
+			const component = mountComponent(xpathSyntaxErrorFormXML);
+
+			await flushPromises();
+
+			expect(component.get('.form-load-failure-dialog').isVisible()).toBe(true);
+		});
+
+		// TODO: tests failure which is currently produced by throwing a string.
+		// Checking the text content here is intended to ensure we are actually
+		// presenting the message to a user.
+		it('presents an error message when failing to load a form with a computation referencing an unknown XPath function', async () => {
+			const xpathUnknownFunctionFormXML = await getWebFormsTestFixture(
+				'xpath-unknown-function.xml'
+			);
+			const component = mountComponent(xpathUnknownFunctionFormXML);
+
+			await flushPromises();
+
+			const formLoadFailureDialog = component.get('.form-load-failure-dialog');
+
+			expect(formLoadFailureDialog.isVisible()).toBe(true);
+			expect(formLoadFailureDialog.text()).toMatch(/\bnope\b/);
+		});
 	});
 });

--- a/packages/web-forms/tests/helpers.ts
+++ b/packages/web-forms/tests/helpers.ts
@@ -8,6 +8,31 @@ import type { MockInstance } from 'vitest';
 import { vi } from 'vitest';
 import { reactive } from 'vue';
 
+/**
+ * @todo this does roughly the same thing as {@link getFormXml}, except it
+ * conveys a clearer intent that the fixture being loaded is specifically
+ * associated with one or more `@getodk/web-forms` tests. However, it's worth
+ * considering whether it would be more useful to reference such fixtures by
+ * `import`, e.g.:
+ *
+ * ```ts
+ * import(`@getodk/common/fixtures/test-web-forms/${identifier}?raw`);
+ * ```
+ *
+ * Even more useful might be to wrap such directly referenced fixtures in a
+ * basic `.ts` module, so such imports can actually be statically analyzed like
+ * any other real module import.
+ */
+export const getWebFormsTestFixture = (identifier: string): Promise<string> => {
+	const fixture = xformFixturesByIdentifier.get(identifier);
+
+	if (fixture?.category !== 'test-web-forms') {
+		throw new Error(`Could not find web-forms test fixture with identifier: ${identifier}`);
+	}
+
+	return fixture.loadXML();
+};
+
 export const getFormXml = (fileName: string): Promise<string> => {
 	const fixture = xformFixturesByIdentifier.get(fileName);
 

--- a/packages/web-forms/tsconfig.vitest.json
+++ b/packages/web-forms/tsconfig.vitest.json
@@ -8,7 +8,8 @@
     "tests",
     "tests-examples",
     "src/components/**/*.vue",
-    "src/directives/**/*.ts"
+    "src/directives/**/*.ts",
+    "src/lib/**/*.ts"
   ],
   "exclude": ["../common/src/test/**/*.ts"],
   "compilerOptions": {

--- a/packages/xforms-engine/package.json
+++ b/packages/xforms-engine/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@getodk/tree-sitter-xpath": "0.1.2",
-    "@getodk/xpath": "0.2.0",
+    "@getodk/xpath": "0.2.1",
     "@playwright/test": "^1.47.2",
     "@vitest/browser": "^2.1.1",
     "babel-plugin-transform-jsbi-to-bigint": "^1.4.0",

--- a/packages/xpath/CHANGELOG.md
+++ b/packages/xpath/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @getodk/xpath
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [27c440d]
+  - @getodk/common@0.4.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/xpath/package.json
+++ b/packages/xpath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/xpath",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "description": "XPath implementation for ODK Web Forms",
   "type": "module",
@@ -52,7 +52,7 @@
     "test:types": "tsc --project ./tsconfig.json --emitDeclarationOnly false --noEmit"
   },
   "dependencies": {
-    "@getodk/common": "0.3.0",
+    "@getodk/common": "0.4.0",
     "@js-temporal/polyfill": "^0.4.4",
     "crypto-js": "^4.2.0",
     "itertools-ts": "^1.27.1"


### PR DESCRIPTION
## I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [x] Safari (iOS)
- [ ] Not applicable

## What else has been done to verify that this works as intended?

A few tests. I think we'll want to expand testing in this area significantly, probably at different levels of the stack.

## Why is this the best possible solution? Were any other approaches considered?

It's approximately the quickest solution, which was the priority for now. There are known areas for improvement, discussed under **What's changed** below.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

If users previously depended on getting no information whatsoever when a form fails to load, this will break that workflow.

## Do we need any specific form for testing your changes? If so, please attach one.

Added a few fixtures, each demonstrating a known failure case.

## What's changed

Here, a “form load failure” is any `Promise` rejection produced by the engine’s `initializeForm` entrypoint. This is intentionally broad, and what I think is a relatively minimal first pass that might be useful to users (and to us).

“Relatively” minimal because I took the opportunity to lay a bit of groundwork for a few things either cued for near term work, or ripe for near term improvement.

Notable among those:

- Establish a more intentional approach to use of test fixtures in the `web-forms` package. This includes a dedicated fixtures directory (alongside those already used by `scenario`), and a narrower “test helper” (ugh) to access those. That access point also includes some additional breadcrumbs for ways we might improve fixture access in the future.

- `FormLoadFailure` begins laying a bit of groundwork for the incoming, much more comprehensive overhaul of error messaging.

- Actually tests a few different form load failure conditions. I believe these will be useful for catching potential regressions in that overhaul, as well in other future work around those specific failure modes.

### UI/UX/presentation design note

I had a brief discussion with @alyblenkin about this being a minimal first step. We agreed that this seems like a reasonable first pass, and agreed there’s more to do in near-future iterations. Some of the things which are currently lacking from a UX perspective, blocked by work with a larger scope:

- Better messaging of specific errors. We’ll be cataloguing known cases as part of #202, which will give us a much clearer picture of how to address this.
- Any kind of direct prompt for user action. Deferred for the same reasons.
- Ability to close the dialog or go back. Deferred because this would expand scope to navigation more generally, which we should look at more holistically.
