### PR TITLE
Support for external secondary instances

### DIFF
--- a/.changeset/seven-eels-drop.md
+++ b/.changeset/seven-eels-drop.md
@@ -1,0 +1,8 @@
+---
+'@getodk/xforms-engine': minor
+'@getodk/web-forms': minor
+'@getodk/scenario': minor
+'@getodk/common': minor
+---
+
+Support for external secondary instances (XML, CSV, GeoJSON)

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/eslint": "^9.6.1",
     "@types/eslint-config-prettier": "^6.11.3",
     "@types/eslint__js": "^8.42.3",
+    "@types/geojson": "^7946.0.14",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.7.2",
     "@typescript-eslint/eslint-plugin": "^8.7.0",

--- a/packages/common/src/fixtures/import-glob-helper.ts
+++ b/packages/common/src/fixtures/import-glob-helper.ts
@@ -1,0 +1,60 @@
+import { IS_NODE_RUNTIME } from '../env/detection.ts';
+
+interface GlobURLFetchResponse {
+	text(): Promise<string>;
+}
+
+type Awaitable<T> = Promise<T> | T;
+
+type FetchGlobURL = (globURL: string) => Awaitable<GlobURLFetchResponse>;
+
+let fetchGlobURL: FetchGlobURL;
+
+if (IS_NODE_RUNTIME) {
+	const { readFile } = await import('node:fs/promises');
+
+	class NodeGlobURLFetchResponse {
+		readonly fsPath: string;
+
+		constructor(globURL: string) {
+			this.fsPath = globURL.replace('/@fs/', '/');
+		}
+
+		text(): Promise<string> {
+			return readFile(this.fsPath, 'utf-8');
+		}
+	}
+
+	fetchGlobURL = (globURL) => {
+		return new NodeGlobURLFetchResponse(globURL);
+	};
+} else {
+	fetchGlobURL = fetch;
+}
+
+type ImportMetaGlobURLRecord = Readonly<Record<string, string>>;
+
+export type ImportMetaGlobLoader = (this: void) => Promise<string>;
+
+export type GlobLoaderEntry = readonly [absolutePath: string, loader: ImportMetaGlobLoader];
+
+const globLoader = (globURL: string): ImportMetaGlobLoader => {
+	return async () => {
+		const response = await fetchGlobURL(globURL);
+
+		return response.text();
+	};
+};
+
+export const toGlobLoaderEntries = (
+	importMeta: ImportMeta,
+	globObject: ImportMetaGlobURLRecord
+): readonly GlobLoaderEntry[] => {
+	const parentPathURL = new URL('./', importMeta.url);
+
+	return Object.entries(globObject).map(([relativePath, value]) => {
+		const { pathname: absolutePath } = new URL(relativePath, parentPathURL);
+
+		return [absolutePath, globLoader(value)];
+	});
+};

--- a/packages/common/src/fixtures/test-scenario/csv-attachment.csv
+++ b/packages/common/src/fixtures/test-scenario/csv-attachment.csv
@@ -1,0 +1,3 @@
+item-label,item-value
+Y,y
+Z,z

--- a/packages/common/src/fixtures/test-scenario/xml-attachment.xml
+++ b/packages/common/src/fixtures/test-scenario/xml-attachment.xml
@@ -1,0 +1,10 @@
+<instance-root>
+  <instance-item>
+    <item-label>A</item-label>
+    <item-value>a</item-value>
+  </instance-item>
+  <instance-item>
+    <item-label>B</item-label>
+    <item-value>b</item-value>
+  </instance-item>
+</instance-root>

--- a/packages/common/src/fixtures/xform-attachments.ts
+++ b/packages/common/src/fixtures/xform-attachments.ts
@@ -1,0 +1,137 @@
+import { UpsertableMap } from '../lib/collections/UpsertableMap.ts';
+import { UnreachableError } from '../lib/error/UnreachableError.ts';
+import type { ImportMetaGlobLoader } from './import-glob-helper.ts';
+import { toGlobLoaderEntries } from './import-glob-helper.ts';
+
+/**
+ * @todo Support Windows paths?
+ */
+const getFileName = (absolutePath: string): string => {
+	const fileName = absolutePath.split('/').at(-1);
+
+	if (fileName == null) {
+		throw new Error(`Failed to get file name for file system path: ${absolutePath}`);
+	}
+
+	return fileName;
+};
+
+// prettier-ignore
+const xformAttachmentFileExtensions = [
+	'.csv',
+	'.geojson',
+	'.xml',
+	'.xml.example',
+	'.xlsx',
+] as const;
+
+type XFormAttachmentFileExtensions = typeof xformAttachmentFileExtensions;
+type XFormAttachmentFileExtension = XFormAttachmentFileExtensions[number];
+
+const getFileExtension = (absolutePath: string): XFormAttachmentFileExtension => {
+	for (const extension of xformAttachmentFileExtensions) {
+		if (absolutePath.endsWith(extension)) {
+			return extension;
+		}
+	}
+
+	throw new Error(`Unknown file extension for file name: ${getFileName(absolutePath)}`);
+};
+
+const getParentDirectory = (absolutePath: string): string => {
+	const fileName = getFileName(absolutePath);
+
+	return absolutePath.slice(0, absolutePath.length - fileName.length - 1);
+};
+
+const xformAttachmentFixtureLoaderEntries = toGlobLoaderEntries(
+	import.meta,
+	import.meta.glob<true, 'url', string>('./*/**/*', {
+		query: '?url',
+		import: 'default',
+		eager: true,
+	})
+);
+
+export class XFormAttachmentFixture {
+	readonly fileName: string;
+	readonly fileExtension: string;
+	readonly mimeType: string;
+
+	constructor(
+		readonly absolutePath: string,
+		readonly load: ImportMetaGlobLoader
+	) {
+		const fileName = getFileName(absolutePath);
+		const fileExtension = getFileExtension(fileName);
+
+		this.fileName = fileName;
+		this.fileExtension = fileExtension;
+
+		switch (fileExtension) {
+			case '.csv':
+				this.mimeType = 'text/csv';
+				break;
+
+			case '.geojson':
+				this.mimeType = 'application/geo+json';
+				break;
+
+			case '.xml':
+			case '.xml.example':
+				this.mimeType = 'text/xml';
+				break;
+
+			case '.xlsx':
+				this.mimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+				break;
+
+			default:
+				throw new UnreachableError(fileExtension);
+		}
+	}
+}
+
+type XFormAttachmentFixtureEntry = readonly [absolutePath: string, fixture: XFormAttachmentFixture];
+
+type XFormAttachmentFixtureEntries = readonly XFormAttachmentFixtureEntry[];
+
+const xformAttachmentFixtureEntries: XFormAttachmentFixtureEntries =
+	xformAttachmentFixtureLoaderEntries.map(([absolutePath, load]) => {
+		const fixture = new XFormAttachmentFixture(absolutePath, load);
+
+		return [absolutePath, fixture];
+	});
+
+type XFormAttachmentFixturesByAbsolutePath = ReadonlyMap<string, XFormAttachmentFixture>;
+
+const buildXFormAttachmentFixturesByAbsolutePath = (
+	entries: XFormAttachmentFixtureEntries
+): XFormAttachmentFixturesByAbsolutePath => {
+	return new Map(entries);
+};
+
+export const xformAttachmentFixturesByPath = buildXFormAttachmentFixturesByAbsolutePath(
+	xformAttachmentFixtureEntries
+);
+
+type XFormAttachmentFixturesByDirectory = ReadonlyMap<string, readonly XFormAttachmentFixture[]>;
+
+const buildXFormAttachmentFixturesByDirectory = (
+	entries: XFormAttachmentFixtureEntries
+): XFormAttachmentFixturesByDirectory => {
+	const result = new UpsertableMap<string, XFormAttachmentFixture[]>();
+
+	for (const [absolutePath, fixture] of entries) {
+		const parentDirectory = getParentDirectory(absolutePath);
+		const subset = result.upsert(parentDirectory, () => []);
+
+		subset.push(fixture);
+	}
+
+	return result;
+};
+
+export const xformAttachmentFixturesByDirectory = buildXFormAttachmentFixturesByDirectory(
+	xformAttachmentFixtureEntries
+);

--- a/packages/common/src/fixtures/xforms.ts
+++ b/packages/common/src/fixtures/xforms.ts
@@ -1,24 +1,40 @@
+import { JRResourceService } from '../jr-resources/JRResourceService.ts';
+import type { JRResourceURL } from '../jr-resources/JRResourceURL.ts';
 import { UpsertableMap } from '../lib/collections/UpsertableMap.ts';
 import { toGlobLoaderEntries } from './import-glob-helper.ts';
 
 type XFormResourceType = 'local' | 'remote';
 
+type ResourceServiceFactory = () => JRResourceService;
+
 interface BaseXFormResourceOptions {
 	readonly localPath: string | null;
 	readonly identifier: string | null;
 	readonly category: string | null;
+	readonly initializeFormAttachmentService?: ResourceServiceFactory;
 }
 
 interface LocalXFormResourceOptions extends BaseXFormResourceOptions {
 	readonly localPath: string;
 	readonly identifier: string;
 	readonly category: string;
+	readonly initializeFormAttachmentService: ResourceServiceFactory;
 }
 
 interface RemoteXFormResourceOptions extends BaseXFormResourceOptions {
 	readonly category: string | null;
 	readonly localPath: null;
 	readonly identifier: string;
+
+	/**
+	 * @todo Note that {@link RemoteXFormResourceOptions} corresponds to an API
+	 * primarily serving
+	 * {@link https://getodk.org/web-forms-preview/ | Web Forms Preview}
+	 * functionality. In theory, we could allow a mechanism to support form
+	 * attachments in for that use case, but we'd need to design for it. Until
+	 * then, it doesn't make a whole lot of sense to accept arbitrary IO here.
+	 */
+	readonly initializeFormAttachmentService?: never;
 }
 
 type XFormResourceOptions<Type extends XFormResourceType> = {
@@ -71,6 +87,10 @@ const xformURLLoader = (url: URL): LoadXFormXML => {
 	};
 };
 
+const getNoopResourceService: ResourceServiceFactory = () => {
+	return new JRResourceService();
+};
+
 export class XFormResource<Type extends XFormResourceType> {
 	static forLocalFixture(
 		localPath: string,
@@ -81,6 +101,14 @@ export class XFormResource<Type extends XFormResourceType> {
 			category: localFixtureDirectoryCategory(localPath),
 			localPath,
 			identifier: pathToFileName(localPath),
+			initializeFormAttachmentService: () => {
+				const service = new JRResourceService();
+				const parentPath = localPath.replace(/\/[^/]+$/, '');
+
+				service.activateFixtures(parentPath, ['file', 'file-csv']);
+
+				return service;
+			},
 		});
 	}
 
@@ -92,6 +120,8 @@ export class XFormResource<Type extends XFormResourceType> {
 		const loadXML = xformURLLoader(resourceURL);
 
 		return new XFormResource('remote', resourceURL, loadXML, {
+			...options,
+
 			category: options?.category ?? 'other',
 			identifier: options?.identifier ?? extractURLIdentifier(resourceURL),
 			localPath: options?.localPath ?? null,
@@ -101,6 +131,7 @@ export class XFormResource<Type extends XFormResourceType> {
 	readonly category: string;
 	readonly localPath: XFormResourceOptions<Type>['localPath'];
 	readonly identifier: XFormResourceOptions<Type>['identifier'];
+	readonly fetchFormAttachment: (url: JRResourceURL) => Promise<Response>;
 
 	private constructor(
 		readonly resourceType: Type,
@@ -111,6 +142,17 @@ export class XFormResource<Type extends XFormResourceType> {
 		this.category = options.category ?? 'other';
 		this.localPath = options.localPath;
 		this.identifier = options.identifier;
+
+		const initializeFormAttachmentService =
+			options.initializeFormAttachmentService ?? getNoopResourceService;
+
+		let resourceService: JRResourceService | null = null;
+
+		this.fetchFormAttachment = (url) => {
+			resourceService = resourceService ?? initializeFormAttachmentService();
+
+			return resourceService.handleRequest(url);
+		};
 	}
 }
 

--- a/packages/common/src/jr-resources/JRResource.ts
+++ b/packages/common/src/jr-resources/JRResource.ts
@@ -1,0 +1,39 @@
+import type { XFormAttachmentFixture } from '../fixtures/xform-attachments.ts';
+import { JRResourceURL } from './JRResourceURL.ts';
+
+type JRResourceLoader = (this: void) => Promise<string>;
+
+export interface JRResourceSource {
+	readonly url: JRResourceURL;
+	readonly fileName: string;
+	readonly mimeType: string;
+	readonly load: JRResourceLoader;
+}
+
+export class JRResource {
+	static fromFormAttachmentFixture(category: string, fixture: XFormAttachmentFixture): JRResource {
+		const { fileName, mimeType, load } = fixture;
+		const url = JRResourceURL.create(category, fileName);
+
+		return new JRResource({
+			url,
+			fileName,
+			mimeType,
+			load,
+		});
+	}
+
+	readonly url: JRResourceURL;
+	readonly fileName: string;
+	readonly mimeType: string;
+	readonly load: JRResourceLoader;
+
+	constructor(source: JRResourceSource) {
+		const { url, fileName, mimeType, load } = source;
+
+		this.url = url;
+		this.fileName = fileName;
+		this.mimeType = mimeType;
+		this.load = load;
+	}
+}

--- a/packages/common/src/jr-resources/JRResourceService.ts
+++ b/packages/common/src/jr-resources/JRResourceService.ts
@@ -1,0 +1,108 @@
+import { xformAttachmentFixturesByDirectory } from '../fixtures/xform-attachments.ts';
+import { JRResource } from './JRResource.ts';
+import type { JRResourceURLString } from './JRResourceURL.ts';
+import { JRResourceURL } from './JRResourceURL.ts';
+
+export interface InlineFixtureMetadata {
+	readonly url: JRResourceURLString;
+	readonly fileName: string;
+	readonly mimeType: string;
+}
+
+class JRResourceServiceRegistry extends Map<JRResourceURLString, JRResource> {}
+
+interface ActivateFixturesOptions {
+	readonly suppressMissingFixturesDirectoryWarning?: boolean;
+}
+
+export class JRResourceService {
+	readonly resources = new JRResourceServiceRegistry();
+
+	readonly handleRequest = async (url: JRResourceURL | JRResourceURLString): Promise<Response> => {
+		let resourceKey: JRResourceURLString;
+
+		if (typeof url === 'string') {
+			resourceKey = url;
+		} else {
+			resourceKey = url.href;
+		}
+
+		const resource = this.resources.get(resourceKey);
+
+		if (resource == null) {
+			return new Response('Not found', {
+				status: 404,
+				headers: { 'Content-Type': 'text/plain' },
+			});
+		}
+
+		const { load, mimeType } = resource;
+		const body = await load();
+
+		return new Response(body, {
+			status: 200,
+			headers: { 'Content-Type': mimeType },
+		});
+	};
+
+	private setRegisteredResourceState(resource: JRResource) {
+		const url = resource.url.href;
+
+		if (this.resources.has(url)) {
+			throw new Error(`Resource already registered for URL: ${url}`);
+		}
+
+		this.resources.set(url, resource);
+	}
+
+	activateFixtures(
+		fixtureDirectory: string,
+		categories: readonly string[],
+		options?: ActivateFixturesOptions
+	): void {
+		this.reset();
+
+		try {
+			for (const category of categories) {
+				const fixtures = xformAttachmentFixturesByDirectory.get(fixtureDirectory);
+
+				if (fixtures == null) {
+					if (options?.suppressMissingFixturesDirectoryWarning !== true) {
+						// eslint-disable-next-line no-console
+						console.warn(`No form attachments in directory: ${fixtureDirectory}`);
+					}
+
+					continue;
+				}
+
+				for (const fixture of fixtures) {
+					const resource = JRResource.fromFormAttachmentFixture(category, fixture);
+
+					this.setRegisteredResourceState(resource);
+				}
+			}
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.error('Error occurred during resource state setup:', error);
+
+			this.reset();
+		}
+	}
+
+	activateResource(metadata: InlineFixtureMetadata, data: string): void {
+		const url = JRResourceURL.from(metadata.url);
+		const load = () => Promise.resolve(data);
+		const resource = new JRResource({
+			url,
+			fileName: metadata.fileName,
+			mimeType: metadata.mimeType,
+			load,
+		});
+
+		this.setRegisteredResourceState(resource);
+	}
+
+	reset(): void {
+		this.resources.clear();
+	}
+}

--- a/packages/common/src/jr-resources/JRResourceURL.ts
+++ b/packages/common/src/jr-resources/JRResourceURL.ts
@@ -30,7 +30,7 @@ export class JRResourceURL extends URL {
 	}
 
 	static isJRResourceReference(reference: string | null): reference is JRResourceURLString {
-		return reference?.startsWith('jr:') ?? false;
+		return reference?.startsWith(JR_RESOURCE_URL_PROTOCOL) ?? false;
 	}
 
 	declare readonly protocol: JRResourceURLProtocol;

--- a/packages/common/src/jr-resources/JRResourceURL.ts
+++ b/packages/common/src/jr-resources/JRResourceURL.ts
@@ -1,0 +1,46 @@
+const JR_RESOURCE_URL_PROTOCOL = 'jr:';
+type JRResourceURLProtocol = typeof JR_RESOURCE_URL_PROTOCOL;
+
+export type JRResourceURLString = `${JRResourceURLProtocol}${string}`;
+
+interface ValidatedJRResourceURL extends URL {
+	readonly protocol: JRResourceURLProtocol;
+	readonly href: JRResourceURLString;
+}
+
+type ValidateJRResourceURL = (url: URL) => asserts url is ValidatedJRResourceURL;
+
+const validateJRResourceURL: ValidateJRResourceURL = (url) => {
+	if (import.meta.env.DEV) {
+		const { protocol, href } = url;
+
+		if (protocol !== JR_RESOURCE_URL_PROTOCOL || !href.startsWith(JR_RESOURCE_URL_PROTOCOL)) {
+			throw new Error(`Invalid JRResoruceURL: ${url}`);
+		}
+	}
+};
+
+export class JRResourceURL extends URL {
+	static create(category: string, fileName: string): JRResourceURL {
+		return new this(`jr://${category}/${fileName}`);
+	}
+
+	static from(url: JRResourceURLString): JRResourceURL {
+		return new this(url);
+	}
+
+	static isJRResourceReference(reference: string | null): reference is JRResourceURLString {
+		return reference?.startsWith('jr:') ?? false;
+	}
+
+	declare readonly protocol: JRResourceURLProtocol;
+	declare readonly href: JRResourceURLString;
+
+	private constructor(url: JRResourceURL);
+	private constructor(url: JRResourceURLString);
+	private constructor(url: URL | string) {
+		super(url);
+
+		validateJRResourceURL(this);
+	}
+}

--- a/packages/common/src/lib/type-assertions/assertUnknownObject.ts
+++ b/packages/common/src/lib/type-assertions/assertUnknownObject.ts
@@ -1,4 +1,4 @@
-type UnknownObject = Record<PropertyKey, unknown>;
+export type UnknownObject = Record<PropertyKey, unknown>;
 
 type AssertUnknownObject = (value: unknown) => asserts value is UnknownObject;
 

--- a/packages/scenario/src/client/init.ts
+++ b/packages/scenario/src/client/init.ts
@@ -9,6 +9,7 @@ import type {
 import { initializeForm } from '@getodk/xforms-engine';
 import type { Owner } from 'solid-js';
 import { createRoot, getOwner, runWithOwner } from 'solid-js';
+import type { MissingResourceBehavior } from '../../../xforms-engine/dist/client/constants';
 import { FormDefinitionResource } from '../jr/resource/FormDefinitionResource.ts';
 
 /**
@@ -55,6 +56,7 @@ const fetchResourceStub: typeof fetch = () => {
 
 export interface InitializeTestFormOptions {
 	readonly resourceService: JRResourceService;
+	readonly missingResourceBehavior: MissingResourceBehavior;
 	readonly stateFactory: OpaqueReactiveObjectFactory;
 }
 
@@ -85,6 +87,7 @@ export const initializeTestForm = async (
 				config: {
 					...defaultConfig,
 					fetchFormAttachment: options.resourceService.handleRequest,
+					missingResourceBehavior: options.missingResourceBehavior,
 					stateFactory: options.stateFactory,
 				},
 			});

--- a/packages/scenario/src/client/init.ts
+++ b/packages/scenario/src/client/init.ts
@@ -1,3 +1,4 @@
+import type { JRResourceService } from '@getodk/common/jr-resources/JRResourceService.ts';
 import type { XFormsElement } from '@getodk/common/test/fixtures/xform-dsl/XFormsElement.ts';
 import type {
 	EngineConfig,
@@ -53,6 +54,7 @@ const fetchResourceStub: typeof fetch = () => {
 };
 
 export interface InitializeTestFormOptions {
+	readonly resourceService: JRResourceService;
 	readonly stateFactory: OpaqueReactiveObjectFactory;
 }
 
@@ -82,6 +84,7 @@ export const initializeTestForm = async (
 			return initializeForm(formResource, {
 				config: {
 					...defaultConfig,
+					fetchFormAttachment: options.resourceService.handleRequest,
 					stateFactory: options.stateFactory,
 				},
 			});

--- a/packages/scenario/src/client/init.ts
+++ b/packages/scenario/src/client/init.ts
@@ -50,8 +50,8 @@ export const getFormResource = async (
  * @todo Currently we stub resource fetching. We can address this as needed
  * while we port existing tests and/or add new ones which require it.
  */
-const fetchResourceStub: typeof fetch = () => {
-	throw new Error('TODO: resource fetching not implemented');
+const fetchFormDefinitionStub: typeof fetch = () => {
+	throw new Error('TODO: fetching form definition not implemented');
 };
 
 export interface InitializeTestFormOptions {
@@ -61,7 +61,7 @@ export interface InitializeTestFormOptions {
 }
 
 const defaultConfig = {
-	fetchResource: fetchResourceStub,
+	fetchFormDefinition: fetchFormDefinitionStub,
 } as const satisfies Omit<EngineConfig, 'stateFactory'>;
 
 interface InitializedTestForm {

--- a/packages/scenario/src/jr/Scenario.ts
+++ b/packages/scenario/src/jr/Scenario.ts
@@ -11,6 +11,7 @@ import type {
 	SubmissionOptions,
 	SubmissionResult,
 } from '@getodk/xforms-engine';
+import { constants as ENGINE_CONSTANTS } from '@getodk/xforms-engine';
 import type { Accessor, Setter } from 'solid-js';
 import { createMemo, createSignal, runWithOwner } from 'solid-js';
 import { afterEach, expect } from 'vitest';
@@ -156,6 +157,9 @@ export class Scenario {
 	): InitializeTestFormOptions {
 		return {
 			resourceService: overrideOptions?.resourceService ?? SharedJRResourceService.init(),
+			missingResourceBehavior:
+				overrideOptions?.missingResourceBehavior ??
+				ENGINE_CONSTANTS.MISSING_RESOURCE_BEHAVIOR.DEFAULT,
 			stateFactory: overrideOptions?.stateFactory ?? nonReactiveIdentityStateFactory,
 		};
 	}

--- a/packages/scenario/src/jr/reference/ReferenceManagerTestUtils.ts
+++ b/packages/scenario/src/jr/reference/ReferenceManagerTestUtils.ts
@@ -1,67 +1,39 @@
-import type { EngineConfig, InitializeFormOptions } from '@getodk/xforms-engine';
-import { afterEach, beforeEach } from 'vitest';
 import type { JavaNIOPath } from '../../java/nio/Path.ts';
-import type { TextFileResourcePath } from '../file/TextFileResourcePath.ts';
-
-/**
- * @todo This is incomplete! It was intended to add preliminary support for
- * resource loading consistent with setup in ported JavaRosa tests. Since we
- * don't yet have any non-form resource loading logic, we'd have no way of
- * exercising the actual functionality. As such, this is currently a sketch of
- * what a basis for that might look like in terms of JavaRosa interface
- * compatibility, test-scoped setup and teardown. When it does become relevant,
- * it will likely intersect with {@link TextFileResourcePath} (or some other
- * similar interface to resource fixtures) to service the pertinent resources as
- * the engine requests them (via {@link EngineConfig}'s `fetchResource` option).
- */
-class ResourceManager {
-	constructor(
-		readonly path: JavaNIOPath,
-		readonly jrResourceBasePaths: readonly string[]
-	) {}
-}
-
-let resourceManagers: ResourceManager[] = [];
-
-beforeEach(() => {
-	resourceManagers = [];
-});
-
-afterEach(() => {
-	resourceManagers = [];
-});
+import { SharedJRResourceService } from '../../resources/SharedJRResourceService.ts';
 
 /**
  * **PORTING NOTES**
  *
- * The name {@link schemes} has been preserved in the signature of this function
- * (corresponding to JavaRosa's static method of the same name). It somewhat
- * unintuitively **does not** refer to a URL scheme (i.e. `jr:`), but rather the
- * first path segment in a `jr:` resource template URL. For instance, if a form
- * references a file resource `jr://file/external-data.geojson`, a test may set
- * up access to that resource by calling this function and specifying `"files"`
- * as a "scheme".
+ * This signature is preserved as a reference to the equivalent JavaRosa test
+ * setup interface. Some time was spent tracing the actual setup behavior, and
+ * it was determined (and since confirmed) that ultimately for test purposes the
+ * intent is to register a set of file system paths which are available for
+ * resolving fixtures and fixture resources.
  *
- * - - -
+ * As such, the actual behavior when calling this function produces the
+ * following minimal equivalent behavior:
  *
- * Exposed as a plain function; addresses pertinent aspects of the semantic
- * intent of JavaRosa's same-named static method on the
- * `ReferenceManagerTestUtils` class.
+ * 1. When called, any state produced by a prior call is reset.
+ * 2. The string representation of {@link path} establishes a common base file
+ *    system path for all state produced by the current call.
+ * 3. For each value in {@link schemes} (naming preserved from JavaRosa), a file
+ *    system path is produced by concatenating that as a subdirectory of that
+ *    common base path.
+ * 4. Any logic in the active running test will serve fixture resources from the
+ *    set of file system paths produced by the above steps.
  *
- * Significant divergences:
- *
- * 1. Returns `void`, where JavaRosa's equivalent returns a `ReferenceManager`
- *    (which, per @lognaturel, "nobody likes [...] Don't look :smile:"). This
- *    appears to be safe for now, as there are no current references to its
- *    return value.
- *
- * 2. While also implicitly stateful, the intent is to keep that state scoped as
- *    clearly as possible to a given test (its state being tracked and cleaned
- *    up in an `afterEach` controlled locally in this module as well), and as
- *    minimal as possible to set up the web forms engine's closest semantic
- *    equivalent (the configuration of `config.fetchResource` in
- *    {@link InitializeFormOptions}).
+ * **Implicitly**, the same state is cleared before and after each test, to
+ * avoid establishing shared state between tests which might cause them to
+ * become dependent on ordering of test runs.
  */
 export const setUpSimpleReferenceManager = (path: JavaNIOPath, ...schemes: string[]): void => {
-	resourceManagers.push(new ResourceManager(path, schemes));
+	const service = SharedJRResourceService.init();
+
+	service.activateFixtures(path.toAbsolutePath().toString(), schemes, {
+		get suppressMissingFixturesDirectoryWarning(): boolean {
+			const stack = new Error().stack;
+
+			return stack?.includes('configureReferenceManagerIncorrectly') ?? false;
+		},
+	});
 };

--- a/packages/scenario/src/reactive/ReactiveScenario.ts
+++ b/packages/scenario/src/reactive/ReactiveScenario.ts
@@ -6,10 +6,10 @@ import type { InitializeTestFormOptions } from '../client/init.ts';
 import { Scenario, type ScenarioConstructorOptions } from '../jr/Scenario.ts';
 
 export class ReactiveScenario extends Scenario {
-	static override get initializeTestFormOptions(): InitializeTestFormOptions {
-		return {
+	static override getInitializeTestFormOptions(): InitializeTestFormOptions {
+		return super.getInitializeTestFormOptions({
 			stateFactory: createMutable,
-		};
+		});
 	}
 
 	private readonly testScopedOwner: Owner;

--- a/packages/scenario/src/resources/SharedJRResourceService.ts
+++ b/packages/scenario/src/resources/SharedJRResourceService.ts
@@ -1,0 +1,26 @@
+import { JRResourceService } from '@getodk/common/jr-resources/JRResourceService.ts';
+import { afterEach, beforeEach } from 'vitest';
+
+let state: SharedJRResourceService | null = null;
+
+export class SharedJRResourceService extends JRResourceService {
+	static init(): SharedJRResourceService {
+		if (state == null) {
+			state = new this();
+		}
+
+		return state;
+	}
+
+	private constructor() {
+		super();
+
+		beforeEach(() => {
+			this.reset();
+		});
+
+		afterEach(() => {
+			this.reset();
+		});
+	}
+}

--- a/packages/scenario/test/actions-events.test.ts
+++ b/packages/scenario/test/actions-events.test.ts
@@ -1117,8 +1117,8 @@ describe('Actions/Events', () => {
 	 * what we might want to change, such as providing a more direct mechanism to
 	 * influence the resolution of geolocation data for testing purposes (hint:
 	 * it'll probably be configurable in a very similar same way to the
-	 * `fetchResource` engine config option), I also thought it worth mentioning
-	 * these thoughts in anticipation of working on the feature:
+	 * `fetchFormDefinition` engine config option), I also thought it worth
+	 * mentioning these thoughts in anticipation of working on the feature:
 	 *
 	 * - Any web-native solution will almost certainly be async.
 	 *

--- a/packages/scenario/test/secondary-instances.test.ts
+++ b/packages/scenario/test/secondary-instances.test.ts
@@ -781,38 +781,6 @@ describe('Secondary instances', () => {
 			resourceService.activateFixtures(fixturesDirectory, ['file', 'file-csv']);
 		};
 
-		const activateInlineResources = () => {
-			resourceService.activateResource(
-				{
-					url: xmlAttachmentURL,
-					fileName: xmlAttachmentFileName,
-					mimeType: 'text/xml',
-				},
-				// prettier-ignore
-				t('instance-root',
-					t('instance-item',
-							t('item-label', 'A'),
-							t('item-value', 'a')),
-					t('instance-item',
-							t('item-label', 'B'),
-							t('item-value', 'b'))).asXml()
-			);
-			resourceService.activateResource(
-				{
-					url: csvAttachmentURL,
-					fileName: csvAttachmentFileName,
-					mimeType: 'text/csv',
-				},
-				// prettier-ignore
-				[
-					'item-label,item-value',
-					'Y,y',
-					'Z,z',
-					'\n\r\n'
-				].join('\n')
-			);
-		};
-
 		let fixturesDirectory: string;
 		let resourceService: JRResourceService;
 
@@ -848,22 +816,6 @@ describe('Secondary instances', () => {
 			expect(scenario.answerOf('/data/first')).toEqualAnswer(stringAnswer('a'));
 		});
 
-		// This test is redundant to the one above, but demonstrates how we could
-		// define form attachments inline, like we do form definitions—a pattern
-		// worth considering if we want to expand external secondary instance
-		// support and/or test coverage.
-		it('supports external secondary instances (XML, inline fixture)', async () => {
-			activateInlineResources();
-
-			const scenario = await Scenario.init(formTitle, formDefinition, {
-				resourceService,
-			});
-
-			scenario.answer('/data/first', 'a');
-
-			expect(scenario.answerOf('/data/first')).toEqualAnswer(stringAnswer('a'));
-		});
-
 		it('supports external secondary instances (CSV, file system fixture)', async () => {
 			activateFixtures();
 
@@ -874,18 +826,6 @@ describe('Secondary instances', () => {
 			scenario.answer('/data/second', 'y');
 
 			expect(scenario.answerOf('/data/second')).toEqualAnswer(stringAnswer('y'));
-		});
-
-		it('supports external secondary instances (CSV, inline fixture)', async () => {
-			activateInlineResources();
-
-			const scenario = await Scenario.init(formTitle, formDefinition, {
-				resourceService,
-			});
-
-			scenario.answer('/data/second', 'z');
-
-			expect(scenario.answerOf('/data/second')).toEqualAnswer(stringAnswer('z'));
 		});
 	});
 

--- a/packages/scenario/test/secondary-instances.test.ts
+++ b/packages/scenario/test/secondary-instances.test.ts
@@ -528,7 +528,7 @@ describe('Secondary instances', () => {
 					 *
 					 * - Typical `getDisplayText` -> `getValue`
 					 */
-					it.fails('can be selected', async () => {
+					it('can be selected', async () => {
 						configureReferenceManagerCorrectly();
 
 						const scenario = await Scenario.init(r('external-select-geojson.xml'));

--- a/packages/scenario/test/secondary-instances.test.ts
+++ b/packages/scenario/test/secondary-instances.test.ts
@@ -686,16 +686,6 @@ describe('Secondary instances', () => {
 		it.todo('dummyNodesInExternalInstanceDeclaration_ShouldBeIgnored');
 
 		describe('//region Missing external file', () => {
-			/**
-			 * **PORTING NOTES**
-			 *
-			 * Should probably fail pending feature support. Currently passes because
-			 * this is the expected behavior:
-			 *
-			 * - Without support for external secondary instances (and CSV)
-			 *
-			 * - Without producing an error in their absence
-			 */
 			it('[uses an] empty placeholder [~~]is used[~~] when [referenced] external instance [is] not found', async () => {
 				configureReferenceManagerIncorrectly();
 

--- a/packages/scenario/test/secondary-instances.test.ts
+++ b/packages/scenario/test/secondary-instances.test.ts
@@ -616,16 +616,6 @@ describe('Secondary instances', () => {
 		});
 
 		describe('CSV secondary instance with header only', () => {
-			/**
-			 * **PORTING NOTES**
-			 *
-			 * Should probably fail pending feature support. Currently passes because
-			 * this is the expected behavior:
-			 *
-			 * - Without support for external secondary instances (and CSV)
-			 *
-			 * - Without producing an error in their absence
-			 */
 			it('parses without error', async () => {
 				configureReferenceManagerCorrectly();
 

--- a/packages/scenario/test/secondary-instances.test.ts
+++ b/packages/scenario/test/secondary-instances.test.ts
@@ -84,33 +84,25 @@ describe('Secondary instances', () => {
 			 *    (`answerOf` return value) to be `equalTo(null)`. It seems likely
 			 *    given the form's shape that the intent is to check that the field is
 			 *    present and its value is blank, at that point in time.
-			 *
-			 * 3. (HUNCH ONLY!) I'm betting this failure is related to the form's
-			 *    `current()` sub-expression (which I doubt is being accounted for in
-			 *    dependency analysis, and is therefore failing to establish a
-			 *    reactive subscription within the engine).
 			 */
 			// JR: `doNotGetConfused`
-			it.fails(
-				"[re]computes separately within each respective repeat instance, when the predicate's dependencies affecting that node change",
-				async () => {
-					const scenario = await Scenario.init('repeat-secondary-instance.xml');
+			it("[re]computes separately within each respective repeat instance, when the predicate's dependencies affecting that node change", async () => {
+				const scenario = await Scenario.init('repeat-secondary-instance.xml');
 
-					scenario.createNewRepeat('/data/repeat');
-					scenario.createNewRepeat('/data/repeat');
+				scenario.createNewRepeat('/data/repeat');
+				scenario.createNewRepeat('/data/repeat');
 
-					scenario.answer('/data/repeat[1]/choice', 'a');
+				scenario.answer('/data/repeat[1]/choice', 'a');
 
-					expect(scenario.answerOf('/data/repeat[1]/calculate').getValue()).toBe('A');
-					// assertThat(scenario.answerOf('/data/repeat[2]/calculate'), equalTo(null));
-					expect(scenario.answerOf('/data/repeat[1]/calculate').getValue()).toBe('');
+				expect(scenario.answerOf('/data/repeat[1]/calculate').getValue()).toBe('A');
+				// assertThat(scenario.answerOf('/data/repeat[2]/calculate'), equalTo(null));
+				expect(scenario.answerOf('/data/repeat[2]/calculate').getValue()).toBe('');
 
-					scenario.answer('/data/repeat[2]/choice', 'b');
+				scenario.answer('/data/repeat[2]/choice', 'b');
 
-					expect(scenario.answerOf('/data/repeat[1]/calculate').getValue()).toBe('A');
-					expect(scenario.answerOf('/data/repeat[2]/calculate').getValue()).toBe('B');
-				}
-			);
+				expect(scenario.answerOf('/data/repeat[1]/calculate').getValue()).toBe('A');
+				expect(scenario.answerOf('/data/repeat[2]/calculate').getValue()).toBe('B');
+			});
 		});
 
 		describe('predicates on different child names', () => {

--- a/packages/scenario/test/serialization.test.ts
+++ b/packages/scenario/test/serialization.test.ts
@@ -175,10 +175,11 @@ describe('ExternalSecondaryInstanceParseTest.java', () => {
 		 * - Insofar as we may find ourselves implementing similar logic (albeit
 		 *   serving other purposes), how can we establish a clear interface
 		 *   contract around behaviors like this? Should it be more consistent? Does
-		 *   our current {@link EngineConfig.fetchResource} option—configurable in
-		 *   {@link InitializeFormOptions}—provide enough informational surface area
-		 *   to communicate such intent (and allow both clients and engine alike to
-		 *   have clarity of that intent at call/handling sites)?
+		 *   our current {@link EngineConfig.fetchFormDefinition}
+		 *   option—configurable in {@link InitializeFormOptions}—provide enough
+		 *   informational surface area to communicate such intent (and allow both
+		 *   clients and engine alike to have clarity of that intent at
+		 *   call/handling sites)?
 		 *
 		 * - - -
 		 *

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { MissingResourceBehavior } from '@getodk/xforms-engine';
 import { initializeForm, type FetchFormAttachment, type RootNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import Card from 'primevue/card';
@@ -14,6 +15,7 @@ const webFormsVersion = __WEB_FORMS_VERSION__;
 const props = defineProps<{
 	formXml: string;
 	fetchFormAttachment: FetchFormAttachment;
+	missingResourceBehavior?: MissingResourceBehavior;
 }>();
 const emit = defineEmits(['submit']);
 
@@ -24,6 +26,7 @@ const initializeFormError = ref<FormInitializationError | null>();
 initializeForm(props.formXml, {
 	config: {
 		fetchFormAttachment: props.fetchFormAttachment,
+		missingResourceBehavior: props.missingResourceBehavior,
 		stateFactory: reactive,
 	},
 })

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { initializeForm, type RootNode } from '@getodk/xforms-engine';
+import { initializeForm, type FetchFormAttachment, type RootNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import Card from 'primevue/card';
 import PrimeMessage from 'primevue/message';
@@ -11,7 +11,10 @@ import QuestionList from './QuestionList.vue';
 
 const webFormsVersion = __WEB_FORMS_VERSION__;
 
-const props = defineProps<{ formXml: string }>();
+const props = defineProps<{
+	formXml: string;
+	fetchFormAttachment: FetchFormAttachment;
+}>();
 const emit = defineEmits(['submit']);
 
 const odkForm = ref<RootNode>();
@@ -20,6 +23,7 @@ const initializeFormError = ref<FormInitializationError | null>();
 
 initializeForm(props.formXml, {
 	config: {
+		fetchFormAttachment: props.fetchFormAttachment,
 		stateFactory: reactive,
 	},
 })

--- a/packages/web-forms/src/demo/FormPreview.vue
+++ b/packages/web-forms/src/demo/FormPreview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { xformFixturesByCategory, XFormResource } from '@getodk/common/fixtures/xforms.ts';
+import type { FetchFormAttachment } from '@getodk/xforms-engine';
 import { ref } from 'vue';
 import { useRoute } from 'vue-router';
 import OdkWebForm from '../components/OdkWebForm.vue';
@@ -10,7 +11,12 @@ const route = useRoute();
 const categoryParam = route.params.category as string;
 const formParam = route.params.form as string;
 
-const formXML = ref<string>();
+interface FormPreviewState {
+	readonly formXML: string;
+	readonly fetchFormAttachment: FetchFormAttachment;
+}
+
+const formPreviewState = ref<FormPreviewState>();
 
 let xformResource: XFormResource<'local'> | XFormResource<'remote'> | undefined;
 
@@ -24,8 +30,11 @@ if (route.query.url) {
 
 xformResource
 	?.loadXML()
-	.then((fixtureXML) => {
-		formXML.value = fixtureXML;
+	.then((formXML) => {
+		formPreviewState.value = {
+			formXML,
+			fetchFormAttachment: xformResource.fetchFormAttachment,
+		};
 	})
 	.catch((error) => {
 		// eslint-disable-next-line no-console
@@ -39,8 +48,8 @@ const handleSubmit = () => {
 };
 </script>
 <template>
-	<template v-if="formXML">
-		<OdkWebForm :form-xml="formXML" @submit="handleSubmit" />
+	<template v-if="formPreviewState">
+		<OdkWebForm :form-xml="formPreviewState.formXML" :fetch-form-attachment="formPreviewState.fetchFormAttachment" @submit="handleSubmit" />
 		<FeedbackButton />
 	</template>
 	<div v-else>

--- a/packages/web-forms/tests/components/OdkWebForm.test.ts
+++ b/packages/web-forms/tests/components/OdkWebForm.test.ts
@@ -13,6 +13,9 @@ const mountComponent = (formXML: string) => {
 	const component = mount(OdkWebForm, {
 		props: {
 			formXml: formXML,
+			fetchFormAttachment: () => {
+				throw new Error('Not exercised here');
+			},
 		},
 		global: globalMountOptions,
 		attachTo: document.body,

--- a/packages/xforms-engine/package.json
+++ b/packages/xforms-engine/package.json
@@ -54,6 +54,7 @@
     "test:types": "tsc --project ./tsconfig.json --emitDeclarationOnly false --noEmit"
   },
   "dependencies": {
+    "papaparse": "^5.4.1",
     "solid-js": "^1.9.1"
   },
   "devDependencies": {
@@ -61,6 +62,7 @@
     "@getodk/tree-sitter-xpath": "0.1.2",
     "@getodk/xpath": "0.2.1",
     "@playwright/test": "^1.47.2",
+    "@types/papaparse": "^5.3.15",
     "@vitest/browser": "^2.1.1",
     "babel-plugin-transform-jsbi-to-bigint": "^1.4.0",
     "http-server": "^14.1.1",

--- a/packages/xforms-engine/src/client/EngineConfig.ts
+++ b/packages/xforms-engine/src/client/EngineConfig.ts
@@ -1,43 +1,6 @@
-import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
 import type { initializeForm } from '../instance/index.ts';
 import type { OpaqueReactiveObjectFactory } from './OpaqueReactiveObjectFactory.ts';
-
-/**
- * @todo this is currently a strict subset of the web standard `Response`. Is it
- * sufficient? Ways it might not be:
- *
- * - No way to convey metadata about the resource
- * - Ambiguous if a client supplies an alternative implementation which doesn't
- *   exhaust the body on access
- */
-export interface FetchResourceResponse {
-	readonly ok?: boolean;
-	readonly body?: ReadableStream<Uint8Array> | null;
-	readonly bodyUsed?: boolean;
-
-	readonly blob: () => Promise<Blob>;
-	readonly text: () => Promise<string>;
-}
-
-/**
- * @todo this is a strict subset of the web standard `fetch` interface. It
- * implicitly assumes that the engine itself will only ever issue `GET`-like
- * requests. It also provides no further request-like semantics to the engine.
- * This is presumed sufficient for now, but notably doesn't expose any notion of
- * content negotiation (e.g. the ability to supply `Accept` headers).
- *
- * This also completely ignores any notion of mapping
- * {@link https://getodk.github.io/xforms-spec/#uris | `jr:` URLs} to their
- * actual resources (likely, but not necessarily, accessed at a corresponding
- * HTTP URL).
- */
-export type FetchResource<Resource extends URL = URL> = (
-	resource: Resource
-) => Promise<FetchResourceResponse>;
-
-export type FormAttachmentURL = JRResourceURL;
-
-export type FetchFormAttachment = FetchResource<FormAttachmentURL>;
+import type { FetchFormAttachment, FetchResource } from './resources.ts';
 
 /**
  * Options provided by a client to specify certain aspects of engine runtime

--- a/packages/xforms-engine/src/client/EngineConfig.ts
+++ b/packages/xforms-engine/src/client/EngineConfig.ts
@@ -1,4 +1,5 @@
 import type { initializeForm } from '../instance/index.ts';
+import type { MissingResourceBehavior, MissingResourceBehaviorDefault } from './constants.ts';
 import type { OpaqueReactiveObjectFactory } from './OpaqueReactiveObjectFactory.ts';
 import type { FetchFormAttachment, FetchResource } from './resources.ts';
 
@@ -76,9 +77,14 @@ export interface EngineConfig {
 	 *   therefore inherently need to coordinate state between the Service Worker
 	 *   and the main thread (or whatever other realm calls
 	 *   {@link initializeForm}).
-	 *
-	 * - **PENDING:** Any usage where the engine does not require access to a
-	 *   form's attachments.
 	 */
 	readonly fetchFormAttachment?: FetchFormAttachment;
+
+	/**
+	 * @see {@link MissingResourceBehavior}
+	 * @see {@link MissingResourceBehaviorDefault}
+	 *
+	 * @default MissingResourceBehaviorDefault
+	 */
+	readonly missingResourceBehavior?: MissingResourceBehavior;
 }

--- a/packages/xforms-engine/src/client/EngineConfig.ts
+++ b/packages/xforms-engine/src/client/EngineConfig.ts
@@ -44,12 +44,6 @@ export interface EngineConfig {
 	readonly fetchFormDefinition?: FetchResource;
 
 	/**
-	 * @deprecated
-	 * @alias fetchFormDefinition
-	 */
-	readonly fetchResource?: FetchResource;
-
-	/**
 	 * A client may specify an arbitrary {@link fetch}-like function to retrieve a
 	 * form's attachments, i.e. any `jr:` URL referenced by the form (as specified
 	 * by {@link https://getodk.github.io/xforms-spec/ | ODK XForms}).

--- a/packages/xforms-engine/src/client/constants.ts
+++ b/packages/xforms-engine/src/client/constants.ts
@@ -1,4 +1,65 @@
+import type { PrimaryInstance } from '../instance/PrimaryInstance.ts';
+import type { InitializeForm } from './index.ts';
 import type { ValidationTextRole } from './TextRange.ts';
+
+export const MISSING_RESOURCE_BEHAVIOR = {
+	/**
+	 * When this behavior is configured, {@link InitializeForm | initializing} a
+	 * {@link PrimaryInstance} for a form which references any **missing**
+	 * resources will fail, producing an error to the calling client.
+	 *
+	 * @see {@link MissingResourceBehavior}
+	 */
+	ERROR: 'ERROR',
+
+	/**
+	 * When this behavior is configured, {@link InitializeForm | initializing} a
+	 * {@link PrimaryInstance} for a form which references any **missing**
+	 * resources will succeed (producing a warning).
+	 *
+	 * Such missing resources will be parsed as if they are blank, as appropriate
+	 * for the resource's XForm semantic usage and/or format.
+	 *
+	 * @see {@link MissingResourceBehavior}
+	 */
+	BLANK: 'BLANK',
+
+	/**
+	 * @see {@link MISSING_RESOURCE_BEHAVIOR.ERROR}
+	 */
+	get DEFAULT(): 'ERROR' {
+		return MISSING_RESOURCE_BEHAVIOR.ERROR;
+	},
+} as const;
+
+export type MissingResourceBehaviorError = typeof MISSING_RESOURCE_BEHAVIOR.ERROR;
+
+export type MissingResourceBehaviorBlank = typeof MISSING_RESOURCE_BEHAVIOR.BLANK;
+
+export type MissingResourceBehaviorDefault = typeof MISSING_RESOURCE_BEHAVIOR.DEFAULT;
+
+/**
+ * Specifies behavior for {@link InitializeForm | initializing} a form's
+ * {@link PrimaryInstance} which references any **missing** resources.
+ *
+ * Here the term "missing" is consistent with
+ * {@link https://www.rfc-editor.org/rfc/rfc9110#status.404 | HTTP 404 status}
+ * semantics. Clients which provide access to form attachments by performing
+ * HTTP network requests (e.g. with {@link fetch}) can generally convey this
+ * semantic meaning with a standard {@link Response}.
+ *
+ * **IMPORTANT**
+ *
+ * The term "missing" is distinct from other network/IO failures, e.g. when
+ * network access itself is unavailable. In these cases, the engine will
+ * consider a resource's availability **ambiguous**, producing an error
+ * regardless of the configured behavior for **missing** resources.
+ */
+// prettier-ignore
+export type MissingResourceBehavior =
+	// eslint-disable-next-line @typescript-eslint/sort-type-constituents
+	| MissingResourceBehaviorError
+	| MissingResourceBehaviorBlank;
 
 export const VALIDATION_TEXT = {
 	constraintMsg: 'Condition not satisfied: constraint',

--- a/packages/xforms-engine/src/client/resources.ts
+++ b/packages/xforms-engine/src/client/resources.ts
@@ -1,0 +1,118 @@
+import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import type { initializeForm } from '../instance/index.ts';
+
+interface FetchResourceHeadersIterator<T>
+	extends IteratorObject<
+		T,
+		// Note: we use this weird TypeScript intrinsic type so a built-in
+		// `HeadersIterator` is assignable regardless of a client's configured
+		// TypeScript or linting strictness. We don't actually care about the type, or
+		// consume the value it represents.
+		BuiltinIteratorReturn,
+		unknown
+	> {
+	[Symbol.iterator](): FetchResourceHeadersIterator<T>;
+}
+
+type FetchResourceHeadersForEachCallbackFn = (
+	value: string,
+	key: string,
+	parent: FetchResourceResponseHeaders
+) => void;
+
+/**
+ * A read-only strict subset of the web standard {@link Headers}.
+ *
+ * Note that the engine may make the following assumptions about
+ * {@link FetchResourceResponse.headers}:
+ *
+ * - If {@link FetchResourceResponse} is an instance of {@link Response}, it
+ *   will be assumed its {@link FetchResourceResponse.headers | headers object}
+ *   _is present_, and that it is an instance of {@link Headers}. In other
+ *   words: for the purposes of resource resolution, we explicitly expect that
+ *   clients using APIs provided by the runtime platform (or polyfills thereof)
+ *   will not monkey-patch properties of values produced by those APIs.
+ *
+ * - If the object is an instance of {@link Headers} (whether by inference as a
+ *   property of {@link Response}, or by a direct instance type check), the
+ *   engine will assume it is safe to treat header names as case insensitive for
+ *   any lookups it may perform. In other words: we explicitly expect that
+ *   clients _providing access_ to APIs rovided by the runtime platform (or
+ *   polyfills thereof) will not alter the guarantees of those APIs.
+ *
+ * - If the object is not an instance of {@link Headers}, it will be treated as
+ *   a {@link ReadonlyMap<string, string>}. In other words: we explicitly expect
+ *   that clients, when providing a bespoke implementation of
+ *   {@link FetchResourceResponse} and its constituent parts, will likely
+ *   implement them partially (and in the case of
+ *   {@link FetchResourceResponse.headers}, with the nearest common idiom
+ *   available). In this case, we will favor a best effort at correctness,
+ *   generally at some expense of performance.
+ */
+export interface FetchResourceResponseHeaders {
+	[Symbol.iterator](): FetchResourceHeadersIterator<[string, string]>;
+
+	entries(): FetchResourceHeadersIterator<[string, string]>;
+	keys(): FetchResourceHeadersIterator<string>;
+	values(): FetchResourceHeadersIterator<string>;
+
+	get(name: string): string | null;
+	has(name: string): boolean;
+	forEach(callbackfn: FetchResourceHeadersForEachCallbackFn): void;
+}
+
+/**
+ * This is a strict subset of the web standard {@link Response}. Clients are
+ * encouraged to use the global {@link Response} constructor (as provided by the
+ * runtime platform, or by a global runtime polyfill), but may also provide a
+ * bespoke implementation if it suits their needs.
+ *
+ * Since we cannot assume a client's implementation will always be an instance
+ * of {@link Response}, we make some assumptions about its {@link headers}
+ * object (if available, as detailed on {@link FetchResourceResponseHeaders}).
+ *
+ * For other properties, we make the following assumptions (all of which are
+ * assumptions we would make about a platform-provided/polyfilled
+ * {@link Response}, but are explicitly stated for the benefit of confidence in
+ * client implementations):
+ *
+ * - If we read {@link body} directly, we will assume it is consumed on first
+ *   read, and will not read it again.
+ *
+ * - We assume that {@link blob} and {@link text} indirectly consume
+ *   {@link body} on first read as well, and will only ever read one of each of
+ *   these properties, and only ever once.
+ *
+ * Furthermore, if the engine intends to read {@link body} (or its indirect
+ * {@link blob} or {@link text} consumers), it will do so in the course of a
+ * client's call to {@link initializeForm}, and before the
+ * {@link Promise<PrimaryInstance>} returned by that call is resolved.
+ */
+export interface FetchResourceResponse {
+	readonly ok?: boolean;
+	readonly status?: number;
+	readonly body?: ReadableStream<Uint8Array> | null;
+	readonly bodyUsed?: boolean;
+	readonly headers?: FetchResourceResponseHeaders;
+
+	readonly blob: () => Promise<Blob>;
+	readonly text: () => Promise<string>;
+}
+
+/**
+ * This is a strict subset of the web standard `fetch` interface. It implicitly
+ * assumes that the engine itself will only ever perform `GET`-like network/IO
+ * requests. It also provides no further request-like semantics to the engine.
+ *
+ * This is presumed sufficient for now, but notably doesn't expose any notion of
+ * content negotiation (e.g. the ability for the engine to include `Accept`
+ * headers in resource requests issued to a client's {@link FetchResource}
+ * implementation).
+ */
+export type FetchResource<Resource extends URL = URL> = (
+	resource: Resource
+) => Promise<FetchResourceResponse>;
+
+export type FormAttachmentURL = JRResourceURL;
+
+export type FetchFormAttachment = FetchResource<FormAttachmentURL>;

--- a/packages/xforms-engine/src/index.ts
+++ b/packages/xforms-engine/src/index.ts
@@ -25,6 +25,7 @@ export type * from './client/OpaqueReactiveObjectFactory.ts';
 export type * from './client/repeat/RepeatInstanceNode.ts';
 export type * from './client/repeat/RepeatRangeControlledNode.ts';
 export type * from './client/repeat/RepeatRangeUncontrolledNode.ts';
+export type * from './client/resources.ts';
 export type * from './client/RootNode.ts';
 export type * from './client/SelectNode.ts';
 export type * from './client/StringNode.ts';

--- a/packages/xforms-engine/src/index.ts
+++ b/packages/xforms-engine/src/index.ts
@@ -3,6 +3,7 @@ import { initializeForm as engine__initializeForm } from './instance/index.ts';
 
 export const initializeForm: InitializeForm = engine__initializeForm;
 
+export type * from './client/constants.ts';
 export * as constants from './client/constants.ts';
 export type * from './client/EngineConfig.ts';
 export type * from './client/FormLanguage.ts';

--- a/packages/xforms-engine/src/instance/PrimaryInstance.ts
+++ b/packages/xforms-engine/src/instance/PrimaryInstance.ts
@@ -28,6 +28,7 @@ import type { SimpleAtomicStateSetter } from '../lib/reactivity/types.ts';
 import type { BodyClassList } from '../parse/body/BodyDefinition.ts';
 import type { ModelDefinition } from '../parse/model/ModelDefinition.ts';
 import type { RootDefinition } from '../parse/model/RootDefinition.ts';
+import type { SecondaryInstancesDefinition } from '../parse/model/SecondaryInstance/SecondaryInstancesDefinition.ts';
 import { InstanceNode } from './abstract/InstanceNode.ts';
 import type { EvaluationContext } from './internal-api/EvaluationContext.ts';
 import type { InstanceConfig } from './internal-api/InstanceConfig.ts';
@@ -116,7 +117,12 @@ export class PrimaryInstance
 	readonly evaluator: EngineXPathEvaluator;
 	override readonly contextNode = this;
 
-	constructor(scope: ReactiveScope, model: ModelDefinition, engineConfig: InstanceConfig) {
+	constructor(
+		scope: ReactiveScope,
+		model: ModelDefinition,
+		secondaryInstances: SecondaryInstancesDefinition,
+		engineConfig: InstanceConfig
+	) {
 		const { root: definition } = model;
 
 		super(engineConfig, null, definition, {
@@ -131,7 +137,7 @@ export class PrimaryInstance
 		const evaluator = new EngineXPathEvaluator({
 			rootNode: this,
 			itextTranslationsByLanguage: model.itextTranslations,
-			secondaryInstancesById: model.secondaryInstances,
+			secondaryInstancesById: secondaryInstances,
 		});
 
 		const { languages, getActiveLanguage, setActiveLanguage } = createTranslationState(

--- a/packages/xforms-engine/src/instance/index.ts
+++ b/packages/xforms-engine/src/instance/index.ts
@@ -2,6 +2,7 @@ import { identity } from '@getodk/common/lib/identity.ts';
 import { getOwner } from 'solid-js';
 import type { EngineConfig } from '../client/EngineConfig.ts';
 import type { RootNode } from '../client/RootNode.ts';
+import { MISSING_RESOURCE_BEHAVIOR } from '../client/constants.ts';
 import type {
 	InitializeFormOptions as BaseInitializeFormOptions,
 	FormResource,
@@ -25,6 +26,7 @@ const buildInstanceConfig = (options: EngineConfig = {}): InstanceConfig => {
 		createUniqueId,
 		fetchFormDefinition: options.fetchFormDefinition ?? options.fetchResource ?? fetch,
 		fetchFormAttachment: options.fetchFormAttachment ?? fetch,
+		missingResourceBehavior: options.missingResourceBehavior ?? MISSING_RESOURCE_BEHAVIOR.DEFAULT,
 		stateFactory: options.stateFactory ?? identity,
 	};
 };
@@ -42,6 +44,7 @@ export const initializeForm = async (
 	const xformDOM = XFormDOM.from(sourceXML);
 	const secondaryInstances = await SecondaryInstancesDefinition.load(xformDOM, {
 		fetchResource: engineConfig.fetchFormAttachment,
+		missingResourceBehavior: engineConfig.missingResourceBehavior,
 	});
 	const form = new XFormDefinition(xformDOM);
 	const primaryInstance = new PrimaryInstance(scope, form.model, secondaryInstances, engineConfig);

--- a/packages/xforms-engine/src/instance/index.ts
+++ b/packages/xforms-engine/src/instance/index.ts
@@ -1,5 +1,6 @@
 import { identity } from '@getodk/common/lib/identity.ts';
 import { getOwner } from 'solid-js';
+import type { EngineConfig } from '../client/EngineConfig.ts';
 import type { RootNode } from '../client/RootNode.ts';
 import type {
 	InitializeFormOptions as BaseInitializeFormOptions,
@@ -17,10 +18,11 @@ interface InitializeFormOptions extends BaseInitializeFormOptions {
 	readonly config: Partial<InstanceConfig>;
 }
 
-const buildInstanceConfig = (options: Partial<InstanceConfig> = {}): InstanceConfig => {
+const buildInstanceConfig = (options: EngineConfig = {}): InstanceConfig => {
 	return {
-		createUniqueId: options.createUniqueId ?? createUniqueId,
-		fetchResource: options.fetchResource ?? fetch,
+		createUniqueId,
+		fetchFormDefinition: options.fetchFormDefinition ?? options.fetchResource ?? fetch,
+		fetchFormAttachment: options.fetchFormAttachment ?? fetch,
 		stateFactory: options.stateFactory ?? identity,
 	};
 };
@@ -32,7 +34,9 @@ export const initializeForm = async (
 	const owner = getOwner();
 	const scope = createReactiveScope({ owner });
 	const engineConfig = buildInstanceConfig(options.config);
-	const sourceXML = await retrieveSourceXMLResource(input, engineConfig);
+	const sourceXML = await retrieveSourceXMLResource(input, {
+		fetchResource: engineConfig.fetchFormDefinition,
+	});
 	const form = new XFormDefinition(sourceXML);
 	const primaryInstance = new PrimaryInstance(scope, form.model, engineConfig);
 

--- a/packages/xforms-engine/src/instance/index.ts
+++ b/packages/xforms-engine/src/instance/index.ts
@@ -24,7 +24,7 @@ interface InitializeFormOptions extends BaseInitializeFormOptions {
 const buildInstanceConfig = (options: EngineConfig = {}): InstanceConfig => {
 	return {
 		createUniqueId,
-		fetchFormDefinition: options.fetchFormDefinition ?? options.fetchResource ?? fetch,
+		fetchFormDefinition: options.fetchFormDefinition ?? fetch,
 		fetchFormAttachment: options.fetchFormAttachment ?? fetch,
 		missingResourceBehavior: options.missingResourceBehavior ?? MISSING_RESOURCE_BEHAVIOR.DEFAULT,
 		stateFactory: options.stateFactory ?? identity,

--- a/packages/xforms-engine/src/instance/index.ts
+++ b/packages/xforms-engine/src/instance/index.ts
@@ -10,7 +10,9 @@ import type {
 import { retrieveSourceXMLResource } from '../instance/resource.ts';
 import { createReactiveScope } from '../lib/reactivity/scope.ts';
 import { createUniqueId } from '../lib/unique-id.ts';
+import { XFormDOM } from '../parse/XFormDOM.ts';
 import { XFormDefinition } from '../parse/XFormDefinition.ts';
+import { SecondaryInstancesDefinition } from '../parse/model/SecondaryInstance/SecondaryInstancesDefinition.ts';
 import { PrimaryInstance } from './PrimaryInstance.ts';
 import type { InstanceConfig } from './internal-api/InstanceConfig.ts';
 
@@ -37,8 +39,12 @@ export const initializeForm = async (
 	const sourceXML = await retrieveSourceXMLResource(input, {
 		fetchResource: engineConfig.fetchFormDefinition,
 	});
-	const form = new XFormDefinition(sourceXML);
-	const primaryInstance = new PrimaryInstance(scope, form.model, engineConfig);
+	const xformDOM = XFormDOM.from(sourceXML);
+	const secondaryInstances = await SecondaryInstancesDefinition.load(xformDOM, {
+		fetchResource: engineConfig.fetchFormAttachment,
+	});
+	const form = new XFormDefinition(xformDOM);
+	const primaryInstance = new PrimaryInstance(scope, form.model, secondaryInstances, engineConfig);
 
 	return primaryInstance.root;
 };

--- a/packages/xforms-engine/src/instance/internal-api/InstanceConfig.ts
+++ b/packages/xforms-engine/src/instance/internal-api/InstanceConfig.ts
@@ -1,5 +1,5 @@
-import type { FetchFormAttachment, FetchResource } from '../../client/EngineConfig.ts';
 import type { OpaqueReactiveObjectFactory } from '../../client/OpaqueReactiveObjectFactory.ts';
+import type { FetchFormAttachment, FetchResource } from '../../client/resources.ts';
 import type { CreateUniqueId } from '../../lib/unique-id.ts';
 
 export interface InstanceConfig {

--- a/packages/xforms-engine/src/instance/internal-api/InstanceConfig.ts
+++ b/packages/xforms-engine/src/instance/internal-api/InstanceConfig.ts
@@ -1,3 +1,4 @@
+import type { MissingResourceBehavior } from '../../client/constants.ts';
 import type { OpaqueReactiveObjectFactory } from '../../client/OpaqueReactiveObjectFactory.ts';
 import type { FetchFormAttachment, FetchResource } from '../../client/resources.ts';
 import type { CreateUniqueId } from '../../lib/unique-id.ts';
@@ -6,6 +7,7 @@ export interface InstanceConfig {
 	readonly stateFactory: OpaqueReactiveObjectFactory;
 	readonly fetchFormDefinition: FetchResource;
 	readonly fetchFormAttachment: FetchFormAttachment;
+	readonly missingResourceBehavior: MissingResourceBehavior;
 
 	/**
 	 * Uniqueness per form instance session (so e.g. persistence isn't necessary).

--- a/packages/xforms-engine/src/instance/internal-api/InstanceConfig.ts
+++ b/packages/xforms-engine/src/instance/internal-api/InstanceConfig.ts
@@ -1,7 +1,12 @@
-import type { EngineConfig } from '../../client/EngineConfig.ts';
+import type { FetchFormAttachment, FetchResource } from '../../client/EngineConfig.ts';
+import type { OpaqueReactiveObjectFactory } from '../../client/OpaqueReactiveObjectFactory.ts';
 import type { CreateUniqueId } from '../../lib/unique-id.ts';
 
-export interface InstanceConfig extends Required<EngineConfig> {
+export interface InstanceConfig {
+	readonly stateFactory: OpaqueReactiveObjectFactory;
+	readonly fetchFormDefinition: FetchResource;
+	readonly fetchFormAttachment: FetchFormAttachment;
+
 	/**
 	 * Uniqueness per form instance session (so e.g. persistence isn't necessary).
 	 */

--- a/packages/xforms-engine/src/instance/resource.ts
+++ b/packages/xforms-engine/src/instance/resource.ts
@@ -1,7 +1,7 @@
 import { UnreachableError } from '@getodk/common/lib/error/UnreachableError.ts';
 import { getBlobText } from '@getodk/common/lib/web-compat/blob.ts';
-import type { FetchResource, FetchResourceResponse } from '../client/EngineConfig.ts';
 import type { FormResource } from '../client/index.ts';
+import type { FetchResource, FetchResourceResponse } from '../client/resources.ts';
 
 export type { FetchResource, FetchResourceResponse, FormResource };
 

--- a/packages/xforms-engine/src/parse/XFormDefinition.ts
+++ b/packages/xforms-engine/src/parse/XFormDefinition.ts
@@ -3,7 +3,6 @@ import { ModelDefinition } from './model/ModelDefinition.ts';
 import { XFormDOM } from './XFormDOM.ts';
 
 export class XFormDefinition {
-	readonly xformDOM: XFormDOM;
 	readonly xformDocument: XMLDocument;
 
 	readonly id: string;
@@ -14,11 +13,7 @@ export class XFormDefinition {
 	readonly body: BodyDefinition;
 	readonly model: ModelDefinition;
 
-	constructor(readonly sourceXML: string) {
-		const xformDOM = XFormDOM.from(sourceXML);
-
-		this.xformDOM = xformDOM;
-
+	constructor(readonly xformDOM: XFormDOM) {
 		const { primaryInstanceRoot, title, xformDocument } = xformDOM;
 		const id = primaryInstanceRoot.getAttribute('id');
 

--- a/packages/xforms-engine/src/parse/attachments/FormAttachmentResource.ts
+++ b/packages/xforms-engine/src/parse/attachments/FormAttachmentResource.ts
@@ -1,0 +1,40 @@
+import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
+
+export type FormAttachmentDataType = 'media' | 'secondary-instance';
+
+/**
+ * @todo This type anticipates work to support media form attachments, which
+ * will tend to be associated with binary data. The
+ * expectation is that:
+ *
+ * - {@link Blob} would be appropriate for representing data from attachment
+ *   resources which are conventionally loaded to completion (where network
+ *   conditions are favorable), such as images
+ *
+ * - {@link MediaSource} or {@link ReadableStream} may be more appropriate for
+ *   representing data from resources which are conventionally streamed in a
+ *   browser context (often regardless of network conditions), such as video and
+ *   audio
+ */
+// prettier-ignore
+export type FormAttachmentMediaData =
+	| Blob
+	| MediaSource
+	| ReadableStream<unknown>;
+
+export type FormAttachmentSecondaryInstanceData = string;
+
+// prettier-ignore
+type FormAttachmentData<DataType extends FormAttachmentDataType> =
+	DataType extends 'media'
+		? FormAttachmentMediaData
+		: FormAttachmentSecondaryInstanceData;
+
+export abstract class FormAttachmentResource<DataType extends FormAttachmentDataType> {
+	protected constructor(
+		readonly dataType: DataType,
+		readonly resourceURL: JRResourceURL,
+		readonly contentType: string,
+		readonly data: FormAttachmentData<DataType>
+	) {}
+}

--- a/packages/xforms-engine/src/parse/model/ModelDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/ModelDefinition.ts
@@ -3,20 +3,17 @@ import { FormSubmissionDefinition } from './FormSubmissionDefinition.ts';
 import { ItextTranslationsDefinition } from './ItextTranslation/ItextTranslationsDefinition.ts';
 import { ModelBindMap } from './ModelBindMap.ts';
 import { RootDefinition } from './RootDefinition.ts';
-import { SecondaryInstancesDefinition } from './SecondaryInstance/SecondaryInstancesDefinition.ts';
 
 export class ModelDefinition {
 	readonly binds: ModelBindMap;
 	readonly root: RootDefinition;
 	readonly itextTranslations: ItextTranslationsDefinition;
-	readonly secondaryInstances: SecondaryInstancesDefinition;
 
 	constructor(readonly form: XFormDefinition) {
 		const submission = new FormSubmissionDefinition(form.xformDOM);
 		this.binds = ModelBindMap.fromModel(this);
 		this.root = new RootDefinition(form, this, submission, form.body.classes);
 		this.itextTranslations = ItextTranslationsDefinition.from(form.xformDOM);
-		this.secondaryInstances = SecondaryInstancesDefinition.from(form.xformDOM);
 	}
 
 	toJSON() {

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/SecondaryInstancesDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/SecondaryInstancesDefinition.ts
@@ -7,7 +7,7 @@ import type { XFormDOM } from '../../XFormDOM.ts';
 import { SecondaryInstanceRootDefinition } from './SecondaryInstanceRootDefinition.ts';
 import { BlankSecondaryInstanceSource } from './sources/BlankSecondaryInstanceSource.ts';
 import { CSVExternalSecondaryInstanceSource } from './sources/CSVExternalSecondaryInstance.ts';
-import type { ExternalSecondaryInstanceResourceOptions } from './sources/ExternalSecondaryInstanceResource.ts';
+import type { ExternalSecondaryInstanceResourceLoadOptions } from './sources/ExternalSecondaryInstanceResource.ts';
 import { ExternalSecondaryInstanceResource } from './sources/ExternalSecondaryInstanceResource.ts';
 import { GeoJSONExternalSecondaryInstanceSource } from './sources/GeoJSONExternalSecondaryInstance.ts';
 import { InternalSecondaryInstanceSource } from './sources/InternalSecondaryInstanceSource.ts';
@@ -41,7 +41,7 @@ export class SecondaryInstancesDefinition
 
 	static async load(
 		xformDOM: XFormDOM,
-		options: ExternalSecondaryInstanceResourceOptions
+		options: ExternalSecondaryInstanceResourceLoadOptions
 	): Promise<SecondaryInstancesDefinition> {
 		const { secondaryInstanceElements } = xformDOM;
 
@@ -67,7 +67,7 @@ export class SecondaryInstancesDefinition
 					options
 				);
 
-				if (resource == null) {
+				if (resource.isBlank) {
 					return new BlankSecondaryInstanceSource(instanceId, resourceURL, domElement);
 				}
 

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/SecondaryInstancesDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/SecondaryInstancesDefinition.ts
@@ -1,29 +1,95 @@
+import { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import { UnreachableError } from '@getodk/common/lib/error/UnreachableError.ts';
 import type { XFormsSecondaryInstanceMap } from '@getodk/xpath';
+import { ErrorProductionDesignPendingError } from '../../../error/ErrorProductionDesignPendingError.ts';
 import type { EngineXPathNode } from '../../../integration/xpath/adapter/kind.ts';
-import { parseStaticDocumentFromDOMSubtree } from '../../shared/parseStaticDocumentFromDOMSubtree.ts';
 import type { XFormDOM } from '../../XFormDOM.ts';
-import { SecondaryInstanceDefinition } from './SecondaryInstanceDefinition.ts';
 import { SecondaryInstanceRootDefinition } from './SecondaryInstanceRootDefinition.ts';
+import { CSVExternalSecondaryInstanceSource } from './sources/CSVExternalSecondaryInstance.ts';
+import type { ExternalSecondaryInstanceResourceOptions } from './sources/ExternalSecondaryInstanceResource.ts';
+import { ExternalSecondaryInstanceResource } from './sources/ExternalSecondaryInstanceResource.ts';
+import { GeoJSONExternalSecondaryInstanceSource } from './sources/GeoJSONExternalSecondaryInstance.ts';
+import { InternalSecondaryInstanceSource } from './sources/InternalSecondaryInstanceSource.ts';
+import type { SecondaryInstanceSource } from './sources/SecondaryInstanceSource.ts';
+import { XMLExternalSecondaryInstanceSource } from './sources/XMLExternalSecondaryInstanceSource.ts';
 
 export class SecondaryInstancesDefinition
 	extends Map<string, SecondaryInstanceRootDefinition>
 	implements XFormsSecondaryInstanceMap<EngineXPathNode>
 {
-	static from(xformDOM: XFormDOM): SecondaryInstancesDefinition {
-		const definitions = xformDOM.secondaryInstanceElements.map((element) => {
-			return parseStaticDocumentFromDOMSubtree(
-				SecondaryInstanceDefinition,
-				SecondaryInstanceRootDefinition,
-				element
-			);
+	/**
+	 * @package Only to be used for testing
+	 */
+	static loadSync(xformDOM: XFormDOM): SecondaryInstancesDefinition {
+		const { secondaryInstanceElements } = xformDOM;
+		const sources = secondaryInstanceElements.map((domElement) => {
+			const instanceId = domElement.getAttribute('id');
+			const src = domElement.getAttribute('src');
+
+			if (src != null) {
+				throw new ErrorProductionDesignPendingError(
+					`Unexpected external secondary instance src attribute: ${src}`
+				);
+			}
+
+			return new InternalSecondaryInstanceSource(instanceId, src, domElement);
 		});
 
-		return new this(definitions);
+		return new this(sources);
 	}
 
-	private constructor(translations: readonly SecondaryInstanceDefinition[]) {
+	static async load(
+		xformDOM: XFormDOM,
+		options: ExternalSecondaryInstanceResourceOptions
+	): Promise<SecondaryInstancesDefinition> {
+		const { secondaryInstanceElements } = xformDOM;
+
+		const sources = await Promise.all(
+			secondaryInstanceElements.map(async (domElement) => {
+				const instanceId = domElement.getAttribute('id');
+				const src = domElement.getAttribute('src');
+
+				if (src == null) {
+					return new InternalSecondaryInstanceSource(instanceId, src, domElement);
+				}
+
+				if (!JRResourceURL.isJRResourceReference(src)) {
+					throw new ErrorProductionDesignPendingError(
+						`Unexpected external secondary instance src attribute: ${src}`
+					);
+				}
+
+				const resourceURL = JRResourceURL.from(src);
+				const resource = await ExternalSecondaryInstanceResource.load(
+					instanceId,
+					resourceURL,
+					options
+				);
+
+				switch (resource.format) {
+					case 'csv':
+						return new CSVExternalSecondaryInstanceSource(domElement, resource);
+
+					case 'geojson':
+						return new GeoJSONExternalSecondaryInstanceSource(domElement, resource);
+
+					case 'xml':
+						return new XMLExternalSecondaryInstanceSource(domElement, resource);
+
+					default:
+						throw new UnreachableError(resource);
+				}
+			})
+		);
+
+		return new this(sources);
+	}
+
+	private constructor(sources: readonly SecondaryInstanceSource[]) {
 		super(
-			translations.map(({ root }) => {
+			sources.map((source) => {
+				const { root } = source.parseDefinition();
+
 				return [root.getAttributeValue('id'), root];
 			})
 		);

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/SecondaryInstancesDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/SecondaryInstancesDefinition.ts
@@ -5,6 +5,7 @@ import { ErrorProductionDesignPendingError } from '../../../error/ErrorProductio
 import type { EngineXPathNode } from '../../../integration/xpath/adapter/kind.ts';
 import type { XFormDOM } from '../../XFormDOM.ts';
 import { SecondaryInstanceRootDefinition } from './SecondaryInstanceRootDefinition.ts';
+import { BlankSecondaryInstanceSource } from './sources/BlankSecondaryInstanceSource.ts';
 import { CSVExternalSecondaryInstanceSource } from './sources/CSVExternalSecondaryInstance.ts';
 import type { ExternalSecondaryInstanceResourceOptions } from './sources/ExternalSecondaryInstanceResource.ts';
 import { ExternalSecondaryInstanceResource } from './sources/ExternalSecondaryInstanceResource.ts';
@@ -65,6 +66,10 @@ export class SecondaryInstancesDefinition
 					resourceURL,
 					options
 				);
+
+				if (resource == null) {
+					return new BlankSecondaryInstanceSource(instanceId, resourceURL, domElement);
+				}
 
 				switch (resource.format) {
 					case 'csv':

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/BlankSecondaryInstanceSource.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/BlankSecondaryInstanceSource.ts
@@ -1,0 +1,40 @@
+import { XFORMS_NAMESPACE_URI } from '@getodk/common/constants/xmlns.ts';
+import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import type { StaticNode } from '../../../../integration/xpath/static-dom/StaticNode.ts';
+import { parseStaticDocumentFromDOMSubtree } from '../../../shared/parseStaticDocumentFromDOMSubtree.ts';
+import type { DOMSecondaryInstanceElement } from '../../../XFormDOM.ts';
+import { SecondaryInstanceDefinition } from '../SecondaryInstanceDefinition.ts';
+import { SecondaryInstanceRootDefinition } from '../SecondaryInstanceRootDefinition.ts';
+import { SecondaryInstanceSource } from './SecondaryInstanceSource.ts';
+
+export class BlankSecondaryInstanceSource extends SecondaryInstanceSource<'blank'> {
+	constructor(
+		instanceId: string,
+		resourceURL: JRResourceURL,
+		domElement: DOMSecondaryInstanceElement
+	) {
+		super('blank', instanceId, resourceURL, domElement);
+	}
+
+	/**
+	 * @todo there is really no sense in using the DOM for this, other than it was
+	 * quicker/more ergonomic than constructing the requisite {@link StaticNode}
+	 * structures directly. Pretty good sign those constructor signatures could
+	 * use some TLC!
+	 */
+	parseDefinition(): SecondaryInstanceDefinition {
+		const xmlDocument = this.domElement.ownerDocument.implementation.createDocument(
+			XFORMS_NAMESPACE_URI,
+			'instance'
+		);
+		const instanceElement = xmlDocument.documentElement;
+
+		instanceElement.setAttribute('id', this.instanceId);
+
+		return parseStaticDocumentFromDOMSubtree(
+			SecondaryInstanceDefinition,
+			SecondaryInstanceRootDefinition,
+			instanceElement
+		);
+	}
+}

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/CSVExternalSecondaryInstance.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/CSVExternalSecondaryInstance.ts
@@ -1,0 +1,9 @@
+import { ErrorProductionDesignPendingError } from '../../../../error/ErrorProductionDesignPendingError.ts';
+import { SecondaryInstanceDefinition } from '../SecondaryInstanceDefinition.ts';
+import { ExternalSecondaryInstanceSource } from './ExternalSecondaryInstanceSource.ts';
+
+export class CSVExternalSecondaryInstanceSource extends ExternalSecondaryInstanceSource<'csv'> {
+	parseDefinition(): SecondaryInstanceDefinition {
+		throw new ErrorProductionDesignPendingError('CSV external secondary instance support pending');
+	}
+}

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/CSVExternalSecondaryInstance.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/CSVExternalSecondaryInstance.ts
@@ -275,7 +275,7 @@ export class CSVExternalSecondaryInstanceSource extends ExternalSecondaryInstanc
 	}
 
 	parseDefinition(): SecondaryInstanceDefinition {
-		const csvData = this.resource.data;
+		const csvData = this.resource.data.replace(/[\n\r]+$/, '');
 		const { columns, meta } = this.parseCSVHeader(csvData);
 		const { rows } = this.parseCSVRows(csvData, {
 			columns,

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/CSVExternalSecondaryInstance.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/CSVExternalSecondaryInstance.ts
@@ -1,9 +1,288 @@
+import { XFORMS_NAMESPACE_URI } from '@getodk/common/constants/xmlns.ts';
+import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import * as papa from 'papaparse';
 import { ErrorProductionDesignPendingError } from '../../../../error/ErrorProductionDesignPendingError.ts';
+import { StaticAttribute } from '../../../../integration/xpath/static-dom/StaticAttribute.ts';
+import { StaticElement } from '../../../../integration/xpath/static-dom/StaticElement.ts';
+import { StaticText } from '../../../../integration/xpath/static-dom/StaticText.ts';
 import { SecondaryInstanceDefinition } from '../SecondaryInstanceDefinition.ts';
+import { SecondaryInstanceRootDefinition } from '../SecondaryInstanceRootDefinition.ts';
 import { ExternalSecondaryInstanceSource } from './ExternalSecondaryInstanceSource.ts';
 
+type CSVColumn = string;
+type CSVRow = readonly CSVColumn[];
+
+type AssertCSVRow = (columns: unknown) => asserts columns is CSVRow;
+
+/**
+ * Based on {@link https://github.com/getodk/central-frontend/commit/29cebcc870c9be70ab0d222e3349e34639045d19}
+ *
+ * Central performs this check for header and rows. A comment is included there for the header check, but the logic is the same in both cases.
+ */
+const rejectNullCharacters = (cell: string) => {
+	if (cell.includes('\0')) {
+		throw new ErrorProductionDesignPendingError(`Failed to parse CSV: null character`);
+	}
+};
+
+const assertCSVRow: AssertCSVRow = (columns) => {
+	if (!Array.isArray(columns)) {
+		throw new ErrorProductionDesignPendingError('Failed to parse CSV columns');
+	}
+
+	for (const [index, column] of columns.entries()) {
+		if (typeof column !== 'string') {
+			throw new ErrorProductionDesignPendingError(`Failed to parse CSV column at index ${index}`);
+		}
+
+		rejectNullCharacters(column);
+	}
+};
+
+type AssertPapaparseSuccess = (
+	resourceURL: JRResourceURL,
+	errors: readonly papa.ParseError[]
+) => asserts errors is readonly [];
+
+const assertPapaparseSuccess: AssertPapaparseSuccess = (resourceURL, errors) => {
+	if (errors.length > 0) {
+		const cause = new AggregateError(errors);
+		throw new ErrorProductionDesignPendingError(
+			`Failed to parse CSV external secondary instance ${resourceURL.href}`,
+			{ cause }
+		);
+	}
+};
+
+interface ParsedCSVHeader {
+	readonly columns: CSVRow;
+	readonly errors: readonly [];
+	readonly meta: papa.ParseMeta;
+}
+
+interface ParseCSVOptions {
+	readonly columns: readonly string[];
+	readonly delimiter: string;
+}
+
+const stripTrailingEmptyCells = (columns: CSVRow, row: CSVRow): CSVRow => {
+	const result = row.slice();
+
+	while (result.length > columns.length && result.at(-1) === '') {
+		result.pop();
+	}
+
+	return result;
+};
+
+interface ParsedCSVRows {
+	readonly rows: readonly CSVRow[];
+	readonly errors: readonly [];
+	readonly meta: papa.ParseMeta;
+}
+
+interface CSVExternalSecondaryInstanceItemColumn {
+	readonly columnName: string;
+	readonly cellValue: string;
+}
+
+type CSVExternalSecondaryInstanceItem = readonly CSVExternalSecondaryInstanceItemColumn[];
+
+class CSVExternalSecondaryInstanceColumnElement extends StaticElement {
+	constructor(parent: StaticElement, column: CSVExternalSecondaryInstanceItemColumn) {
+		const { columnName, cellValue } = column;
+
+		super(
+			parent,
+			() => [],
+			(self) => [new StaticText(self, cellValue)],
+			{
+				namespaceURI: XFORMS_NAMESPACE_URI,
+				localName: columnName,
+			}
+		);
+	}
+}
+
+class CSVExternalSecondaryInstanceItemElement extends StaticElement {
+	constructor(parent: StaticElement, item: CSVExternalSecondaryInstanceItem) {
+		super(
+			parent,
+			() => [],
+			(self) => {
+				return item.map((column) => {
+					return new CSVExternalSecondaryInstanceColumnElement(self, column);
+				});
+			},
+			{
+				namespaceURI: XFORMS_NAMESPACE_URI,
+				localName: 'item',
+			}
+		);
+	}
+}
+
+class CSVExternalSecondaryInstanceRootElement extends StaticElement {
+	constructor(parent: StaticElement, items: readonly CSVExternalSecondaryInstanceItem[]) {
+		super(
+			parent,
+			() => [],
+			(self) => {
+				return items.map((item) => {
+					return new CSVExternalSecondaryInstanceItemElement(self, item);
+				});
+			},
+			{
+				namespaceURI: XFORMS_NAMESPACE_URI,
+				localName: 'root',
+			}
+		);
+	}
+}
+
+class CSVExternalSecondaryInstanceDocumentElement extends SecondaryInstanceRootDefinition {
+	constructor(
+		instanceId: string,
+		parent: CSVExternalSecondaryInstanceDefinition,
+		items: readonly CSVExternalSecondaryInstanceItem[]
+	) {
+		super(
+			parent,
+			(self) => [
+				new StaticAttribute(self, {
+					namespaceURI: XFORMS_NAMESPACE_URI,
+					localName: 'id',
+					value: instanceId,
+				}),
+			],
+			(self) => [new CSVExternalSecondaryInstanceRootElement(self, items)],
+			{
+				namespaceURI: XFORMS_NAMESPACE_URI,
+				localName: 'instance',
+			}
+		);
+	}
+}
+
+class CSVExternalSecondaryInstanceDefinition extends SecondaryInstanceDefinition {
+	constructor(instanceId: string, items: readonly CSVExternalSecondaryInstanceItem[]) {
+		super((self) => {
+			return new CSVExternalSecondaryInstanceDocumentElement(instanceId, self, items);
+		});
+	}
+}
+
 export class CSVExternalSecondaryInstanceSource extends ExternalSecondaryInstanceSource<'csv'> {
+	/**
+	 * Based on
+	 * {@link https://github.com/getodk/central-frontend/blob/42c9277709e593480d1462e28b4be5f1364532b7/src/util/csv.js#L79} (and {@link https://github.com/getodk/central-frontend/blob/42c9277709e593480d1462e28b4be5f1364532b7/src/util/csv.js#L13}).
+	 *
+	 * The most significant deviations at time of writing:
+	 *
+	 * - we have already retrieved the CSV resource, so we are parsing the raw CSV data directly.
+	 * - we have no need for asynchronous/streaming parsing at this point in the
+	 *   form initialization process, so we can dispense with those details of the
+	 *   {@link papa | papaparse} API/config.
+	 */
+	private parseCSVHeader(csvData: string): ParsedCSVHeader {
+		const { data, errors, meta } = papa.parse(csvData, {
+			delimitersToGuess: [',', ';', '\t', '|'],
+			download: false,
+			preview: 1,
+		});
+		const [columns = []] = data;
+
+		assertCSVRow(columns);
+		assertPapaparseSuccess(this.resourceURL, errors);
+
+		return {
+			errors,
+			meta,
+			columns,
+		};
+	}
+
+	/**
+	 * Largely based on {@link https://github.com/getodk/central-frontend/blob/42c9277709e593480d1462e28b4be5f1364532b7/src/util/csv.js#L170}
+	 */
+	private parseCSVRows(csvData: string, options: ParseCSVOptions): ParsedCSVRows {
+		const { columns, delimiter } = options;
+		const { data, errors, meta } = papa.parse(csvData, {
+			delimiter,
+			download: false,
+		});
+
+		assertPapaparseSuccess(this.resourceURL, errors);
+
+		const rowData = data.slice(1);
+		const lastRowIndex = rowData.length - 1;
+
+		let stripLastRow = false;
+
+		const rows = rowData.map((values, index) => {
+			assertCSVRow(values);
+
+			const rowIndex = index + 1;
+
+			// Central: Remove trailing empty cells.
+			const row = stripTrailingEmptyCells(columns, values);
+
+			// Central: Skip trailing empty rows and do not check them for warnings.
+			// Throw for an empty row that is not trailing.
+			if (row.every((cell) => cell === '')) {
+				if (index === lastRowIndex) {
+					stripLastRow = true;
+				} else {
+					throw new ErrorProductionDesignPendingError(
+						`Failed to parse CSV row ${rowIndex}: unexpected empty row`
+					);
+				}
+			}
+
+			// Central: Throw if there are too many cells.
+			if (row.length > columns.length) {
+				throw new ErrorProductionDesignPendingError(
+					`Failed to parse CSV row ${rowIndex}: expected ${columns.length} columns, got ${row.length}`
+				);
+			}
+
+			return row;
+		});
+
+		if (stripLastRow) {
+			rows.pop();
+		}
+
+		return {
+			errors,
+			meta,
+			rows,
+		};
+	}
+
+	private toItems(
+		columns: CSVRow,
+		rows: readonly CSVRow[]
+	): readonly CSVExternalSecondaryInstanceItem[] {
+		return rows.map((row) => {
+			return columns.map((columnName, index) => {
+				return {
+					columnName,
+					cellValue: row[index] ?? '',
+				};
+			});
+		});
+	}
+
 	parseDefinition(): SecondaryInstanceDefinition {
-		throw new ErrorProductionDesignPendingError('CSV external secondary instance support pending');
+		const csvData = this.resource.data;
+		const { columns, meta } = this.parseCSVHeader(csvData);
+		const { rows } = this.parseCSVRows(csvData, {
+			columns,
+			delimiter: meta.delimiter,
+		});
+		const items = this.toItems(columns, rows);
+
+		return new CSVExternalSecondaryInstanceDefinition(this.instanceId, items);
 	}
 }

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/ExternalSecondaryInstanceResource.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/ExternalSecondaryInstanceResource.ts
@@ -132,8 +132,12 @@ export class ExternalSecondaryInstanceResource<
 		instanceId: string,
 		resourceURL: JRResourceURL,
 		options: ExternalSecondaryInstanceResourceOptions
-	): Promise<LoadedExternalSecondaryInstanceResource> {
+	): Promise<LoadedExternalSecondaryInstanceResource | null> {
 		const response = await options.fetchResource(resourceURL);
+
+		if (response.status === 404) {
+			return null;
+		}
 
 		assertResponseSuccess(resourceURL, response);
 

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/ExternalSecondaryInstanceResource.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/ExternalSecondaryInstanceResource.ts
@@ -1,0 +1,167 @@
+import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import type { FetchResource, FetchResourceResponse } from '../../../../client/resources.ts';
+import { ErrorProductionDesignPendingError } from '../../../../error/ErrorProductionDesignPendingError.ts';
+import { FormAttachmentResource } from '../../../attachments/FormAttachmentResource.ts';
+import type { ExternalSecondaryInstanceSourceFormat } from './SecondaryInstanceSource.ts';
+
+const assertResponseSuccess = (resourceURL: JRResourceURL, response: FetchResourceResponse) => {
+	const { ok = true, status = 200 } = response;
+
+	if (!ok || status !== 200) {
+		throw new ErrorProductionDesignPendingError(`Failed to load ${resourceURL.href}`);
+	}
+};
+
+const stripContentTypeCharset = (contentType: string): string => {
+	return contentType.replace(/;charset=.*$/, '');
+};
+
+const getResponseContentType = (response: FetchResourceResponse): string | null => {
+	const { headers } = response;
+
+	if (headers == null) {
+		return null;
+	}
+
+	const contentType = headers.get('content-type');
+
+	if (contentType != null) {
+		return stripContentTypeCharset(contentType);
+	}
+
+	if (headers instanceof Headers) {
+		return contentType;
+	}
+
+	for (const [header, value] of headers) {
+		if (header.toLowerCase() === 'content-type') {
+			return stripContentTypeCharset(value);
+		}
+	}
+
+	return null;
+};
+
+interface ExternalSecondaryInstanceResourceMetadata<
+	Format extends ExternalSecondaryInstanceSourceFormat = ExternalSecondaryInstanceSourceFormat,
+> {
+	readonly contentType: string;
+	readonly format: Format;
+}
+
+const inferSecondaryInstanceResourceMetadata = (
+	resourceURL: JRResourceURL,
+	contentType: string | null,
+	data: string
+): ExternalSecondaryInstanceResourceMetadata => {
+	const url = resourceURL.href;
+
+	let format: ExternalSecondaryInstanceSourceFormat | null = null;
+
+	if (url.endsWith('.xml') && data.startsWith('<')) {
+		format = 'xml';
+	} else if (url.endsWith('.csv')) {
+		format = 'csv';
+	} else if (url.endsWith('.geojson') && data.startsWith('{')) {
+		format = 'geojson';
+	}
+
+	if (format == null) {
+		throw new ErrorProductionDesignPendingError(
+			`Failed to infer external secondary instance format/content type for resource ${url} (response content type: ${contentType}, data: ${data})`
+		);
+	}
+
+	return {
+		contentType: contentType ?? 'text/plain',
+		format,
+	};
+};
+
+const detectSecondaryInstanceResourceMetadata = (
+	resourceURL: JRResourceURL,
+	response: FetchResourceResponse,
+	data: string
+): ExternalSecondaryInstanceResourceMetadata => {
+	const contentType = getResponseContentType(response);
+
+	if (contentType == null || contentType === 'text/plain') {
+		return inferSecondaryInstanceResourceMetadata(resourceURL, contentType, data);
+	}
+
+	let format: ExternalSecondaryInstanceSourceFormat | null = null;
+
+	switch (contentType) {
+		case 'text/csv':
+			format = 'csv';
+			break;
+
+		case 'application/geo+json':
+			format = 'geojson';
+			break;
+
+		case 'text/xml':
+			format = 'xml';
+			break;
+	}
+
+	if (format == null) {
+		throw new ErrorProductionDesignPendingError(
+			`Failed to detect external secondary instance format for resource ${resourceURL.href} (response content type: ${contentType}, data: ${data})`
+		);
+	}
+
+	return {
+		contentType,
+		format,
+	};
+};
+
+export interface ExternalSecondaryInstanceResourceOptions {
+	readonly fetchResource: FetchResource<JRResourceURL>;
+}
+
+type LoadedExternalSecondaryInstanceResource = {
+	[Format in ExternalSecondaryInstanceSourceFormat]: ExternalSecondaryInstanceResource<Format>;
+}[ExternalSecondaryInstanceSourceFormat];
+
+export class ExternalSecondaryInstanceResource<
+	Format extends ExternalSecondaryInstanceSourceFormat = ExternalSecondaryInstanceSourceFormat,
+> extends FormAttachmentResource<'secondary-instance'> {
+	static async load(
+		instanceId: string,
+		resourceURL: JRResourceURL,
+		options: ExternalSecondaryInstanceResourceOptions
+	): Promise<LoadedExternalSecondaryInstanceResource> {
+		const response = await options.fetchResource(resourceURL);
+
+		assertResponseSuccess(resourceURL, response);
+
+		const data = await response.text();
+		const metadata = detectSecondaryInstanceResourceMetadata(resourceURL, response, data);
+
+		return new this(
+			response.status ?? null,
+			instanceId,
+			resourceURL,
+			metadata,
+			data
+		) satisfies ExternalSecondaryInstanceResource as LoadedExternalSecondaryInstanceResource;
+	}
+
+	readonly format: Format;
+
+	protected constructor(
+		readonly responseStatus: number | null,
+		readonly instanceId: string,
+		resourceURL: JRResourceURL,
+		metadata: ExternalSecondaryInstanceResourceMetadata<Format>,
+		data: string
+	) {
+		const { contentType, format } = metadata;
+
+		super('secondary-instance', resourceURL, contentType, data);
+
+		this.format = format;
+	}
+}

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/ExternalSecondaryInstanceSource.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/ExternalSecondaryInstanceSource.ts
@@ -1,0 +1,22 @@
+import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import type { DOMSecondaryInstanceElement } from '../../../XFormDOM.ts';
+import type { ExternalSecondaryInstanceResource } from './ExternalSecondaryInstanceResource.ts';
+import type { ExternalSecondaryInstanceSourceFormat } from './SecondaryInstanceSource.ts';
+import { SecondaryInstanceSource } from './SecondaryInstanceSource.ts';
+
+export abstract class ExternalSecondaryInstanceSource<
+	Format extends ExternalSecondaryInstanceSourceFormat = ExternalSecondaryInstanceSourceFormat,
+> extends SecondaryInstanceSource<Format> {
+	override readonly resourceURL: JRResourceURL;
+
+	constructor(
+		domElement: DOMSecondaryInstanceElement,
+		protected readonly resource: ExternalSecondaryInstanceResource<Format>
+	) {
+		const { format, instanceId, resourceURL } = resource;
+
+		super(format, instanceId, resourceURL, domElement);
+
+		this.resourceURL = resourceURL;
+	}
+}

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/GeoJSONExternalSecondaryInstance.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/GeoJSONExternalSecondaryInstance.ts
@@ -1,0 +1,11 @@
+import { ErrorProductionDesignPendingError } from '../../../../error/ErrorProductionDesignPendingError.ts';
+import { SecondaryInstanceDefinition } from '../SecondaryInstanceDefinition.ts';
+import { ExternalSecondaryInstanceSource } from './ExternalSecondaryInstanceSource.ts';
+
+export class GeoJSONExternalSecondaryInstanceSource extends ExternalSecondaryInstanceSource<'geojson'> {
+	parseDefinition(): SecondaryInstanceDefinition {
+		throw new ErrorProductionDesignPendingError(
+			'GeoJSON external secondary instance support pending'
+		);
+	}
+}

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/GeoJSONExternalSecondaryInstance.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/GeoJSONExternalSecondaryInstance.ts
@@ -1,11 +1,414 @@
+import { XFORMS_NAMESPACE_URI } from '@getodk/common/constants/xmlns.ts';
+import { UnreachableError } from '@getodk/common/lib/error/UnreachableError.ts';
+import { assertUnknownArray } from '@getodk/common/lib/type-assertions/assertUnknownArray.ts';
+import type { UnknownObject } from '@getodk/common/lib/type-assertions/assertUnknownObject.ts';
+import { assertUnknownObject } from '@getodk/common/lib/type-assertions/assertUnknownObject.ts';
+import type {
+	GeoJsonProperties as BaseGeoJSONProperties,
+	LineString as BaseLineString,
+	Point as BasePoint,
+	Polygon as BasePolygon,
+	Feature as GeoJSONFeature,
+	FeatureCollection as GeoJSONFeatureCollection,
+} from 'geojson';
 import { ErrorProductionDesignPendingError } from '../../../../error/ErrorProductionDesignPendingError.ts';
+import { StaticAttribute } from '../../../../integration/xpath/static-dom/StaticAttribute.ts';
+import { StaticElement } from '../../../../integration/xpath/static-dom/StaticElement.ts';
+import { StaticText } from '../../../../integration/xpath/static-dom/StaticText.ts';
 import { SecondaryInstanceDefinition } from '../SecondaryInstanceDefinition.ts';
+import { SecondaryInstanceRootDefinition } from '../SecondaryInstanceRootDefinition.ts';
 import { ExternalSecondaryInstanceSource } from './ExternalSecondaryInstanceSource.ts';
+
+const FEATURE_COLLECTION = 'FeatureCollection';
+type FEATURE_COLLECTION = typeof FEATURE_COLLECTION;
+
+const FEATURE = 'Feature';
+type FEATURE = typeof FEATURE;
+
+const POINT = 'Point';
+type POINT = typeof POINT;
+
+const LINE_STRING = 'LineString';
+type LINE_STRING = typeof LINE_STRING;
+
+const POLYGON = 'Polygon';
+type POLYGON = typeof POLYGON;
+
+type SupportedGeometryType = LINE_STRING | POINT | POLYGON;
+
+const SUPPORTED_TYPES = new Set<SupportedGeometryType>([POINT, LINE_STRING, POLYGON]);
+
+const SUPPORTED_TYPES_MESSAGE = 'Only Points, LineStrings and Polygons are currently supported';
+
+type LongLatCoordinates = readonly [longitude: number, latitude: number];
+
+interface UnknownCoordinatesObject {
+	readonly coordinates: unknown;
+}
+
+// prettier-ignore
+type ExtensibleBaseGeoJSONType<T> =
+	T extends UnknownCoordinatesObject
+		? Readonly<Omit<T, 'coordinates'>>
+		: Readonly<T>;
+
+interface Point extends ExtensibleBaseGeoJSONType<BasePoint> {
+	readonly coordinates: LongLatCoordinates;
+}
+
+type LineStringCoordinates = readonly LongLatCoordinates[];
+
+interface LineString extends ExtensibleBaseGeoJSONType<BaseLineString> {
+	readonly coordinates: LineStringCoordinates;
+}
+
+// prettier-ignore
+type PolygonCoordinates =
+	| readonly []
+	| readonly [LineStringCoordinates];
+
+interface Polygon extends ExtensibleBaseGeoJSONType<BasePolygon> {
+	readonly coordinates: PolygonCoordinates;
+}
+
+// prettier-ignore
+type SupportedGeometry =
+	| LineString
+	| Point
+	| Polygon;
+
+interface UnparsedGeometry<Type extends SupportedGeometryType> {
+	readonly type: Type;
+	readonly coordinates: readonly unknown[];
+}
+
+type UnknownGeometry = {
+	[Type in SupportedGeometryType]: UnparsedGeometry<Type>;
+}[SupportedGeometryType];
+
+/**
+ * This is a stricter variant of {@link BaseGeoJSONProperties}.
+ */
+type GeoJSONProperties = UnknownObject;
+
+/**
+ * This is our supported variant/subset of {@link GeoJSONFeature} where:
+ *
+ * - {@link geometry} is parsed/validated to be one of our
+ *   {@link SupportedGeometry | supported geometries}
+ *
+ * - all properties and non-primitive property values are deeply `readonly`
+ */
+interface Feature {
+	readonly type: FEATURE;
+	readonly geometry: SupportedGeometry;
+	readonly id?: number | string | undefined;
+
+	/**
+	 * Perhaps surprising: this property is required by the
+	 * {@link https://datatracker.ietf.org/doc/html/rfc7946#section-3.2 | GeoJSON spec}!
+	 */
+	readonly properties: GeoJSONProperties | null;
+}
+
+/**
+ * This is our supported variant/subset of {@link GeoJSONFeatureCollection}, as
+ * described for {@link Feature}.
+ */
+interface FeatureCollection {
+	readonly type: FEATURE_COLLECTION;
+	readonly features: readonly Feature[];
+}
+
+type AssertLongLatCoordinates = (data: unknown) => asserts data is LongLatCoordinates;
+
+const assertLongLatCoordinates: AssertLongLatCoordinates = (data) => {
+	assertUnknownArray(data);
+
+	const [longitude, latitude, ...rest] = data;
+
+	if (typeof longitude === 'number' && typeof latitude === 'number' && rest.length === 0) {
+		return;
+	}
+
+	throw new ErrorProductionDesignPendingError(
+		`Only ${POINT}s with latitude and longitude are currently supported`
+	);
+};
+
+type AssertUnknownGeometry = (value: unknown) => asserts value is UnknownGeometry;
+
+const assertUnknownGeometry: AssertUnknownGeometry = (value) => {
+	assertUnknownObject(value);
+
+	if (!SUPPORTED_TYPES.has(value.type as SupportedGeometryType)) {
+		throw new ErrorProductionDesignPendingError(SUPPORTED_TYPES_MESSAGE);
+	}
+
+	assertUnknownArray(value.coordinates);
+};
+
+type AssertSupportedGeometry = (value: unknown) => asserts value is SupportedGeometry;
+
+const assertSupportedGeometry: AssertSupportedGeometry = (value) => {
+	assertUnknownGeometry(value);
+
+	switch (value.type) {
+		case LINE_STRING:
+			value.coordinates.forEach(assertLongLatCoordinates);
+			break;
+
+		case POINT:
+			assertLongLatCoordinates(value.coordinates);
+			break;
+
+		case POLYGON: {
+			const [coordinates, ...rest] = value.coordinates;
+
+			if (coordinates == null) {
+				return;
+			}
+
+			if (rest.length > 0) {
+				throw new ErrorProductionDesignPendingError(
+					`Unsupported ${POLYGON}: multiple sets of coordinates`
+				);
+			}
+
+			assertUnknownArray(coordinates);
+			coordinates.forEach(assertLongLatCoordinates);
+
+			break;
+		}
+
+		default:
+			throw new UnreachableError(value);
+	}
+};
+
+type AssertFeature = (value: unknown) => asserts value is Feature;
+
+const assertFeature: AssertFeature = (value) => {
+	assertUnknownObject(value);
+
+	const { geometry, type, id, properties } = value;
+
+	if (type !== FEATURE) {
+		throw new ErrorProductionDesignPendingError(
+			`Expected Feature.type ${FEATURE}, got ${String(type)}`
+		);
+	}
+
+	assertSupportedGeometry(geometry);
+
+	if ('id' in value) {
+		const typeofId = typeof id;
+
+		switch (typeofId) {
+			case 'number':
+			case 'string':
+			case 'undefined':
+				break;
+
+			default:
+				throw new ErrorProductionDesignPendingError(
+					`Unexpected type of feature id property: ${typeofId}`
+				);
+		}
+	}
+
+	// Note: atypical strict check for `null` value! The `properties` key is
+	// required per
+	if (properties === null) {
+		return;
+	}
+
+	assertUnknownObject(properties);
+};
+
+type AssertFeatureCollection = (value: unknown) => asserts value is FeatureCollection;
+
+const assertFeatureCollection: AssertFeatureCollection = (value) => {
+	assertUnknownObject(value);
+
+	const { type, features } = value;
+
+	if (type !== FEATURE_COLLECTION) {
+		throw new ErrorProductionDesignPendingError(
+			`Expected FeatureCollection.type ${FEATURE_COLLECTION}, got ${String(type)}`
+		);
+	}
+
+	assertUnknownArray(features);
+
+	features.forEach(assertFeature);
+};
+
+type SerializedCoordinates = `${LongLatCoordinates[1]} ${LongLatCoordinates[0]} 0 0`;
+
+const serializeCoordinates = (coordinates: LongLatCoordinates): SerializedCoordinates => {
+	const [longitude, latitude] = coordinates;
+
+	return `${latitude} ${longitude} 0 0`;
+};
+
+class GeoJSONSecondaryInstanceFeatureGeometryElement extends StaticElement {
+	static from(
+		parent: StaticElement,
+		feature: Feature
+	): GeoJSONSecondaryInstanceFeatureGeometryElement {
+		const { geometry } = feature;
+
+		switch (geometry.type) {
+			case 'LineString':
+				return new this(parent, geometry.coordinates);
+
+			case 'Point':
+				return new this(parent, [geometry.coordinates]);
+
+			case 'Polygon':
+				return new this(parent, geometry.coordinates[0] ?? []);
+
+			default:
+				throw new UnreachableError(geometry);
+		}
+	}
+
+	constructor(parent: StaticElement, points: readonly LongLatCoordinates[]) {
+		const values = points.map(serializeCoordinates);
+		const value = values.join('; ');
+
+		super(
+			parent,
+			() => [],
+			(self) => [new StaticText(self, value)],
+			{
+				namespaceURI: XFORMS_NAMESPACE_URI,
+				localName: 'geometry',
+			}
+		);
+	}
+}
+
+class GeoJSONSecondaryInstanceFeaturePropertyElement extends StaticElement {
+	static *buildPropertyElements(
+		parent: StaticElement,
+		feature: Feature
+	): Iterable<GeoJSONSecondaryInstanceFeaturePropertyElement> {
+		const { properties } = feature;
+
+		if (properties == null) {
+			return [];
+		}
+
+		const { id: propertiesId, ...nonIdProperties } = properties;
+		const { id = propertiesId } = feature;
+
+		if (id !== undefined) {
+			yield new this(parent, 'id', String(id));
+		}
+
+		for (const [propertyName, propertyValue] of Object.entries(nonIdProperties)) {
+			yield new this(parent, propertyName, String(propertyValue));
+		}
+	}
+
+	constructor(parent: StaticElement, propertyName: string, propertyValue: string) {
+		super(
+			parent,
+			() => [],
+			(self) => [new StaticText(self, propertyValue)],
+			{
+				namespaceURI: XFORMS_NAMESPACE_URI,
+				localName: propertyName,
+			}
+		);
+	}
+}
+
+class GeoJSONSecondaryInstanceFeatureItemElement extends StaticElement {
+	constructor(parent: StaticElement, feature: Feature) {
+		super(
+			parent,
+			() => [],
+			(self) => {
+				const geometry = GeoJSONSecondaryInstanceFeatureGeometryElement.from(self, feature);
+				const properties = GeoJSONSecondaryInstanceFeaturePropertyElement.buildPropertyElements(
+					self,
+					feature
+				);
+
+				return [geometry, ...properties];
+			},
+			{
+				namespaceURI: XFORMS_NAMESPACE_URI,
+				localName: 'item',
+			}
+		);
+	}
+}
+
+class GeoJSONSecondaryInstanceRootElement extends StaticElement {
+	constructor(parent: StaticElement, featureCollection: FeatureCollection) {
+		super(
+			parent,
+			() => [],
+			(self) => {
+				return featureCollection.features.map((feature) => {
+					return new GeoJSONSecondaryInstanceFeatureItemElement(self, feature);
+				});
+			},
+			{
+				namespaceURI: XFORMS_NAMESPACE_URI,
+				localName: 'root',
+			}
+		);
+	}
+}
+
+class GeoJSONExternalSecondaryInstanceDocumentElement extends SecondaryInstanceRootDefinition {
+	constructor(
+		instanceId: string,
+		parent: GeoJSONExternalSecondaryInstanceDefinition,
+		featureCollection: FeatureCollection
+	) {
+		super(
+			parent,
+			(self) => [
+				new StaticAttribute(self, {
+					namespaceURI: XFORMS_NAMESPACE_URI,
+					localName: 'id',
+					value: instanceId,
+				}),
+			],
+			(self) => [new GeoJSONSecondaryInstanceRootElement(self, featureCollection)],
+			{
+				namespaceURI: XFORMS_NAMESPACE_URI,
+				localName: 'instance',
+			}
+		);
+	}
+}
+
+class GeoJSONExternalSecondaryInstanceDefinition extends SecondaryInstanceDefinition {
+	constructor(instanceId: string, featureCollection: FeatureCollection) {
+		super((self) => {
+			return new GeoJSONExternalSecondaryInstanceDocumentElement(
+				instanceId,
+				self,
+				featureCollection
+			);
+		});
+	}
+}
 
 export class GeoJSONExternalSecondaryInstanceSource extends ExternalSecondaryInstanceSource<'geojson'> {
 	parseDefinition(): SecondaryInstanceDefinition {
-		throw new ErrorProductionDesignPendingError(
-			'GeoJSON external secondary instance support pending'
-		);
+		const { data } = this.resource;
+		const value = JSON.parse(data) as unknown;
+
+		assertFeatureCollection(value);
+
+		return new GeoJSONExternalSecondaryInstanceDefinition(this.instanceId, value);
 	}
 }

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/InternalSecondaryInstanceSource.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/InternalSecondaryInstanceSource.ts
@@ -1,0 +1,19 @@
+import { parseStaticDocumentFromDOMSubtree } from '../../../shared/parseStaticDocumentFromDOMSubtree.ts';
+import type { DOMSecondaryInstanceElement } from '../../../XFormDOM.ts';
+import { SecondaryInstanceDefinition } from '../SecondaryInstanceDefinition.ts';
+import { SecondaryInstanceRootDefinition } from '../SecondaryInstanceRootDefinition.ts';
+import { SecondaryInstanceSource } from './SecondaryInstanceSource.ts';
+
+export class InternalSecondaryInstanceSource extends SecondaryInstanceSource<'internal'> {
+	constructor(instanceId: string, resourceURL: null, domElement: DOMSecondaryInstanceElement) {
+		super('internal', instanceId, resourceURL, domElement);
+	}
+
+	parseDefinition(): SecondaryInstanceDefinition {
+		return parseStaticDocumentFromDOMSubtree(
+			SecondaryInstanceDefinition,
+			SecondaryInstanceRootDefinition,
+			this.domElement
+		);
+	}
+}

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/SecondaryInstanceSource.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/SecondaryInstanceSource.ts
@@ -1,0 +1,27 @@
+import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import type { DOMSecondaryInstanceElement } from '../../../XFormDOM.ts';
+import type { SecondaryInstanceDefinition } from '../SecondaryInstanceDefinition.ts';
+
+// prettier-ignore
+export type ExternalSecondaryInstanceSourceFormat =
+	| 'csv'
+	| 'geojson'
+	| 'xml';
+
+// prettier-ignore
+export type SecondaryInstanceSourceFormat =
+	| ExternalSecondaryInstanceSourceFormat
+	| 'internal';
+
+export abstract class SecondaryInstanceSource<
+	Format extends SecondaryInstanceSourceFormat = SecondaryInstanceSourceFormat,
+> {
+	constructor(
+		readonly format: Format,
+		readonly instanceId: string,
+		readonly resourceURL: JRResourceURL | null,
+		readonly domElement: DOMSecondaryInstanceElement
+	) {}
+
+	abstract parseDefinition(): SecondaryInstanceDefinition;
+}

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/SecondaryInstanceSource.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/SecondaryInstanceSource.ts
@@ -10,8 +10,10 @@ export type ExternalSecondaryInstanceSourceFormat =
 
 // prettier-ignore
 export type SecondaryInstanceSourceFormat =
+	// eslint-disable-next-line @typescript-eslint/sort-type-constituents
 	| ExternalSecondaryInstanceSourceFormat
-	| 'internal';
+	| 'internal'
+	| 'blank';
 
 export abstract class SecondaryInstanceSource<
 	Format extends SecondaryInstanceSourceFormat = SecondaryInstanceSourceFormat,

--- a/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/XMLExternalSecondaryInstanceSource.ts
+++ b/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/XMLExternalSecondaryInstanceSource.ts
@@ -1,0 +1,32 @@
+import { XFORMS_NAMESPACE_URI } from '@getodk/common/constants/xmlns.ts';
+import { parseStaticDocumentFromDOMSubtree } from '../../../shared/parseStaticDocumentFromDOMSubtree.ts';
+import { SecondaryInstanceDefinition } from '../SecondaryInstanceDefinition.ts';
+import { SecondaryInstanceRootDefinition } from '../SecondaryInstanceRootDefinition.ts';
+import { ExternalSecondaryInstanceSource } from './ExternalSecondaryInstanceSource.ts';
+import type { InternalSecondaryInstanceSource } from './InternalSecondaryInstanceSource.ts';
+
+export class XMLExternalSecondaryInstanceSource extends ExternalSecondaryInstanceSource<'xml'> {
+	/**
+	 * Note: this logic is a superset of the logic in
+	 * {@link InternalSecondaryInstanceSource.parseDefinition}. That subset is so
+	 * trivial/already sufficiently abstracted that it doesn't really make a lot
+	 * of sense to abstract further, but it might be worth considering if both
+	 * method implementations grow their responsibilities in the same ways.
+	 */
+	parseDefinition(): SecondaryInstanceDefinition {
+		const xmlDocument = this.domElement.ownerDocument.implementation.createDocument(
+			XFORMS_NAMESPACE_URI,
+			'instance'
+		);
+		const instanceElement = xmlDocument.documentElement;
+
+		instanceElement.setAttribute('id', this.instanceId);
+		instanceElement.innerHTML = this.resource.data;
+
+		return parseStaticDocumentFromDOMSubtree(
+			SecondaryInstanceDefinition,
+			SecondaryInstanceRootDefinition,
+			instanceElement
+		);
+	}
+}

--- a/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
+++ b/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ActiveLanguage } from '../../src/client/FormLanguage.ts';
 import type { OpaqueReactiveObjectFactory } from '../../src/client/OpaqueReactiveObjectFactory.ts';
 import type { RootNode } from '../../src/client/RootNode.ts';
+import { MISSING_RESOURCE_BEHAVIOR } from '../../src/client/constants.ts';
 import type { FetchResource } from '../../src/client/resources.ts';
 import { PrimaryInstance } from '../../src/instance/PrimaryInstance.ts';
 import { Root } from '../../src/instance/Root.ts';
@@ -85,6 +86,7 @@ describe('PrimaryInstance engine representation of instance state', () => {
 				createUniqueId,
 				fetchFormAttachment: fetchResource,
 				fetchFormDefinition: fetchResource,
+				missingResourceBehavior: MISSING_RESOURCE_BEHAVIOR.DEFAULT,
 				stateFactory,
 			});
 		});

--- a/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
+++ b/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
@@ -77,7 +77,8 @@ describe('PrimaryInstance engine representation of instance state', () => {
 		return scope.runTask(() => {
 			return new PrimaryInstance(scope, xformDefinition.model, {
 				createUniqueId,
-				fetchResource,
+				fetchFormAttachment: fetchResource,
+				fetchFormDefinition: fetchResource,
 				stateFactory,
 			});
 		});

--- a/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
+++ b/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
@@ -11,10 +11,10 @@ import {
 	title,
 } from '@getodk/common/test/fixtures/xform-dsl';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { FetchResource } from '../../src/client/EngineConfig.ts';
 import type { ActiveLanguage } from '../../src/client/FormLanguage.ts';
 import type { OpaqueReactiveObjectFactory } from '../../src/client/OpaqueReactiveObjectFactory.ts';
 import type { RootNode } from '../../src/client/RootNode.ts';
+import type { FetchResource } from '../../src/client/resources.ts';
 import { PrimaryInstance } from '../../src/instance/PrimaryInstance.ts';
 import { Root } from '../../src/instance/Root.ts';
 import { InstanceNode } from '../../src/instance/abstract/InstanceNode.ts';

--- a/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
+++ b/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
@@ -20,12 +20,15 @@ import { Root } from '../../src/instance/Root.ts';
 import { InstanceNode } from '../../src/instance/abstract/InstanceNode.ts';
 import { createReactiveScope, type ReactiveScope } from '../../src/lib/reactivity/scope.ts';
 import { createUniqueId } from '../../src/lib/unique-id.ts';
+import { XFormDOM } from '../../src/parse/XFormDOM.ts';
 import { XFormDefinition } from '../../src/parse/XFormDefinition.ts';
+import { SecondaryInstancesDefinition } from '../../src/parse/model/SecondaryInstance/SecondaryInstancesDefinition.ts';
 import { reactiveTestScope } from '../helpers/reactive/internal.ts';
 
 describe('PrimaryInstance engine representation of instance state', () => {
 	let scope: ReactiveScope;
 	let xformDefinition: XFormDefinition;
+	let secondaryInstances: SecondaryInstancesDefinition;
 
 	beforeEach(() => {
 		scope = createReactiveScope();
@@ -58,7 +61,10 @@ describe('PrimaryInstance engine representation of instance state', () => {
 			)
 		);
 
-		xformDefinition = new XFormDefinition(xform.asXml());
+		const xformDOM = XFormDOM.from(xform.asXml());
+
+		xformDefinition = new XFormDefinition(xformDOM);
+		secondaryInstances = SecondaryInstancesDefinition.loadSync(xformDOM);
 	});
 
 	afterEach(() => {
@@ -75,7 +81,7 @@ describe('PrimaryInstance engine representation of instance state', () => {
 	// directly, with caution.
 	const createPrimaryInstance = (stateFactory: OpaqueReactiveObjectFactory): PrimaryInstance => {
 		return scope.runTask(() => {
-			return new PrimaryInstance(scope, xformDefinition.model, {
+			return new PrimaryInstance(scope, xformDefinition.model, secondaryInstances, {
 				createUniqueId,
 				fetchFormAttachment: fetchResource,
 				fetchFormDefinition: fetchResource,

--- a/packages/xforms-engine/test/parse/XFormDefinition.test.ts
+++ b/packages/xforms-engine/test/parse/XFormDefinition.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { BodyDefinition } from '../../src/parse/body/BodyDefinition.ts';
 import { ModelDefinition } from '../../src/parse/model/ModelDefinition.ts';
 import { XFormDefinition } from '../../src/parse/XFormDefinition.ts';
+import { XFormDOM } from '../../src/parse/XFormDOM.ts';
 
 describe('XFormDefinition', () => {
 	const FORM_TITLE = 'Minimal XForm';
@@ -48,7 +49,9 @@ describe('XFormDefinition', () => {
 			)
 		);
 
-		xformDefinition = new XFormDefinition(xform.asXml());
+		const xformDOM = XFormDOM.from(xform.asXml());
+
+		xformDefinition = new XFormDefinition(xformDOM);
 	});
 
 	it('defines the form title', () => {

--- a/packages/xforms-engine/test/parse/body/BodyDefinition.test.ts
+++ b/packages/xforms-engine/test/parse/body/BodyDefinition.test.ts
@@ -15,6 +15,7 @@ import {
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { BodyDefinition } from '../../../src/parse/body/BodyDefinition.ts';
 import { XFormDefinition } from '../../../src/parse/XFormDefinition.ts';
+import { XFormDOM } from '../../../src/parse/XFormDOM.ts';
 
 describe('BodyDefinition', () => {
 	let bodyDefinition: BodyDefinition;
@@ -175,7 +176,9 @@ describe('BodyDefinition', () => {
 				)
 			)
 		);
-		const xformDefinition = new XFormDefinition(xform.asXml());
+
+		const xformDOM = XFormDOM.from(xform.asXml());
+		const xformDefinition = new XFormDefinition(xformDOM);
 
 		bodyDefinition = xformDefinition.body;
 	});

--- a/packages/xforms-engine/test/parse/model/BindDefinition.test.ts
+++ b/packages/xforms-engine/test/parse/model/BindDefinition.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@getodk/common/test/fixtures/xform-dsl/index.ts';
 import { describe, expect, it } from 'vitest';
 import { XFormDefinition } from '../../../src/parse/XFormDefinition.ts';
+import { XFormDOM } from '../../../src/parse/XFormDOM.ts';
 
 describe('BindDefinition', () => {
 	it.each([
@@ -45,7 +46,8 @@ describe('BindDefinition', () => {
 			body()
 		);
 
-		const xformDefinition = new XFormDefinition(xform.asXml());
+		const xformDOM = XFormDOM.from(xform.asXml());
+		const xformDefinition = new XFormDefinition(xformDOM);
 		const bindDefinition = xformDefinition.model.binds.get('/root/first-question');
 
 		expect(bindDefinition!.dataType).toEqual(expected);
@@ -90,7 +92,8 @@ describe('BindDefinition', () => {
 			body()
 		);
 
-		const xformDefinition = new XFormDefinition(xform.asXml());
+		const xformDOM = XFormDOM.from(xform.asXml());
+		const xformDefinition = new XFormDefinition(xformDOM);
 		const bindDefinition = xformDefinition.model.binds.get('/root/first-question');
 
 		expect(bindDefinition![computation]?.toString() ?? null).toEqual(expression);

--- a/packages/xforms-engine/test/parse/model/ModelBindMap.test.ts
+++ b/packages/xforms-engine/test/parse/model/ModelBindMap.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { BindDefinition } from '../../../src/parse/model/BindDefinition.ts';
 import type { ModelBindMap } from '../../../src/parse/model/ModelBindMap.ts';
 import { XFormDefinition } from '../../../src/parse/XFormDefinition.ts';
+import { XFormDOM } from '../../../src/parse/XFormDOM.ts';
 
 describe('ModelBindMap', () => {
 	let binds: ModelBindMap;
@@ -50,7 +51,8 @@ describe('ModelBindMap', () => {
 			),
 			body()
 		);
-		const form = new XFormDefinition(xform.asXml());
+		const xformDOM = XFormDOM.from(xform.asXml());
+		const form = new XFormDefinition(xformDOM);
 
 		binds = form.model.binds;
 	});

--- a/packages/xforms-engine/test/parse/model/ModelDefinition.test.ts
+++ b/packages/xforms-engine/test/parse/model/ModelDefinition.test.ts
@@ -20,6 +20,7 @@ import type { LeafNodeDefinition } from '../../../src/parse/model/LeafNodeDefini
 import { ModelDefinition } from '../../../src/parse/model/ModelDefinition.ts';
 import type { RepeatRangeDefinition } from '../../../src/parse/model/RepeatRangeDefinition.ts';
 import { XFormDefinition } from '../../../src/parse/XFormDefinition.ts';
+import { XFormDOM } from '../../../src/parse/XFormDOM.ts';
 
 describe('ModelDefinition', () => {
 	let modelDefinition: ModelDefinition;
@@ -49,7 +50,8 @@ describe('ModelDefinition', () => {
 			)
 		);
 
-		const xformDefinition = new XFormDefinition(xform.asXml());
+		const xformDOM = XFormDOM.from(xform.asXml());
+		const xformDefinition = new XFormDefinition(xformDOM);
 
 		modelDefinition = xformDefinition.model;
 	});
@@ -164,7 +166,8 @@ describe('ModelDefinition', () => {
 				)
 			);
 
-			const xformDefinition = new XFormDefinition(xform.asXml());
+			const xformDOM = XFormDOM.from(xform.asXml());
+			const xformDefinition = new XFormDefinition(xformDOM);
 
 			modelDefinition = xformDefinition.model;
 		});
@@ -313,7 +316,8 @@ describe('ModelDefinition', () => {
 				)
 			);
 
-			const xformDefinition = new XFormDefinition(xform.asXml());
+			const xformDOM = XFormDOM.from(xform.asXml());
+			const xformDefinition = new XFormDefinition(xformDOM);
 
 			modelDefinition = xformDefinition.model;
 		});
@@ -474,7 +478,9 @@ describe('ModelDefinition', () => {
 					)
 				);
 
-				expect(() => new XFormDefinition(xform.asXml())).toThrow(
+				const xformDOM = XFormDOM.from(xform.asXml());
+
+				expect(() => new XFormDefinition(xformDOM)).toThrow(
 					'Multiple explicit templates defined for /root/rep/rep2'
 				);
 			});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1756,6 +1756,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
+"@types/geojson@^7946.0.14":
+  version "7946.0.14"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.14.tgz#319b63ad6df705ee2a65a73ef042c8271e696613"
+  integrity sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==
+
 "@types/hast@^3.0.0", "@types/hast@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1822,6 +1822,13 @@
   dependencies:
     undici-types "~6.19.2"
 
+"@types/papaparse@^5.3.15":
+  version "5.3.15"
+  resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-5.3.15.tgz#7cafa16757a1d121422deefbb10b6310b224ecc4"
+  integrity sha512-JHe6vF6x/8Z85nCX4yFdDslN11d+1pr12E526X8WAfhadOeaOTx5AuIkvDKIBopfvlzpzkdMx4YyvSKCM9oqtw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/ramda@^0.30.2":
   version "0.30.2"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.30.2.tgz#70661b20c1bb969589a551b7134ae75008ffbfb6"
@@ -5196,6 +5203,11 @@ package-manager-detector@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/package-manager-detector/-/package-manager-detector-0.2.0.tgz#160395cd5809181f5a047222319262b8c2d8aaea"
   integrity sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==
+
+papaparse@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.4.1.tgz#f45c0f871853578bd3a30f92d96fdcfb6ebea127"
+  integrity sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==
 
 parent-module@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Closes #201

## I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [x] Safari (iOS)
- ~~[ ] Not applicable~~

## What else has been done to verify that this works as intended?

- Some existing tests ported from JavaRosa now pass
- At least one happy path test for each format (XML, CSV, GeoJSON)
- Added a slew of CSV parsing tests based on conversation yesterday with @lognaturel
- Added/updated integration in `@getodk/web-forms` dev/preview modes:
  - Web Forms Preview: when a user uploads a form referencing an external secondary instance, previewing the form will behave as if those instances are blank/empty.
  - Dev mode: when loading a fixture from the file system, it will load any referenced external secondary instances from files of the same name, in the same directory as that fixture; if any referenced file does not exist, the form will fail to load.

  These cases effectively represent the behaviors an integrating host application can expect. The latter is the default behavior for missing external secondary instance resources. The former requires a configuration option, and should be suitable for e.g. Central's form preview mode.

Worth noting: there is still a failing test ported from JavaRosa, where an error is expected when referencing a node that doesn't exist in a secondary instance. This test technically references an external secondary instance, but it isn't clear whether the behavior would be applicable to all secondary instances.

Another test ported from JavaRosa is now marked failing, representing the same default behavior for missing external secondary instances described above. A companion test has been added representing the optional/configured alternate behavior.

## Why is this the best possible solution? Were any other approaches considered?

This builds on the work in #245, and _mostly_ follows the design laid out in #201. It deviates somewhat from that design, mostly addressing some of the later discussion on that thread. I'll add more detail on that deviation below.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The main regression risk I can think of is that the newer default behavior is technically stricter for forms with external secondary instance references. Prior to this PR, those forms will always treat all such instances as blank. As of this PR, by default they'll be loaded and parsed by default, and evaluated as appropriate for any `instance(...)/...` expression defined in the form.

The other regression risk is that this does introduce breaking changes for host applications. Those will also be detailed below.

## Do we need any specific form for testing your changes? If so, please attach one.

This is pretty much covered by existing/added test fixtures. If you want to try it with your own form/attachments, they can be placed together in any fixtures subdirectory and accessed in dev mode.

## What's changed

### Breaking changes: host application <-> `@getodk/web-forms`

1. To support **loading** external secondary instances, a host application must implement a `fetchFormAttachment` function.
2. To provide a graceful fallback for loading a form **without loading** external secondary instances, a host application must override the default `missingResourceBehavior` option.

Both of these are specified (likely in `kebab-case`) as props on the `OdkWebForm` component.

### Breaking changes: client <-> engine

The same host/client breaking changes apply to integration between clients and the engine. These breaking changes have been implemented in `@getodk/web-forms` to support host application integration. They've also been implemented in `@getodk/scenario` to reflect the functionality in existing/added tests.

**Note:** I am only realizing now that I've neglected to integrate these changes in `@getodk/ui-solid`. I am honestly not sure how valuable the package is at this point, so I'm hesitant to address this unless anyone feels strongly otherwise. If we all agree that the package itself isn't providing much value now, I'd like to consider removing it sometime soon (so it doesn't languish in a weird semi-broken state).

### Engine configuration: `fetchFormAttachment`

The interface for this configuration is (simplified for reading inline):

```ts
type FetchFormAttachment = (resource: URL & { protocol: 'jr:' }) => Promise<FetchResourceResponse>
```

... where `FetchResourceResponse` is the same subset of `Response` already exposed for loading remote XForm XML resources, slightly expanded to allow an optional `headers` property (which in turn is a subset of the native `Headers` type).

This deviates from the design in #201: rather than providing a `Map` (or other map-like structure) for resolving `jr:` URLs, clients are expected to provide a `fetch`-like function. This deviation from the design is intended to address discussion in that issue around the appropriate _keys_ for such a map-like structure.

In spirit, it makes sense that the keys should be the full `jr:` URL (which I believe reflects @brontolosone's view in that discussion). In practice, a client and/or host will almost certainly be resolving those `jr:` URLs from a file name without additional information. In order for a caller to **be able** to satisfy a mapping between `jr:` URL and something resolving it, we'd need to provide a parsed set of URLs to satisfy. We can certainly do this! And we've discussed doing it. But as a primary API, it would complicate the form initialization process by introducing a step I believe is unnecessary.

This design change is a compromise recognizing that these are conceptually equivalent concepts:

- map-like structure whose values may be accessed by a suffix of its canonical keys
- function of canonical key to value

I briefly considered providing a sample implementation for the two most common formats we'd expect to derive this configuration: OpenRosa Manifest documents and the Central Form Attachments API. But I decided that implementing them is trivial enough that it shouldn't hold up the PR. I'll be happy to assist with integration if it turns out to be less obvious downstream than I hope.

### Engine configuration: `missingResourceBehavior`

This configuration is mostly described above. It reflects a duality of expected behaviors:

- By default, a form is not complete without its external secondary instances
- There are specific use cases where that default is unsuitable (e.g. various use cases conveniently all called "preview")

The configuration options for this are exposed as constants, but a bare string is acceptable as well.

### Notable engine internal implementation details

This is mostly covered in 0fbc3c5 and its commit notes. The most important detail is that parsing and loading is intentionally staged/layered:

1. I/O
2. Data format detection
3. Per-format parsing logic
4. Common representation of all **external** secondary instances
5. Finally, common representation of **all** secondary instances

That final common representation is then provided through `PrimaryInstance` to its instance of `XFormsXPathAdapter`. From there, evaluation of a form's `instance(...)/...` expressions makes no distinction between any secondary instance's type (internal vs external), source (XForm definition, `FetchFormAttachment` response) or format (XML DOM, XML text, CSV, GeoJSON).

There is also a bit of groundwork in the I/O layer anticipating support for _media attachments_. Not much is done there other than recognizing the entrypoint for that functionality will likely flow through a common `FormAttachmentResource` abstraction (as do external secondary instance resources now).

### Acknowledgement: some of the `StaticNode` interfaces are _super awkward_

(Where `StaticNode` and its subclasses are part of the engine's DOM adapter representation introduced in #245.)

Parsing logic for both CSV and GeoJSON introduce some indirection around these representations to make them a little bit easier to reason about/more ergonomic to use. I think there's some room to simplify the base constructor signatures further, but I decided to put that off and live with that bit of tech debt for now. I'm eager to land the functionality, and expect others on the team are as well. So let's call this ready for review!