### PR TITLE
Fix: Web Forms Preview demo form links 

### DIFF
--- a/packages/common/src/fixtures/xform-attachments.ts
+++ b/packages/common/src/fixtures/xform-attachments.ts
@@ -1,6 +1,6 @@
 import { UpsertableMap } from '../lib/collections/UpsertableMap.ts';
 import { UnreachableError } from '../lib/error/UnreachableError.ts';
-import type { ImportMetaGlobLoader } from './import-glob-helper.ts';
+import type { GlobFixtureLoader } from './import-glob-helper.ts';
 import { toGlobLoaderEntries } from './import-glob-helper.ts';
 
 /**
@@ -60,7 +60,7 @@ export class XFormAttachmentFixture {
 
 	constructor(
 		readonly absolutePath: string,
-		readonly load: ImportMetaGlobLoader
+		readonly load: GlobFixtureLoader
 	) {
 		const fileName = getFileName(absolutePath);
 		const fileExtension = getFileExtension(fileName);
@@ -97,7 +97,7 @@ type XFormAttachmentFixtureEntry = readonly [absolutePath: string, fixture: XFor
 type XFormAttachmentFixtureEntries = readonly XFormAttachmentFixtureEntry[];
 
 const xformAttachmentFixtureEntries: XFormAttachmentFixtureEntries =
-	xformAttachmentFixtureLoaderEntries.map(([absolutePath, load]) => {
+	xformAttachmentFixtureLoaderEntries.map(([absolutePath, { load }]) => {
 		const fixture = new XFormAttachmentFixture(absolutePath, load);
 
 		return [absolutePath, fixture];

--- a/packages/common/src/fixtures/xforms.ts
+++ b/packages/common/src/fixtures/xforms.ts
@@ -1,6 +1,7 @@
 import { JRResourceService } from '../jr-resources/JRResourceService.ts';
 import type { JRResourceURL } from '../jr-resources/JRResourceURL.ts';
 import { UpsertableMap } from '../lib/collections/UpsertableMap.ts';
+import type { GlobFixture } from './import-glob-helper.ts';
 import { toGlobLoaderEntries } from './import-glob-helper.ts';
 
 type XFormResourceType = 'local' | 'remote';
@@ -92,12 +93,8 @@ const getNoopResourceService: ResourceServiceFactory = () => {
 };
 
 export class XFormResource<Type extends XFormResourceType> {
-	static forLocalFixture(
-		localPath: string,
-		resourceURL: URL,
-		loadXML?: LoadXFormXML
-	): XFormResource<'local'> {
-		return new XFormResource('local', resourceURL, loadXML ?? xformURLLoader(resourceURL), {
+	static forLocalFixture(localPath: string, fixture: GlobFixture): XFormResource<'local'> {
+		return new XFormResource('local', fixture.url, fixture.load, {
 			category: localFixtureDirectoryCategory(localPath),
 			localPath,
 			identifier: pathToFileName(localPath),
@@ -168,10 +165,8 @@ const xformFixtureLoaderEntries = toGlobLoaderEntries(
 export type XFormFixture = XFormResource<'local'>;
 
 const buildXFormFixtures = (): readonly XFormFixture[] => {
-	return xformFixtureLoaderEntries.map(([path, loadXML]) => {
-		const resourceURL = new URL(path, SELF_URL);
-
-		return XFormResource.forLocalFixture(path, resourceURL, loadXML);
+	return xformFixtureLoaderEntries.map(([path, fixture]) => {
+		return XFormResource.forLocalFixture(path, fixture);
 	});
 };
 

--- a/packages/web-forms/e2e/build/wf-preview.test.ts
+++ b/packages/web-forms/e2e/build/wf-preview.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test('Web Forms Preview: demo forms load', async ({ context, page }) => {
+	await page.goto('http://localhost:5174/');
+
+	const formPreviewLinks = await page.locator('.form-preview-link').all();
+
+	expect(formPreviewLinks.length).toBeGreaterThan(0);
+
+	for await (const link of formPreviewLinks) {
+		const [previewPage] = await Promise.all([context.waitForEvent('page'), link.click()]);
+
+		await previewPage.waitForSelector(
+			'.form-initialization-status.error, .form-initialization-status.ready',
+			{
+				state: 'attached',
+			}
+		);
+
+		const [failureDialog] = await previewPage.locator('.form-load-failure-dialog').all();
+
+		expect(failureDialog).toBeUndefined();
+
+		await previewPage.close();
+	}
+});

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -75,6 +75,15 @@ watchEffect(() => {
 	applicable for usage of a given tag.
 -->
 <template>
+	<div
+		:class="{
+			'form-initialization-status': true,
+			loading: odkForm == null && initializeFormError == null,
+			error: initializeFormError != null,
+			ready: odkForm != null,
+		}"
+	/>
+
 	<template v-if="initializeFormError != null">
 		<FormLoadFailureDialog
 			severity="error"
@@ -132,6 +141,10 @@ watchEffect(() => {
 
 <style scoped lang="scss">
 @import 'primeflex/core/_variables.scss';
+
+.form-initialization-status {
+	display: none;
+}
 
 .odk-form {
 	width: 100%;

--- a/packages/web-forms/src/demo/DemoForm.vue
+++ b/packages/web-forms/src/demo/DemoForm.vue
@@ -44,7 +44,7 @@ const formXls = computed(() => {
 				<slot name="description" />
 			</p>
 			<div class="actions">
-				<RouterLink :to="`/form?url=${formXml}`" target="_blank">
+				<RouterLink :to="`/form?url=${formXml}`" target="_blank" class="form-preview-link">
 					<PrimeButton class="preview-button" label="View Form" icon="icon-remove_red_eye" />
 				</RouterLink>
 				<a :href="formXls">


### PR DESCRIPTION
## I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable

## What else has been done to verify that this works as intended?

Added an e2e test which loads all of the Web Forms Preview form links, from the build product. That should be much more reliable than any manual testing I might do.

## Why is this the best possible solution? Were any other approaches considered?

It would be preferable if specific fixtures could be referenced by something stable, and not rely on anything dynamic at build time.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's possible some other nuance of glob loading is affected by this. But I would expect to see some sign of that either in `scenario` or dev mode, both of which still seem to be working as expected.

## Do we need any specific form for testing your changes? If so, please attach one.

The links on the preview page should suffice.

## What's changed

- Restored use of build-time asset URLs in links to XForm fixtures
- Added an e2e test to ensure that doesn't break again, along with a couple of basic Vue template supports for (hopefully) clearer intent in e2e tests going forward