### PR TITLE
fix illegal invocation issue when fetching form xml

### DIFF
--- a/.changeset/ten-experts-type.md
+++ b/.changeset/ten-experts-type.md
@@ -1,0 +1,5 @@
+---
+"@getodk/xforms-engine": patch
+---
+
+Fix: illegal invocation when fetching form xml

--- a/packages/xforms-engine/src/instance/resource.ts
+++ b/packages/xforms-engine/src/instance/resource.ts
@@ -10,7 +10,10 @@ export interface ResourceOptions {
 }
 
 const fetchTextFromURL = async (resource: URL, options: ResourceOptions): Promise<string> => {
-	const response = await options.fetchResource(resource);
+	// destructuring prevents "Failed to execute 'fetch' on 'Window': Illegal invocation"
+	const { fetchResource } = options;
+
+	const response = await fetchResource(resource);
 
 	return response.text();
 };


### PR DESCRIPTION
## I have verified this PR works in these browsers (latest versions):

- [X] Chrome
- [X] Firefox
- [X] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Not applicable

## What else has been done to verify that this works as intended?
I built a minimal test html file of the web-component build of web-forms and manually tested to make sure it works.

## Why is this the best possible solution? Were any other approaches considered?
I had tried catching the error, but thought it best to prevent the error from happening at all.  The suggested change also preserve isomorphism and avoids dependency on any browser specific APIs.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change shouldn't affect any users.

## Do we need any specific form for testing your changes? If so, please attach one.
Will work with any form.

## What's changed
Basically just unpacked the fetchResource function (usually built-in fetch I think) before calling it.  When you try to call it on the object as options.fetchResource it throws an illegal invocation error.

## Note
I have only minimal experience with the web-forms code base, so I'd recommend double-checking with someone who has more experience.  I'm honestly a bit confused how this issue didn't come up earlier.  I wonder if it has to do with browser versions or maybe something Vite does.  I'm also wondering if it is specific to web component implementations (but I'm not sure why that is).

Open to your thoughts and feedback!