### PR TITLE
Web Component with Shadow Dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "turbo": "^2.3.3",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.18.1",
-    "vue": "3.3.4",
+    "vue": "3.5.13",
     "vue-tsc": "^2.1.10"
   },
   "resolutions": {

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -31,6 +31,7 @@
     "build:clean": "rimraf dist/ dist-demo/",
     "build:demo": "vite build --mode demo --outDir dist-demo",
     "build:js": "vite build",
+    "build:wc": "vite build --mode web-component --outDir dist-web-component",
     "dev": "vite",
     "dist-demo": "yarn build && yarn vite serve dist-demo --port 5174",
     "test": "npm-run-all -nl test:*",
@@ -68,10 +69,10 @@
     "vite-plugin-css-injected-by-js": "^3.5.2",
     "vite-plugin-static-copy": "^2.2.0",
     "vitest": "^2.1.8",
-    "vue": "3.3.4",
+    "vue": "3.5.13",
     "vue-router": "^4.5.0"
   },
   "peerDependencies": {
-    "vue": "^3.3.4"
+    "vue": "^3.5.13"
   }
 }

--- a/packages/web-forms/src/index.wc.ts
+++ b/packages/web-forms/src/index.wc.ts
@@ -1,0 +1,11 @@
+import { defineCustomElement } from 'vue';
+import { OdkWebForm, webFormsPlugin } from '.';
+
+const WebFormElement = defineCustomElement(OdkWebForm, {
+  configureApp(app) {
+    app.use(webFormsPlugin);
+  },
+  shadowRoot: false
+});
+
+customElements.define('odk-web-form', WebFormElement);

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -68,16 +68,26 @@ const copyConfigFile = viteStaticCopy({
 export default defineConfig(({ mode }) => {
 	const isVueBundled = mode === 'demo';
 	const isDev = mode === 'development';
+	const isWebComponent = mode === 'web-component';
 
 	let lib: LibraryOptions | undefined;
 	let external: string[];
 	let globals: Record<string, string>;
+	let publicDir: string | false = "public";
 	const extraPlugins: PluginOption[] = [];
 
 	if (isVueBundled) {
 		external = [];
 		globals = {};
 		extraPlugins.push(copyConfigFile);
+	} else if (isWebComponent) {
+		lib = {
+			formats: ['es'],
+			entry: resolve(__dirname, 'src/index.wc.ts'),
+			name: 'OdkWebForms',
+			fileName: 'odk-web-form',
+		};
+		publicDir = false;
 	} else {
 		external = ['vue'];
 		globals = { vue: 'Vue' };
@@ -97,6 +107,7 @@ export default defineConfig(({ mode }) => {
 	return {
 		define: {
 			__WEB_FORMS_VERSION__: `"v${currentVersion}"`,
+			'process.env': {},
 		},
 		base: './',
 		plugins: [vue(), vueJsx(), cssInjectedByJsPlugin(), ...extraPlugins],
@@ -180,6 +191,7 @@ export default defineConfig(({ mode }) => {
 		optimizeDeps: {
 			force: true,
 		},
+		publicDir,
 		test: {
 			browser: {
 				enabled: BROWSER_ENABLED,


### PR DESCRIPTION
⚠️  This is a draft pull request.  I mostly created this to share knowledge and unblock the FMTM Web Forms integration work.  I'm not sure this exact implementation is best for everyone.


Builds a Web Component version of `<OdkWebForm/>` without the Shadow DOM

screenshot of web component demo
<img width="1436" alt="Screenshot 2025-01-20 at 4 28 04 PM" src="https://github.com/user-attachments/assets/15b423da-c532-4130-a302-d440d2db3807" />

## I have verified this PR works in these browsers (latest versions):

- [X] Chrome
- [X] Firefox
- [X] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Not applicable

## What else has been done to verify that this works as intended?
Viewed minimal demo (link coming soon)

## Why is this the best possible solution? Were any other approaches considered?
I'm not sure it's the best.  I've tried with using the Shadow DOM but that was more complicated.  I think the benefit of this solution is that it's minimal changes and can serve as a temporary implementation as a Shadow DOM - based approach is built.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
By not using the shadow DOM, this approach is currently leaking styles to the global DOM.  It should be noted as experimental.

## Do we need any specific form for testing your changes? If so, please attach one.

## What's changed
Basically built a web component version of OdkWebForm.  This built on top of the previous work on web components, but passes `shadowRoot: false` to createCustomElement.
