### PR TITLE
Include primary instance root attributes, namespace declarations in submission XML

### DIFF
--- a/.changeset/healthy-jobs-look.md
+++ b/.changeset/healthy-jobs-look.md
@@ -1,0 +1,7 @@
+---
+'@getodk/xforms-engine': patch
+'@getodk/web-forms': patch
+'@getodk/scenario': patch
+---
+
+Fix: include namespace declarations in submission XML

--- a/.changeset/light-mails-appear.md
+++ b/.changeset/light-mails-appear.md
@@ -1,0 +1,7 @@
+---
+'@getodk/xforms-engine': patch
+'@getodk/web-forms': patch
+'@getodk/scenario': patch
+---
+
+Fix: include primary instance root attributes in submission XML

--- a/packages/scenario/test/submission.test.ts
+++ b/packages/scenario/test/submission.test.ts
@@ -141,7 +141,7 @@ describe('Form submission', () => {
 
 			expect(scenario).toHaveSerializedSubmissionXML(
 				// prettier-ignore
-				t('data',
+				t('data id="xml-serialization-basic-default-values"',
 					t('grp',
 						t('inp', defaults.inp ?? ''),
 						t('sel1', defaults.sel1 ?? ''),
@@ -154,6 +154,116 @@ describe('Form submission', () => {
 					t('meta',
 						t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
 			);
+		});
+
+		describe('instance root attributes', () => {
+			it('serializes attributes from the instance root, as they appear in the form definition', async () => {
+				const formId = 'inst-root-attrs';
+				const version = '2018061801';
+
+				const scenario = await Scenario.init(
+					'XML serialization - instance root attrs',
+					// prettier-ignore
+					html(
+						head(
+							title('XML serialization - instance root attrs'),
+							model(
+								mainInstance(
+									t(`data id="${formId}" version="${version}"`,
+										t('inp', 'val'),
+										t('meta',
+											t('instanceID')))
+								),
+								bind('/data/inp').type('string'),
+								bind('/data/meta/instanceID').calculate(`'${DEFAULT_INSTANCE_ID}'`)
+							)
+						),
+						body(
+							input('/data/inp', label('Input (with default value)'))
+						)
+					)
+				);
+
+				expect(scenario).toHaveSerializedSubmissionXML(
+					// prettier-ignore
+					t(`data id="${formId}" version="${version}"`,
+						t('inp', 'val'),
+						t('meta',
+							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
+				);
+			});
+
+			it('preserves instance root attribute namespace prefixes, as they appear in the form definition', async () => {
+				const formId = 'inst-root-attrs';
+				const version = '2018061801';
+
+				const scenario = await Scenario.init(
+					'XML serialization - instance root attrs',
+					// prettier-ignore
+					html(
+						head(
+							title('XML serialization - instance root attrs'),
+							model(
+								mainInstance(
+									t(`data id="${formId}" orx:version="${version}"`,
+										t('inp', 'val'),
+										t('meta',
+											t('instanceID')))
+								),
+								bind('/data/inp').type('string'),
+								bind('/data/meta/instanceID').calculate(`'${DEFAULT_INSTANCE_ID}'`)
+							)
+						),
+						body(
+							input('/data/inp', label('Input (with default value)'))
+						)
+					)
+				);
+
+				expect(scenario).toHaveSerializedSubmissionXML(
+					// prettier-ignore
+					t(`data id="${formId}" orx:version="${version}"`,
+						t('inp', 'val'),
+						t('meta',
+							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
+				);
+			});
+
+			it('preserves escaped values of instance root attributes', async () => {
+				const formId = 'inst-root-attrs';
+				const version = '2018061801&gt;&quot;XML&quot;&amp;special&lt;chars';
+
+				const scenario = await Scenario.init(
+					'XML serialization - instance root attrs',
+					// prettier-ignore
+					html(
+						head(
+							title('XML serialization - instance root attrs'),
+							model(
+								mainInstance(
+									t(`data id="${formId}" orx:version="${version}"`,
+										t('inp', 'val'),
+										t('meta',
+											t('instanceID')))
+								),
+								bind('/data/inp').type('string'),
+								bind('/data/meta/instanceID').calculate(`'${DEFAULT_INSTANCE_ID}'`)
+							)
+						),
+						body(
+							input('/data/inp', label('Input (with default value)'))
+						)
+					)
+				);
+
+				expect(scenario).toHaveSerializedSubmissionXML(
+					// prettier-ignore
+					t(`data id="${formId}" orx:version="${version}"`,
+						t('inp', 'val'),
+						t('meta',
+							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
+				);
+			});
 		});
 
 		// The original ported JavaRosa test exercising Unicode support was a good
@@ -202,7 +312,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data',
+					t('data id="unicode-normalization"',
 						t('rep',
 							t('inp', composed)),
 						t('meta',
@@ -217,7 +327,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data',
+					t('data id="unicode-normalization"',
 						t('rep',
 							t('inp', composed)),
 						t('meta',
@@ -255,7 +365,7 @@ describe('Form submission', () => {
 			it('does not serialize an element for a repeat range', () => {
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data',
+					t('data id="xml-serialization-repeats"',
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
 				);
@@ -269,7 +379,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data',
+					t('data id="xml-serialization-repeats"',
 						t('rep',
 							t('inp', 'a')),
 						t('rep',
@@ -282,7 +392,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data',
+					t('data id="xml-serialization-repeats"',
 						t('rep',
 							t('inp', 'b')),
 						t('meta',
@@ -333,7 +443,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data',
+					t('data id="xml-serialization-relevance"',
 						t('grp-rel', '1'),
 						t('inp-rel', '0'),
 						t('grp'),
@@ -347,7 +457,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data',
+					t('data id="xml-serialization-relevance"',
 						t('grp-rel', '0'),
 						t('inp-rel', '1'),
 						t('meta',
@@ -365,10 +475,10 @@ describe('Form submission', () => {
 					// prettier-ignore
 					html(
 						head(
-							title('Relevance XML serialization'),
+							title('Reactive XML serialization'),
 							model(
 								mainInstance(
-									t('data id="relevance-xml-serialization"',
+									t('data id="reactive-xml-serialization"',
 										t('rep-inp-rel'),
 										t('rep',
 											t('inp')),
@@ -400,7 +510,7 @@ describe('Form submission', () => {
 				// Default serialization before any state change
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -415,7 +525,7 @@ describe('Form submission', () => {
 					// After first value change
 					expect(serialized).toBe(
 						// prettier-ignore
-						t('data',
+						t('data id="reactive-xml-serialization"',
 							t('rep-inp-rel'),
 							t('rep',
 								t('inp', `${i}`)),
@@ -435,7 +545,7 @@ describe('Form submission', () => {
 				// Default serialization before any state change
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -448,7 +558,7 @@ describe('Form submission', () => {
 				// First repeat instance added
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -463,7 +573,7 @@ describe('Form submission', () => {
 				// Second repeat instance added
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -482,7 +592,7 @@ describe('Form submission', () => {
 				// Each of the above values set
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -499,7 +609,7 @@ describe('Form submission', () => {
 				// Last repeat instance removed
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -514,7 +624,7 @@ describe('Form submission', () => {
 				// First repeat instance removed
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 2 inp')),
@@ -527,7 +637,7 @@ describe('Form submission', () => {
 				// All repeat instances removed
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel'),
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
@@ -550,7 +660,7 @@ describe('Form submission', () => {
 				// Current serialization before any relevance change
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -567,7 +677,7 @@ describe('Form submission', () => {
 				// Non-relevant /data/rep[position() != '1']/inp omitted
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel', '1'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -582,7 +692,7 @@ describe('Form submission', () => {
 				// Non-relevant /data/rep[position() != '3']/inp omitted
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data',
+					t('data id="reactive-xml-serialization"',
 						t('rep-inp-rel', '3'),
 						t('rep'),
 						t('rep'),
@@ -732,7 +842,7 @@ describe('Form submission', () => {
 					expect(scenario.getValidationOutcome().outcome).toBe(ANSWER_OK);
 
 					// prettier-ignore
-					validSubmissionXML = t('data',
+					validSubmissionXML = t('data id="prepare-for-submission"',
 						t('rep',
 							t('inp', 'rep 1 inp')),
 						t('rep',
@@ -769,7 +879,7 @@ describe('Form submission', () => {
 					expect(scenario.getValidationOutcome().outcome).toBe(ANSWER_REQUIRED_BUT_EMPTY);
 
 					// prettier-ignore
-					invalidSubmissionXML = t('data',
+					invalidSubmissionXML = t('data id="prepare-for-submission"',
 						t('rep',
 							t('inp', 'rep 1 inp')),
 						t('rep',

--- a/packages/scenario/test/submission.test.ts
+++ b/packages/scenario/test/submission.test.ts
@@ -1,7 +1,4 @@
-import {
-	OPENROSA_XFORMS_NAMESPACE_URI,
-	XFORMS_NAMESPACE_URI,
-} from '@getodk/common/constants/xmlns.ts';
+import { OPENROSA_XFORMS_NAMESPACE_URI } from '@getodk/common/constants/xmlns.ts';
 import {
 	bind,
 	body,
@@ -145,7 +142,7 @@ describe('Form submission', () => {
 
 			expect(scenario).toHaveSerializedSubmissionXML(
 				// prettier-ignore
-				t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-basic-default-values"`,
+				t(`data id="xml-serialization-basic-default-values"`,
 					t('grp',
 						t('inp', defaults.inp ?? ''),
 						t('sel1', defaults.sel1 ?? ''),
@@ -190,7 +187,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="${formId}" version="${version}"`,
+					t(`data id="${formId}" version="${version}"`,
 						t('inp', 'val'),
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
@@ -226,7 +223,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" xmlns:orx="${OPENROSA_XFORMS_NAMESPACE_URI}" id="${formId}" orx:version="${version}"`,
+					t(`data xmlns:orx="${OPENROSA_XFORMS_NAMESPACE_URI}" id="${formId}" orx:version="${version}"`,
 						t('inp', 'val'),
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
@@ -262,7 +259,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" xmlns:orx="${OPENROSA_XFORMS_NAMESPACE_URI}" id="${formId}" orx:version="${version}"`,
+					t(`data xmlns:orx="${OPENROSA_XFORMS_NAMESPACE_URI}" id="${formId}" orx:version="${version}"`,
 						t('inp', 'val'),
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
@@ -316,7 +313,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="unicode-normalization"`,
+					t(`data id="unicode-normalization"`,
 						t('rep',
 							t('inp', composed)),
 						t('meta',
@@ -331,7 +328,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="unicode-normalization"`,
+					t(`data id="unicode-normalization"`,
 						t('rep',
 							t('inp', composed)),
 						t('meta',
@@ -369,7 +366,7 @@ describe('Form submission', () => {
 			it('does not serialize an element for a repeat range', () => {
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-repeats"`,
+					t(`data id="xml-serialization-repeats"`,
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
 				);
@@ -383,7 +380,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-repeats"`,
+					t(`data id="xml-serialization-repeats"`,
 						t('rep',
 							t('inp', 'a')),
 						t('rep',
@@ -396,7 +393,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-repeats"`,
+					t(`data id="xml-serialization-repeats"`,
 						t('rep',
 							t('inp', 'b')),
 						t('meta',
@@ -447,7 +444,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-relevance"`,
+					t(`data id="xml-serialization-relevance"`,
 						t('grp-rel', '1'),
 						t('inp-rel', '0'),
 						t('grp'),
@@ -461,7 +458,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-relevance"`,
+					t(`data id="xml-serialization-relevance"`,
 						t('grp-rel', '0'),
 						t('inp-rel', '1'),
 						t('meta',
@@ -514,7 +511,7 @@ describe('Form submission', () => {
 				// Default serialization before any state change
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -529,7 +526,7 @@ describe('Form submission', () => {
 					// After first value change
 					expect(serialized).toBe(
 						// prettier-ignore
-						t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+						t(`data id="reactive-xml-serialization"`,
 							t('rep-inp-rel'),
 							t('rep',
 								t('inp', `${i}`)),
@@ -549,7 +546,7 @@ describe('Form submission', () => {
 				// Default serialization before any state change
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -562,7 +559,7 @@ describe('Form submission', () => {
 				// First repeat instance added
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -577,7 +574,7 @@ describe('Form submission', () => {
 				// Second repeat instance added
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -596,7 +593,7 @@ describe('Form submission', () => {
 				// Each of the above values set
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -613,7 +610,7 @@ describe('Form submission', () => {
 				// Last repeat instance removed
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -628,7 +625,7 @@ describe('Form submission', () => {
 				// First repeat instance removed
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 2 inp')),
@@ -641,7 +638,7 @@ describe('Form submission', () => {
 				// All repeat instances removed
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
@@ -664,7 +661,7 @@ describe('Form submission', () => {
 				// Current serialization before any relevance change
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -681,7 +678,7 @@ describe('Form submission', () => {
 				// Non-relevant /data/rep[position() != '1']/inp omitted
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel', '1'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -696,7 +693,7 @@ describe('Form submission', () => {
 				// Non-relevant /data/rep[position() != '3']/inp omitted
 				expect(serialized).toBe(
 					// prettier-ignore
-					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
+					t(`data id="reactive-xml-serialization"`,
 						t('rep-inp-rel', '3'),
 						t('rep'),
 						t('rep'),
@@ -846,7 +843,7 @@ describe('Form submission', () => {
 					expect(scenario.getValidationOutcome().outcome).toBe(ANSWER_OK);
 
 					// prettier-ignore
-					validSubmissionXML = t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="prepare-for-submission"`,
+					validSubmissionXML = t(`data id="prepare-for-submission"`,
 						t('rep',
 							t('inp', 'rep 1 inp')),
 						t('rep',
@@ -883,7 +880,7 @@ describe('Form submission', () => {
 					expect(scenario.getValidationOutcome().outcome).toBe(ANSWER_REQUIRED_BUT_EMPTY);
 
 					// prettier-ignore
-					invalidSubmissionXML = t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="prepare-for-submission"`,
+					invalidSubmissionXML = t(`data id="prepare-for-submission"`,
 						t('rep',
 							t('inp', 'rep 1 inp')),
 						t('rep',

--- a/packages/scenario/test/submission.test.ts
+++ b/packages/scenario/test/submission.test.ts
@@ -1,4 +1,8 @@
 import {
+	OPENROSA_XFORMS_NAMESPACE_URI,
+	XFORMS_NAMESPACE_URI,
+} from '@getodk/common/constants/xmlns.ts';
+import {
 	bind,
 	body,
 	group,
@@ -141,7 +145,7 @@ describe('Form submission', () => {
 
 			expect(scenario).toHaveSerializedSubmissionXML(
 				// prettier-ignore
-				t('data id="xml-serialization-basic-default-values"',
+				t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-basic-default-values"`,
 					t('grp',
 						t('inp', defaults.inp ?? ''),
 						t('sel1', defaults.sel1 ?? ''),
@@ -186,7 +190,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data id="${formId}" version="${version}"`,
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="${formId}" version="${version}"`,
 						t('inp', 'val'),
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
@@ -222,7 +226,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data id="${formId}" orx:version="${version}"`,
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" xmlns:orx="${OPENROSA_XFORMS_NAMESPACE_URI}" id="${formId}" orx:version="${version}"`,
 						t('inp', 'val'),
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
@@ -258,7 +262,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t(`data id="${formId}" orx:version="${version}"`,
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" xmlns:orx="${OPENROSA_XFORMS_NAMESPACE_URI}" id="${formId}" orx:version="${version}"`,
 						t('inp', 'val'),
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
@@ -312,7 +316,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data id="unicode-normalization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="unicode-normalization"`,
 						t('rep',
 							t('inp', composed)),
 						t('meta',
@@ -327,7 +331,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data id="unicode-normalization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="unicode-normalization"`,
 						t('rep',
 							t('inp', composed)),
 						t('meta',
@@ -365,7 +369,7 @@ describe('Form submission', () => {
 			it('does not serialize an element for a repeat range', () => {
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data id="xml-serialization-repeats"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-repeats"`,
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
 				);
@@ -379,7 +383,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data id="xml-serialization-repeats"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-repeats"`,
 						t('rep',
 							t('inp', 'a')),
 						t('rep',
@@ -392,7 +396,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data id="xml-serialization-repeats"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-repeats"`,
 						t('rep',
 							t('inp', 'b')),
 						t('meta',
@@ -443,7 +447,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data id="xml-serialization-relevance"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-relevance"`,
 						t('grp-rel', '1'),
 						t('inp-rel', '0'),
 						t('grp'),
@@ -457,7 +461,7 @@ describe('Form submission', () => {
 
 				expect(scenario).toHaveSerializedSubmissionXML(
 					// prettier-ignore
-					t('data id="xml-serialization-relevance"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="xml-serialization-relevance"`,
 						t('grp-rel', '0'),
 						t('inp-rel', '1'),
 						t('meta',
@@ -510,7 +514,7 @@ describe('Form submission', () => {
 				// Default serialization before any state change
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -525,7 +529,7 @@ describe('Form submission', () => {
 					// After first value change
 					expect(serialized).toBe(
 						// prettier-ignore
-						t('data id="reactive-xml-serialization"',
+						t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 							t('rep-inp-rel'),
 							t('rep',
 								t('inp', `${i}`)),
@@ -545,7 +549,7 @@ describe('Form submission', () => {
 				// Default serialization before any state change
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -558,7 +562,7 @@ describe('Form submission', () => {
 				// First repeat instance added
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -573,7 +577,7 @@ describe('Form submission', () => {
 				// Second repeat instance added
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp')),
@@ -592,7 +596,7 @@ describe('Form submission', () => {
 				// Each of the above values set
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -609,7 +613,7 @@ describe('Form submission', () => {
 				// Last repeat instance removed
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -624,7 +628,7 @@ describe('Form submission', () => {
 				// First repeat instance removed
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 2 inp')),
@@ -637,7 +641,7 @@ describe('Form submission', () => {
 				// All repeat instances removed
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('meta',
 							t('instanceID', DEFAULT_INSTANCE_ID))).asXml()
@@ -660,7 +664,7 @@ describe('Form submission', () => {
 				// Current serialization before any relevance change
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -677,7 +681,7 @@ describe('Form submission', () => {
 				// Non-relevant /data/rep[position() != '1']/inp omitted
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel', '1'),
 						t('rep',
 							t('inp', 'rep 1 inp')),
@@ -692,7 +696,7 @@ describe('Form submission', () => {
 				// Non-relevant /data/rep[position() != '3']/inp omitted
 				expect(serialized).toBe(
 					// prettier-ignore
-					t('data id="reactive-xml-serialization"',
+					t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="reactive-xml-serialization"`,
 						t('rep-inp-rel', '3'),
 						t('rep'),
 						t('rep'),
@@ -842,7 +846,7 @@ describe('Form submission', () => {
 					expect(scenario.getValidationOutcome().outcome).toBe(ANSWER_OK);
 
 					// prettier-ignore
-					validSubmissionXML = t('data id="prepare-for-submission"',
+					validSubmissionXML = t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="prepare-for-submission"`,
 						t('rep',
 							t('inp', 'rep 1 inp')),
 						t('rep',
@@ -879,7 +883,7 @@ describe('Form submission', () => {
 					expect(scenario.getValidationOutcome().outcome).toBe(ANSWER_REQUIRED_BUT_EMPTY);
 
 					// prettier-ignore
-					invalidSubmissionXML = t('data id="prepare-for-submission"',
+					invalidSubmissionXML = t(`data xmlns="${XFORMS_NAMESPACE_URI}" id="prepare-for-submission"`,
 						t('rep',
 							t('inp', 'rep 1 inp')),
 						t('rep',

--- a/packages/xforms-engine/src/instance/Root.ts
+++ b/packages/xforms-engine/src/instance/Root.ts
@@ -12,7 +12,7 @@ import type { SubmissionResult } from '../client/submission/SubmissionResult.ts'
 import type { SubmissionState } from '../client/submission/SubmissionState.ts';
 import type { AncestorNodeValidationState } from '../client/validation.ts';
 import type { XFormsXPathElement } from '../integration/xpath/adapter/XFormsXPathNode.ts';
-import { createParentNodeSubmissionState } from '../lib/client-reactivity/submission/createParentNodeSubmissionState.ts';
+import { createRootSubmissionState } from '../lib/client-reactivity/submission/createRootSubmissionState.ts';
 import type { ChildrenState } from '../lib/reactivity/createChildrenState.ts';
 import { createChildrenState } from '../lib/reactivity/createChildrenState.ts';
 import type { MaterializedChildren } from '../lib/reactivity/materializeCurrentStateChildren.ts';
@@ -136,7 +136,7 @@ export class Root
 
 		childrenState.setChildren(buildChildren(this));
 		this.validationState = createAggregatedViolations(this, sharedStateOptions);
-		this.submissionState = createParentNodeSubmissionState(this);
+		this.submissionState = createRootSubmissionState(this);
 	}
 
 	getChildren(): readonly GeneralChildNode[] {

--- a/packages/xforms-engine/src/lib/client-reactivity/submission/createRootSubmissionState.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/submission/createRootSubmissionState.ts
@@ -5,12 +5,14 @@ import { serializeParentElementXML } from '../../xml-serialization.ts';
 export const createRootSubmissionState = (node: Root): SubmissionState => {
 	return {
 		get submissionXML() {
+			const { namespaceDeclarations, attributes } = node.definition;
 			const serializedChildren = node.currentState.children.map((child) => {
 				return child.submissionState.submissionXML;
 			});
 
 			return serializeParentElementXML(node.definition.nodeName, serializedChildren, {
-				attributes: node.definition.attributes,
+				namespaceDeclarations,
+				attributes,
 			});
 		},
 	};

--- a/packages/xforms-engine/src/lib/client-reactivity/submission/createRootSubmissionState.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/submission/createRootSubmissionState.ts
@@ -1,0 +1,17 @@
+import type { SubmissionState } from '../../../client/submission/SubmissionState.ts';
+import type { Root } from '../../../instance/Root.ts';
+import { serializeParentElementXML } from '../../xml-serialization.ts';
+
+export const createRootSubmissionState = (node: Root): SubmissionState => {
+	return {
+		get submissionXML() {
+			const serializedChildren = node.currentState.children.map((child) => {
+				return child.submissionState.submissionXML;
+			});
+
+			return serializeParentElementXML(node.definition.nodeName, serializedChildren, {
+				attributes: node.definition.attributes,
+			});
+		},
+	};
+};

--- a/packages/xforms-engine/src/lib/xml-serialization.ts
+++ b/packages/xforms-engine/src/lib/xml-serialization.ts
@@ -75,22 +75,52 @@ export const escapeXMLText = <Text extends string>(
 		: (out as EscapedXMLText);
 };
 
-const serializeElementXML = (nodeName: string, children: string): string => {
+interface SerializableElementAttribute {
+	readonly nodeName: string;
+	readonly value: string;
+}
+
+const serializeAttributeXML = (attribute: SerializableElementAttribute) => {
+	return ` ${attribute.nodeName}="${escapeXMLText(attribute.value, true)}"`;
+};
+
+interface SerializeElementXMLOptions {
+	readonly attributes: readonly SerializableElementAttribute[];
+}
+
+const serializeElementXML = (
+	nodeName: string,
+	children: string,
+	options: SerializeElementXMLOptions
+): string => {
+	const attributes = options.attributes.map(serializeAttributeXML).join('');
+
 	if (children === '') {
-		return `<${nodeName}/>`;
+		return `<${nodeName}${attributes}/>`;
 	}
 
 	// TODO: attributes
-	return `<${nodeName}>${children}</${nodeName}>`;
+	return `<${nodeName}${attributes}>${children}</${nodeName}>`;
 };
+
+export type ElementXMLSerializationOptions = Partial<SerializeElementXMLOptions>;
 
 export const serializeParentElementXML = (
 	nodeName: string,
-	serializedChildren: readonly string[]
+	serializedChildren: readonly string[],
+	options?: ElementXMLSerializationOptions
 ): string => {
-	return serializeElementXML(nodeName, serializedChildren.join(''));
+	return serializeElementXML(nodeName, serializedChildren.join(''), {
+		attributes: options?.attributes ?? [],
+	});
 };
 
-export const serializeLeafElementXML = (nodeName: string, xmlValue: EscapedXMLText): string => {
-	return serializeElementXML(nodeName, xmlValue.normalize());
+export const serializeLeafElementXML = (
+	nodeName: string,
+	xmlValue: EscapedXMLText,
+	options?: ElementXMLSerializationOptions
+): string => {
+	return serializeElementXML(nodeName, xmlValue.normalize(), {
+		attributes: options?.attributes ?? [],
+	});
 };

--- a/packages/xforms-engine/src/parse/model/RootAttributeDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/RootAttributeDefinition.ts
@@ -1,0 +1,28 @@
+interface RootAttributeSource {
+	/** @see {@link RootAttributeDefinition.nodeName} */
+	readonly nodeName: string;
+	readonly value: string;
+}
+
+/**
+ * @todo This class is named and typed to emphasize its intentionally narrow
+ * usage and purpose. It **intentionally** avoids addressing the much broader
+ * set of concerns around modeling attributes in primary instance/submissions.
+ */
+export class RootAttributeDefinition {
+	/**
+	 * Note: this parameter/property is named and typed to emphasize the fact
+	 * that its source is the **prefixed name** of the attribute (e.g. as a
+	 * reference to {@link Attr.nodeName}, with the same semantics), as parsed
+	 * from a form definition. At time of writing, we have decided that the
+	 * safest way to handle such attributes is to preserve their namespace
+	 * details **as authored**.
+	 */
+	readonly nodeName: string;
+	readonly value: string;
+
+	constructor(source: RootAttributeSource) {
+		this.nodeName = source.nodeName;
+		this.value = source.value;
+	}
+}

--- a/packages/xforms-engine/src/parse/model/RootDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/RootDefinition.ts
@@ -8,6 +8,7 @@ import { NodeDefinition } from './NodeDefinition.ts';
 import { NoteNodeDefinition } from './NoteNodeDefinition.ts';
 import { RangeNodeDefinition } from './RangeNodeDefinition.ts';
 import { RepeatRangeDefinition } from './RepeatRangeDefinition.ts';
+import { RootAttributeDefinition } from './RootAttributeDefinition.ts';
 import { SubtreeDefinition } from './SubtreeDefinition.ts';
 
 export class RootDefinition extends NodeDefinition<'root'> {
@@ -16,6 +17,7 @@ export class RootDefinition extends NodeDefinition<'root'> {
 	readonly bodyElement = null;
 	readonly root = this;
 	readonly parent = null;
+	readonly attributes: readonly RootAttributeDefinition[];
 	readonly children: readonly ChildNodeDefinition[];
 	readonly instances = null;
 	readonly node: Element;
@@ -53,6 +55,9 @@ export class RootDefinition extends NodeDefinition<'root'> {
 
 		this.nodeName = nodeName;
 		this.node = primaryInstanceRoot;
+		this.attributes = Array.from(primaryInstanceRoot.attributes).map((attr) => {
+			return new RootAttributeDefinition(attr);
+		});
 		this.children = this.buildSubtree(this);
 	}
 

--- a/packages/xforms-engine/src/parse/model/RootDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/RootDefinition.ts
@@ -9,6 +9,8 @@ import { NoteNodeDefinition } from './NoteNodeDefinition.ts';
 import { RangeNodeDefinition } from './RangeNodeDefinition.ts';
 import { RepeatRangeDefinition } from './RepeatRangeDefinition.ts';
 import { RootAttributeDefinition } from './RootAttributeDefinition.ts';
+import type { RootNamespaceDeclaration } from './RootNamespaceDeclaration.ts';
+import { RootNamespaceDeclarations } from './RootNamespaceDeclarations.ts';
 import { SubtreeDefinition } from './SubtreeDefinition.ts';
 
 export class RootDefinition extends NodeDefinition<'root'> {
@@ -17,6 +19,7 @@ export class RootDefinition extends NodeDefinition<'root'> {
 	readonly bodyElement = null;
 	readonly root = this;
 	readonly parent = null;
+	readonly namespaceDeclarations: readonly RootNamespaceDeclaration[];
 	readonly attributes: readonly RootAttributeDefinition[];
 	readonly children: readonly ChildNodeDefinition[];
 	readonly instances = null;
@@ -55,9 +58,15 @@ export class RootDefinition extends NodeDefinition<'root'> {
 
 		this.nodeName = nodeName;
 		this.node = primaryInstanceRoot;
-		this.attributes = Array.from(primaryInstanceRoot.attributes).map((attr) => {
+
+		const attributes = Array.from(primaryInstanceRoot.attributes).map((attr) => {
 			return new RootAttributeDefinition(attr);
 		});
+		const namespaceDeclarationMap = new RootNamespaceDeclarations(primaryInstanceRoot, attributes);
+
+		this.attributes = attributes;
+		this.namespaceDeclarations = Array.from(namespaceDeclarationMap.values());
+
 		this.children = this.buildSubtree(this);
 	}
 

--- a/packages/xforms-engine/src/parse/model/RootNamespaceDeclaration.ts
+++ b/packages/xforms-engine/src/parse/model/RootNamespaceDeclaration.ts
@@ -1,0 +1,29 @@
+import { XMLNS_PREFIX } from '@getodk/common/constants/xmlns.ts';
+import { escapeXMLText } from '../../lib/xml-serialization.ts';
+
+export class RootNamespaceDeclaration {
+	private readonly serializedXML: string;
+
+	constructor(
+		readonly prefix: string | null,
+		readonly namespaceURI: string | null
+	) {
+		let serializedName: string;
+
+		if (prefix == null) {
+			serializedName = XMLNS_PREFIX;
+		} else {
+			serializedName = `${XMLNS_PREFIX}:${prefix}`;
+		}
+
+		const serializedValue = escapeXMLText(namespaceURI ?? '', true);
+
+		this.serializedXML = ` ${serializedName}="${serializedValue}"`;
+
+		this.prefix = prefix;
+	}
+
+	serializeNamespaceDeclarationXML(): string {
+		return this.serializedXML;
+	}
+}

--- a/packages/xforms-engine/src/parse/model/RootNamespaceDeclaration.ts
+++ b/packages/xforms-engine/src/parse/model/RootNamespaceDeclaration.ts
@@ -8,19 +8,18 @@ export class RootNamespaceDeclaration {
 		readonly prefix: string | null,
 		readonly namespaceURI: string | null
 	) {
-		let serializedName: string;
-
 		if (prefix == null) {
-			serializedName = XMLNS_PREFIX;
+			// We intentionally omit the default namespace declaration, which is
+			// consistent with both Collect and Enketo. Including it may technically
+			// be more "correct", but consistency ensures we don't introduce subtle
+			// problems in any namespace-aware usage downstream.
+			this.serializedXML = '';
 		} else {
-			serializedName = `${XMLNS_PREFIX}:${prefix}`;
+			const name = `${XMLNS_PREFIX}:${prefix}`;
+			const value = escapeXMLText(namespaceURI ?? '', true);
+
+			this.serializedXML = ` ${name}="${value}"`;
 		}
-
-		const serializedValue = escapeXMLText(namespaceURI ?? '', true);
-
-		this.serializedXML = ` ${serializedName}="${serializedValue}"`;
-
-		this.prefix = prefix;
 	}
 
 	serializeNamespaceDeclarationXML(): string {

--- a/packages/xforms-engine/src/parse/model/RootNamespaceDeclarations.ts
+++ b/packages/xforms-engine/src/parse/model/RootNamespaceDeclarations.ts
@@ -1,0 +1,38 @@
+import { XMLNS_NAMESPACE_URI, XMLNS_PREFIX } from '@getodk/common/constants/xmlns.ts';
+import type { RootAttributeDefinition } from './RootAttributeDefinition.ts';
+import { RootNamespaceDeclaration } from './RootNamespaceDeclaration.ts';
+
+export class RootNamespaceDeclarations extends Map<string | null, RootNamespaceDeclaration> {
+	constructor(sourceElement: Element, attributes: readonly RootAttributeDefinition[]) {
+		const { prefix: elementPrefix, namespaceURI: elementNamespaceURI } = sourceElement;
+
+		super([[elementPrefix, new RootNamespaceDeclaration(elementPrefix, elementNamespaceURI)]]);
+
+		this.set(
+			sourceElement.prefix,
+			new RootNamespaceDeclaration(sourceElement.prefix, sourceElement.namespaceURI)
+		);
+
+		for (const attribute of attributes) {
+			const { namespaceURI, nodeName, prefix, localName, value } = attribute;
+
+			// Attribute **IS** a namespace declaration. See commentary on
+			// `RootAttributeDefinition`.
+			if (namespaceURI === XMLNS_NAMESPACE_URI) {
+				// If the nodeName is `xmlns`, the attribute is a **DEFAULT**
+				// namespace declaration (also known as the "null namespace"). In
+				// which case, the _declared prefix_ is `null`.
+				if (nodeName === XMLNS_PREFIX) {
+					this.set(null, new RootNamespaceDeclaration(null, value));
+				}
+				// Otherwise, the declared prefix is the attribute node's _local name_,
+				// e.g. `xmlns:orx` is a declaration for the namespace prefix `orx`.
+				else {
+					this.set(null, new RootNamespaceDeclaration(localName, value));
+				}
+			} else if (!this.has(prefix)) {
+				this.set(prefix, new RootNamespaceDeclaration(prefix, namespaceURI));
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #286.

## I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Not applicable

## What else has been done to verify that this works as intended?

- Added tests for attributes
- Updated tests for XML namespace declarations

## Why is this the best possible solution? Were any other approaches considered?

It'd be better to have a more general solution for both attributes and namespace declarations.

Both would involve significant work on both parsing (to capture attributes and namespace prefixes/declarations throughout the primary instance subtree), as well as the primary instance state data model (as we don't have a concept of attributes, and presently ignore non-default-namespace element names).

I'd be remiss if I failed to mention that there would have been an even hacker way to deal with namespace declarations: abuse built-in DOM serialization (as it functionally does the same thing to derive namespaces as this change does more explicitly). I didn't do this because:

- It'd be **a lot less clear** what's happening and why
- I don't think it's standardized in any way, and I wouldn't be surprised if `jsdom`/any other DOM-compat library would make that technique unreliable

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's possible that even the simplified solution has ignored some edge case, which would be most likely around namespaces. I think I was fairly thorough, but the parse-stage collection of namespaces in a temporary map would be the most likely suspect.

It's also possible some logical error might have introduced subtle fallibility. I'm hopeful that letting the type system guide the change avoided most if not all of that risk.

## Do we need any specific form for testing your changes? If so, please attach one.

I think any form will do?

## What's changed

- **Static** attributes on the primary instance root element are parsed, and re-serialized on submission
- Namespace declarations are parsed (or derived) on the primary instance root element, also re-serialized on submission