### PR TITLE
Add submission as submit event payload

### DIFF
--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -39,7 +39,7 @@ initializeForm(props.formXml, {
 
 const handleSubmit = () => {
 	if (odkForm.value?.validationState.violations?.length === 0) {
-		emit('submit');
+		emit('submit', odkForm.value.prepareSubmission());
 	} else {
 		submitPressed.value = true;
 		document.scrollingElement?.scrollTo(0, 0);


### PR DESCRIPTION
Towards #23 
Towards #290 

Requirement of getodk/central-frontend#1125

With this, the submission becomes available to a "host application" as in the payload of the Vue event that is emitted when the submit button is used.

## I have verified this PR works in these browsers (latest versions):

- [X] Chrome
- [X] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Not applicable

## What else has been done to verify that this works as intended?

## Why is this the best possible solution? Were any other approaches considered?

Instead of having to await in the event handler, we could instead await right here in Webforms-land so that the event handling code doesn't have to. Perhaps that's easier for host application writers. I'm happy with it either way.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

## Do we need any specific form for testing your changes? If so, please attach one.

## What's changed
