### PR TITLE
Emit submission payload(s) to host app

### DIFF
--- a/.changeset/friendly-monkeys-grab.md
+++ b/.changeset/friendly-monkeys-grab.md
@@ -1,0 +1,6 @@
+---
+'@getodk/web-forms': minor
+---
+
+- Emit submission payload when subscribed to `submit` event
+- Emit chunked submission payload when subscribed to new `submitChunked` event

--- a/.changeset/strange-needles-compare.md
+++ b/.changeset/strange-needles-compare.md
@@ -1,0 +1,5 @@
+---
+'@getodk/xforms-engine': patch
+---
+
+Fix: correct types for chunked/monolithic submission result

--- a/packages/scenario/src/jr/Scenario.ts
+++ b/packages/scenario/src/jr/Scenario.ts
@@ -7,9 +7,6 @@ import type {
 	RepeatRangeUncontrolledNode,
 	RootNode,
 	SelectNode,
-	SubmissionChunkedType,
-	SubmissionOptions,
-	SubmissionResult,
 } from '@getodk/xforms-engine';
 import { constants as ENGINE_CONSTANTS } from '@getodk/xforms-engine';
 import type { Accessor, Setter } from 'solid-js';
@@ -965,10 +962,8 @@ export class Scenario {
 	 * more about Collect's responsibility for submission (beyond serialization,
 	 * already handled by {@link proposed_serializeInstance}).
 	 */
-	prepareWebFormsSubmission<ChunkedType extends SubmissionChunkedType>(
-		options?: SubmissionOptions<ChunkedType>
-	): Promise<SubmissionResult<ChunkedType>> {
-		return this.instanceRoot.prepareSubmission<ChunkedType>(options);
+	prepareWebFormsSubmission() {
+		return this.instanceRoot.prepareSubmission();
 	}
 
 	// TODO: consider adapting tests which use the following interfaces to use

--- a/packages/web-forms/src/demo/FormPreview.vue
+++ b/packages/web-forms/src/demo/FormPreview.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { xformFixturesByCategory, XFormResource } from '@getodk/common/fixtures/xforms.ts';
-import type { FetchFormAttachment, MissingResourceBehavior } from '@getodk/xforms-engine';
+import type {
+	ChunkedSubmissionResult,
+	FetchFormAttachment,
+	MissingResourceBehavior,
+	MonolithicSubmissionResult,
+} from '@getodk/xforms-engine';
 import { constants as ENGINE_CONSTANTS } from '@getodk/xforms-engine';
 import { ref } from 'vue';
 import { useRoute } from 'vue-router';
@@ -50,8 +55,16 @@ xformResource
 		alert('Failed to load the Form XML');
 	});
 
-const handleSubmit = () => {
+const handleSubmit = (payload: MonolithicSubmissionResult) => {
+	// eslint-disable-next-line no-console
+	console.log('submission payload:', payload);
+
 	alert(`Submit button was pressed`);
+};
+
+const handleSubmitChunked = (payload: ChunkedSubmissionResult) => {
+	// eslint-disable-next-line no-console
+	console.log('CHUNKED submission payload:', payload);
 };
 </script>
 <template>
@@ -60,7 +73,9 @@ const handleSubmit = () => {
 			:form-xml="formPreviewState.formXML"
 			:fetch-form-attachment="formPreviewState.fetchFormAttachment"
 			:missing-resource-behavior="formPreviewState.missingResourceBehavior"
+			:submission-max-size="Infinity"
 			@submit="handleSubmit"
+			@submit-chunked="handleSubmitChunked"
 		/>
 		<FeedbackButton />
 	</template>

--- a/packages/xforms-engine/src/client/RootNode.ts
+++ b/packages/xforms-engine/src/client/RootNode.ts
@@ -3,8 +3,12 @@ import type { RootDefinition } from '../parse/model/RootDefinition.ts';
 import type { BaseNode, BaseNodeState } from './BaseNode.ts';
 import type { ActiveLanguage, FormLanguage, FormLanguages } from './FormLanguage.ts';
 import type { GeneralChildNode } from './hierarchy.ts';
-import type { SubmissionChunkedType, SubmissionOptions } from './submission/SubmissionOptions.ts';
-import type { SubmissionResult } from './submission/SubmissionResult.ts';
+import type { SubmissionOptions } from './submission/SubmissionOptions.ts';
+import type {
+	ChunkedSubmissionResult,
+	MonolithicSubmissionResult,
+	SubmissionResult,
+} from './submission/SubmissionResult.ts';
 import type { AncestorNodeValidationState } from './validation.ts';
 
 export interface RootNodeState extends BaseNodeState {
@@ -84,7 +88,7 @@ export interface RootNode extends BaseNode {
 	 * A client may specify {@link SubmissionOptions<'chunked'>}, in which case a
 	 * {@link SubmissionResult<'chunked'>} will be produced, with form attachments
 	 */
-	prepareSubmission<ChunkedType extends SubmissionChunkedType>(
-		options?: SubmissionOptions<ChunkedType>
-	): Promise<SubmissionResult<ChunkedType>>;
+	prepareSubmission(): Promise<MonolithicSubmissionResult>;
+	prepareSubmission(options: SubmissionOptions<'monolithic'>): Promise<MonolithicSubmissionResult>;
+	prepareSubmission(options: SubmissionOptions<'chunked'>): Promise<ChunkedSubmissionResult>;
 }


### PR DESCRIPTION
Supersedes and closes #289. Closes #23. Closes #290.

## I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Not applicable

It would shock me if there's anything browser-specific here.

## What else has been done to verify that this works as intended?

Types do much of the work. Added console logs in `FormPreview.vue` demonstrate both handlers working.

## Why is this the best possible solution? Were any other approaches considered?

I mentioned this in Slack, and will reiterate here: in hindsight, since there are two distinct `SubmissionResult` payload formats, events may not be the best API for this. On the other hand, it may be possible to improve the API by:

- Making `submissionMaxSize` generic at the component/package boundary
- Restoring the single `submit` event emit, implicitly branching the payload type so it's chunked if `submissionMaxSize` is non-nullish, monolithic otherwise

This change already felt big enough (especially compared to the #289 1-liner), so I didn't want to hold it up to explore that. Especially because I'm already kind of uncomfortable with the implicit coupling between a prop and emit, and I'm not sure branching on the prop would ameliorate that!

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I can't think of anything beyond... this exposes existing functionality to a host application, along with any known or unknown bugs that may already be present.

## Do we need any specific form for testing your changes? If so, please attach one.

N/A

## What's changed

The main `@getodk/web-forms` component now:

- Emits a `MonolithicSubmissionResult` if a host application attaches a `submit` event handler
- Adds an optional `submissionMaxSize` prop
- Emits a `ChunkedSubmissionResult` if a host application specifies `submissionMaxSize` and attaches a `submitChunked` event handler