### PR TITLE
Variadic `distance`, minor related XPath geo functionality improvements

### DIFF
--- a/.changeset/funny-items-know.md
+++ b/.changeset/funny-items-know.md
@@ -1,0 +1,5 @@
+---
+"@getodk/xpath": minor
+---
+
+The `xf:distance` function signature is now variadic, consistent with the revised signature specified by ODK XForms.

--- a/.changeset/funny-items-know2.md
+++ b/.changeset/funny-items-know2.md
@@ -1,0 +1,5 @@
+---
+"@getodk/xforms-engine": minor
+---
+
+The `xf:distance` XPath function now accepts multiple arguments. This makes it easier to compute the distance between multiple points within a form's primary instance. Previously, to achieve this, you'd have to introduce a `calculate` which concatenates those points together, then call the distance function with a reference to that `calculate` as the argument.

--- a/.changeset/wise-dancers-itch.md
+++ b/.changeset/wise-dancers-itch.md
@@ -1,0 +1,10 @@
+---
+"@getodk/xpath": patch
+---
+
+Improved consistency with Collect/JavaRosa:
+
+
+- `area` and `distance` handle a trailing semicolon in serialized semicolon-separated `geopoint` lists
+- `distance` produces an error for invalid input
+- `area` returns `0` for invalid input

--- a/packages/common/src/fixtures/xpath-fns/variadic-distance.xml
+++ b/packages/common/src/fixtures/xpath-fns/variadic-distance.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+  xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms"
+  xmlns:odk="http://www.opendatakit.org/xforms">
+  <h:head>
+    <h:title>Examples using the distance() and area() function</h:title>
+    <model odk:xforms-version="1.0.0">
+      <instance>
+        <data id="distance_examples" version="20241025195211">
+          <location1>-6.8137120026589315 39.29392995851879 400 10</location1>
+          <location2>-6.815178491608137 39.29533915133268</location2>
+          <location3>-6.81189589956027 39.2973513889647 600</location3>
+          <location4>-6.81223343508222 39.29735351357036</location4>
+          <geoshape_12341 />
+          <distance_1234 />
+          <area_1234 />
+          <distance_mixed />
+          <distance_via_geoshape />
+          <meta>
+            <instanceID />
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/location1" readonly="true()" type="string" />
+      <bind nodeset="/data/location2" readonly="true()" type="string" />
+      <bind nodeset="/data/location3" readonly="true()" type="string" />
+      <bind nodeset="/data/location4" readonly="true()" type="string" />
+      <bind nodeset="/data/geoshape_12341" readonly="true()" type="string"
+        calculate="join(&quot;; &quot;,  /data/location1 ,  /data/location2 ,  /data/location3 ,  /data/location4 ,  /data/location1 )" />
+      <bind nodeset="/data/distance_1234" readonly="true()" type="string"
+        calculate="distance( /data/location1 ,  /data/location2 ,  /data/location3 ,  /data/location4 )" />
+      <bind nodeset="/data/area_1234" readonly="true()" type="string"
+        calculate="area( /data/geoshape_12341 )" />
+      <bind nodeset="/data/distance_mixed" readonly="true()" type="string"
+        calculate="distance( /data/location1 ,  /data/location2 ,  /data/location3 ,  /data/location4 , '-6.8137120026589315 39.29392995851879 400 10')" />
+      <bind nodeset="/data/distance_via_geoshape" readonly="true()" type="string"
+        calculate="distance( /data/geoshape_12341 )" />
+      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid" />
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/location1">
+      <label>where 1</label>
+    </input>
+    <input ref="/data/location2">
+      <label>where 2</label>
+    </input>
+    <input ref="/data/location3">
+      <label>where 3</label>
+    </input>
+    <input ref="/data/location4">
+      <label>where 4</label>
+    </input>
+    <input ref="/data/geoshape_12341">
+      <label>geoshape 12341</label>
+    </input>
+    <input ref="/data/distance_1234">
+      <label>distance 1234</label>
+    </input>
+    <input ref="/data/area_1234">
+      <label>area 1234</label>
+    </input>
+    <input ref="/data/distance_mixed">
+      <label>distance 12341 mixed-type arguments</label>
+    </input>
+    <input ref="/data/distance_via_geoshape">
+      <label>distance 12341 via geoshape</label>
+    </input>
+  </h:body>
+</h:html>

--- a/packages/scenario/test/data-types/geo.test.ts
+++ b/packages/scenario/test/data-types/geo.test.ts
@@ -17,27 +17,11 @@ import { floatAnswer } from '../../src/answer/ExpectedFloatAnswer.ts';
 import { Scenario } from '../../src/jr/Scenario.ts';
 import { EARTH_EQUATORIAL_CIRCUMFERENCE_METERS } from '../../src/jr/core/util/GeoUtils.ts';
 
-interface TrailingSemicolonOptions {
-	readonly stripTrailingSemicolon: boolean;
-}
-
-const geopointListValue = (portedValue: string, options: TrailingSemicolonOptions) => {
-	if (options.stripTrailingSemicolon) {
-		return portedValue.replace(/;$/, '');
-	}
-
-	return portedValue;
-};
-
 const NINETY_DEGREES_ON_EQUATOR_KM = EARTH_EQUATORIAL_CIRCUMFERENCE_METERS / 4;
 
 interface RelaxedPrecisionOptions {
 	readonly relaxAssertionPrecision: boolean;
 }
-
-interface CombinedParameterizationOptions
-	extends RelaxedPrecisionOptions,
-		TrailingSemicolonOptions {}
 
 /**
  * **PORTING NOTES**
@@ -362,68 +346,55 @@ describe('Geoshape', () => {
 			/**
 			 * **PORTING NOTES**
 			 *
-			 * Fails on both of:
-			 *
-			 * - Directly ported precision. Same notes as previous test in first
-			 *   geopoint distance test.
-			 *
-			 * - Trailing semicolon in `/data/polygon` value.
-			 *
-			 * Parameterized to demonstrate passage when accommodating both.
+			 * Fails on directly ported precision. Same notes as previous test in
+			 * first geopoint distance test. Parameterized to demonstrate passage when
+			 * accommodated.
 			 */
-			describe.each<CombinedParameterizationOptions>([
-				{ relaxAssertionPrecision: false, stripTrailingSemicolon: false },
-				{ relaxAssertionPrecision: true, stripTrailingSemicolon: true },
-			])(
-				'relax assertion precision: $relaxAssertionPrecision; strip triling semicolon: $stripTrailingSemicolon',
-				({ relaxAssertionPrecision, stripTrailingSemicolon }) => {
-					let testFn: typeof it | typeof it.fails;
+			describe.each<RelaxedPrecisionOptions>([
+				{ relaxAssertionPrecision: false },
+				{ relaxAssertionPrecision: true },
+			])('relax assertion precision: $relaxAssertionPrecision', ({ relaxAssertionPrecision }) => {
+				let testFn: typeof it | typeof it.fails;
 
-					if (relaxAssertionPrecision && stripTrailingSemicolon) {
-						testFn = it;
-					} else {
-						testFn = it.fails;
-					}
-
-					testFn('is computed for geoshape', async () => {
-						const scenario = await Scenario.init(
-							'geoshape distance',
-							html(
-								head(
-									title('Geoshape distance'),
-									model(
-										mainInstance(
-											t(
-												'data id="geoshape-distance"',
-												t(
-													'polygon',
-													geopointListValue('0 1 0 0; 0 91 0 0; 0 1 0 0;', {
-														stripTrailingSemicolon,
-													})
-												),
-												t('distance')
-											)
-										),
-										bind('/data/polygon').type('geoshape'),
-										bind('/data/distance').type('decimal').calculate('distance(/data/polygon)')
-									)
-								),
-								body(input('/data/polygon'))
-							)
-						);
-
-						// assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
-						// 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM * 2, 1e-7));
-						// })
-						expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
-							expectedDistance(
-								NINETY_DEGREES_ON_EQUATOR_KM * 2,
-								relaxAssertionPrecision ? 0.0999999 : 1e-7
-							)
-						);
-					});
+				if (relaxAssertionPrecision) {
+					testFn = it;
+				} else {
+					testFn = it.fails;
 				}
-			);
+
+				testFn('is computed for geoshape', async () => {
+					const scenario = await Scenario.init(
+						'geoshape distance',
+						html(
+							head(
+								title('Geoshape distance'),
+								model(
+									mainInstance(
+										t(
+											'data id="geoshape-distance"',
+											t('polygon', '0 1 0 0; 0 91 0 0; 0 1 0 0;'),
+											t('distance')
+										)
+									),
+									bind('/data/polygon').type('geoshape'),
+									bind('/data/distance').type('decimal').calculate('distance(/data/polygon)')
+								)
+							),
+							body(input('/data/polygon'))
+						)
+					);
+
+					// assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
+					// 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM * 2, 1e-7));
+					// })
+					expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
+						expectedDistance(
+							NINETY_DEGREES_ON_EQUATOR_KM * 2,
+							relaxAssertionPrecision ? 0.0999999 : 1e-7
+						)
+					);
+				});
+			});
 		});
 	});
 });
@@ -434,109 +405,78 @@ describe('Geotrace', () => {
 			/**
 			 * **PORTING NOTES**
 			 *
-			 * Fails on both of:
-			 *
-			 * - Directly ported precision. Same notes as previous test in first
-			 *   geopoint distance test.
-			 *
-			 * - Trailing semicolon in `/data/line` value.
-			 *
-			 * Parameterized to demonstrate passage when accommodating both.
+			 * Fails on directly ported precision. Same notes as previous test in
+			 * first geopoint distance test. Parameterized to demonstrate passage with
+			 * relaxed precision.
 			 */
-			describe.each<CombinedParameterizationOptions>([
-				{ relaxAssertionPrecision: false, stripTrailingSemicolon: false },
-				{ relaxAssertionPrecision: true, stripTrailingSemicolon: true },
-			])(
-				'relax assertion precision: $relaxAssertionPrecision; strip triling semicolon: $stripTrailingSemicolon',
-				({ relaxAssertionPrecision, stripTrailingSemicolon }) => {
-					let testFn: typeof it | typeof it.fails;
+			describe.each<RelaxedPrecisionOptions>([
+				{ relaxAssertionPrecision: false },
+				{ relaxAssertionPrecision: true },
+			])('relax assertion precision: $relaxAssertionPrecision', ({ relaxAssertionPrecision }) => {
+				let testFn: typeof it | typeof it.fails;
 
-					if (relaxAssertionPrecision && stripTrailingSemicolon) {
-						testFn = it;
-					} else {
-						testFn = it.fails;
-					}
-
-					testFn('is computed for geotrace', async () => {
-						const scenario = await Scenario.init(
-							'geotrace distance',
-							html(
-								head(
-									title('Geotrace distance'),
-									model(
-										mainInstance(
-											t(
-												'data id="geotrace-distance"',
-												t(
-													'line',
-													geopointListValue('0 1 0 0; 0 91 0 0;', { stripTrailingSemicolon })
-												),
-												t('distance')
-											)
-										),
-										bind('/data/line').type('geotrace'),
-										bind('/data/distance').type('decimal').calculate('distance(/data/line)')
-									)
-								),
-								body(input('/data/line'))
-							)
-						);
-
-						// assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
-						// 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM, 1e-7));
-						expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
-							expectedDistance(
-								NINETY_DEGREES_ON_EQUATOR_KM,
-								relaxAssertionPrecision ? 0.0999999 : 1e-7
-							)
-						);
-					});
+				if (relaxAssertionPrecision) {
+					testFn = it;
+				} else {
+					testFn = it.fails;
 				}
-			);
+
+				testFn('is computed for geotrace', async () => {
+					const scenario = await Scenario.init(
+						'geotrace distance',
+						html(
+							head(
+								title('Geotrace distance'),
+								model(
+									mainInstance(
+										t('data id="geotrace-distance"', t('line', '0 1 0 0; 0 91 0 0;'), t('distance'))
+									),
+									bind('/data/line').type('geotrace'),
+									bind('/data/distance').type('decimal').calculate('distance(/data/line)')
+								)
+							),
+							body(input('/data/line'))
+						)
+					);
+
+					// assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
+					// 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM, 1e-7));
+					expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
+						expectedDistance(
+							NINETY_DEGREES_ON_EQUATOR_KM,
+							relaxAssertionPrecision ? 0.0999999 : 1e-7
+						)
+					);
+				});
+			});
 
 			describe('when [`geotrace`] trace has fewer than two points', () => {
-				describe.each<TrailingSemicolonOptions>([
-					{ stripTrailingSemicolon: false },
-					{ stripTrailingSemicolon: true },
-				])('strip trailing semicolons: $stripTrailingSemicolons', ({ stripTrailingSemicolon }) => {
-					/**
-					 * **PORTING NOTES**
-					 *
-					 * - Direct port is currently expected to fail due to trailing
-					 *   semicolon in `/data/line` value.
-					 *
-					 * - Parameterized alternate test stripping that trailing semicolon
-					 *   also fails, producing {@link NaN} where the value is expected to
-					 *   be zero. This is presumably a bug in the XPath `distance`
-					 *   function's handling of this specific case (and would likely
-					 *   affect Enketo as well, since the extant tests were ported from
-					 *   ORXE).
-					 */
-					it.fails('is zero', async () => {
-						const scenario = await Scenario.init(
-							'geotrace distance',
-							html(
-								head(
-									title('Geotrace distance'),
-									model(
-										mainInstance(
-											t(
-												'data id="geotrace-distance"',
-												t('line', geopointListValue('0 1 0 0;', { stripTrailingSemicolon })),
-												t('distance')
-											)
-										),
-										bind('/data/line').type('geotrace'),
-										bind('/data/distance').type('decimal').calculate('distance(/data/line)')
-									)
-								),
-								body(input('/data/line'))
-							)
-						);
+				/**
+				 * **PORTING NOTES**
+				 *
+				 * Fails due to another nuance of `distance` fallibility. Evidently
+				 *
+				 */
+				it.fails('is zero', async () => {
+					const scenario = await Scenario.init(
+						'geotrace distance',
+						html(
+							head(
+								title('Geotrace distance'),
+								model(
+									mainInstance(
+										t('data id="geotrace-distance"', t('line', '0 1 0 0;'), t('distance'))
+									),
+									bind('/data/line').type('geotrace'),
+									bind('/data/distance').type('decimal').calculate('distance(/data/line)')
+								)
+							),
+							body(input('/data/line'))
+						)
+					);
 
-						// assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()), is(0.0));
-						expect(scenario.answerOf('/data/distance')).toEqualAnswer(floatAnswer(0.0));
-					});
+					// assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()), is(0.0));
+					expect(scenario.answerOf('/data/distance')).toEqualAnswer(floatAnswer(0.0));
 				});
 			});
 		});

--- a/packages/scenario/test/xpath/functions/distance.test.ts
+++ b/packages/scenario/test/xpath/functions/distance.test.ts
@@ -1,0 +1,191 @@
+import {
+	bind,
+	body,
+	head,
+	html,
+	input,
+	mainInstance,
+	model,
+	t,
+	title,
+} from '@getodk/common/test/fixtures/xform-dsl/index.ts';
+import { describe, expect, it } from 'vitest';
+import { expectedDistance } from '../../../src/answer/ExpectedApproximateUOMAnswer.ts';
+import { Scenario } from '../../../src/jr/Scenario.ts';
+
+/**
+ * **PORTING NOTES**
+ *
+ * 1. There are quite a few other `distance` tests ported from JavaRosa, in
+ *    {@link ../../data-types/geo.test.ts}. In hindsight, many (if not all) of
+ *    the tests in that suite/module would be more appropriate here, or in an
+ *    adjacent `area.test.ts` suite/module.
+ *
+ * 2. Whenever we add integration tests of XPath function behavior, I get a
+ *    little bit cautious that we have two competing testing strategies for
+ *    them. Unlike most of the ported JavaRosa tests, the current Web Forms
+ *    project structure would probably prefer to have these functions tested in
+ *    `@getodk/xpath`, as unit-ish tests. There's seldom (if ever) anything
+ *    _about an XPath function_ which warrants an integration test.
+ *
+ * 3. On the other hand, we've recently had some renewed discussion about the
+ *    future of that package's responsibilities: i.e. whether it might make more
+ *    sense to implement ODK XForms extensions downstream (either in
+ *    `@getodk/xforms-engine`, or in some intermediate package). In which case,
+ *    we'd want to reconsider some of the testing strategy broadly. I'm still
+ *    not sure there's much value in integration tests of XPath function
+ *    behavior! But the existing XPath tests are also ported (from
+ *    `openrosa-xpath-evaluator`); if they were to move, we'd also have an
+ *    opportunity to bring those tests more in line with project goals/idioms.
+ */
+describe('XPath function support: `distance`', () => {
+	describe('GeoDistanceTest.java', () => {
+		// JR: distance_isComputedForInlineString
+		it('computes distance for a string (Literal) argument', async () => {
+			// prettier-ignore
+			const scenario = await Scenario.init('string distance', html(
+				head(
+					title('String distance'),
+					model(
+						mainInstance(t('data id="string-distance"',
+							t('point1', '38.253094215699576 21.756382658677467 0 0'),
+							t('point2', '38.25021274773806 21.756382658677467 0 0'),
+							t('point3', '38.25007793942195 21.763892843919166 0 0'),
+							t('point4', '38.25290886154963 21.763935759263404 0 0'),
+							t('point5', '38.25146813817506 21.758421137528785 0 0'),
+							t('distance')
+						)),
+						bind('/data/point1').type('geopoint'),
+						bind('/data/point2').type('geopoint'),
+						bind('/data/point3').type('geopoint'),
+						bind('/data/point4').type('geopoint'),
+						bind('/data/point5').type('geopoint'),
+						bind('/data/distance').type('decimal').calculate("distance(concat(/data/point1, ';', /data/point2, ';', /data/point3, ';', /data/point4, ';', /data/point5))")
+					)),
+				body(
+					input('/data/point1')
+				)
+			));
+
+			// JR:
+			//
+			// // http://www.mapdevelopers.com/area_finder.php?&points=%5B%5B38.253094215699576%2C21.756382658677467%5D%2C%5B38.25021274773806%2C21.756382658677467%5D%2C%5B38.25007793942195%2C21.763892843919166%5D%2C%5B38.25290886154963%2C21.763935759263404%5D%2C%5B38.25146813817506%2C21.758421137528785%5D%5D
+			// assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
+			// 		IsCloseTo.closeTo(1801, 0.5));
+
+			expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(expectedDistance(1801, 0.5));
+		});
+
+		/**
+		 * **PORTING NOTES**
+		 *
+		 * Adapts JavaRosa's use of `try`/`catch` to typical Web Forms error
+		 * condition assertion style.
+		 *
+		 * @todo The shape of this test may change (like many others) when we
+		 * address error production broadly.
+		 */
+		// JR: distance_throwsForNonPoint
+		it('produces an error when the string value is not a valid point', async () => {
+			const init = async () => {
+				// prettier-ignore
+				await Scenario.init('string distance', html(
+						head(
+							title('String distance'),
+							model(
+								mainInstance(t('data id="string-distance"',
+									t('distance')
+								)),
+								bind('/data/distance').type('decimal').calculate("distance('foo')")
+							)),
+						body(
+							input('distance')
+						)
+				));
+			};
+
+			// **PORTING NOTES**
+			//
+			// We've currently copied this error message verbatim.
+			await expect(init).rejects.toThrowError(
+				"The function 'distance' received a value that does not represent GPS coordinates"
+			);
+		});
+
+		/**
+		 * **PORTING NOTES**
+		 *
+		 * The difference in language here is semantically important! Note that the
+		 * JavaRosa test name references "path" arguments, but the test exercises a
+		 * spec expansion where the path may be composed of multiple **point**
+		 * arguments.
+		 */
+		// JR: distance_isComputedForMultiplePathArguments
+		it('computes a distance from multiple node-set arguments, where each node has a `geopoint` value', async () => {
+			// prettier-ignore
+			const scenario = await Scenario.init('string distance', html(
+				head(
+					title('Multi parameter distance'),
+					model(
+						mainInstance(t('data id="string-distance"',
+							t('point1', '38.253094215699576 21.756382658677467 0 0'),
+							t('point2', '38.25021274773806 21.756382658677467 0 0'),
+							t('point3', '38.25007793942195 21.763892843919166 0 0'),
+							t('point4', '38.25290886154963 21.763935759263404 0 0'),
+							t('point5', '38.25146813817506 21.758421137528785 0 0'),
+							t('distance')
+						)),
+						bind('/data/point1').type('geopoint'),
+						bind('/data/point2').type('geopoint'),
+						bind('/data/point3').type('geopoint'),
+						bind('/data/point4').type('geopoint'),
+						bind('/data/point5').type('geopoint'),
+						bind('/data/distance').type('decimal').calculate('distance(/data/point1, /data/point2, /data/point3, /data/point4, /data/point5)')
+					)),
+				body(
+					input('/data/point1')
+				)
+			));
+
+			// JR:
+			//
+			// // http://www.mapdevelopers.com/area_finder.php?&points=%5B%5B38.253094215699576%2C21.756382658677467%5D%2C%5B38.25021274773806%2C21.756382658677467%5D%2C%5B38.25007793942195%2C21.763892843919166%5D%2C%5B38.25290886154963%2C21.763935759263404%5D%2C%5B38.25146813817506%2C21.758421137528785%5D%5D
+			// assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
+			// 		IsCloseTo.closeTo(1801, 0.5));
+
+			expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(expectedDistance(1801, 0.5));
+		});
+
+		// JR: distance_isComputedForMixedPathAndStringArguments
+		it('computes a distance from mixed node-set and string (Literal) arguments', async () => {
+			// prettier-ignore
+			const scenario = await Scenario.init('string distance', html(
+				head(
+					title('Multi parameter distance'),
+					model(
+						mainInstance(t('data id="string-distance"',
+							t('point2', '38.25021274773806 21.756382658677467 0 0'),
+							t('point3', '38.25007793942195 21.763892843919166 0 0'),
+							t('point5', '38.25146813817506 21.758421137528785 0 0'),
+							t('distance')
+						)),
+						bind('/data/point2').type('geopoint'),
+						bind('/data/point3').type('geopoint'),
+						bind('/data/point5').type('geopoint'),
+						bind('/data/distance').type('decimal').calculate("distance('38.253094215699576 21.756382658677467 0 0', /data/point2, /data/point3, '38.25290886154963 21.763935759263404 0 0', /data/point5)")
+					)),
+				body(
+					input('/data/point2')
+				)
+			));
+
+			// JR:
+			//
+			// // http://www.mapdevelopers.com/area_finder.php?&points=%5B%5B38.253094215699576%2C21.756382658677467%5D%2C%5B38.25021274773806%2C21.756382658677467%5D%2C%5B38.25007793942195%2C21.763892843919166%5D%2C%5B38.25290886154963%2C21.763935759263404%5D%2C%5B38.25146813817506%2C21.758421137528785%5D%5D
+			// assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
+			// 		IsCloseTo.closeTo(1801, 0.5));
+
+			expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(expectedDistance(1801, 0.5));
+		});
+	});
+});

--- a/packages/scenario/test/xpath/functions/distance.test.ts
+++ b/packages/scenario/test/xpath/functions/distance.test.ts
@@ -188,4 +188,39 @@ describe('XPath function support: `distance`', () => {
 			expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(expectedDistance(1801, 0.5));
 		});
 	});
+
+	describe('multiple arguments, mixed value types', () => {
+		it('produces an error for a non-geopoint value in a multiple argument call', async () => {
+			const init = async () => {
+				await Scenario.init(
+					'geoshape distance',
+					html(
+						head(
+							title('Geoshape distance'),
+							model(
+								mainInstance(
+									t(
+										'data id="geoshape-distance"',
+										t('polygon-start-trace', '0 1 0 0; 0 91 0 0;'),
+										t('polygon-close-point', '0 1 0 0'),
+										t('distance')
+									)
+								),
+								bind('/data/polygon-start-trace').type('geotrace'),
+								bind('/data/polygon-close-point').type('geopoint'),
+								bind('/data/distance')
+									.type('decimal')
+									.calculate('distance(/data/polygon-start-trace, /data/polygon-close-point)')
+							)
+						),
+						body(input('/data/polygon-start-trace'), input('/data/polygon-close-point'))
+					)
+				);
+			};
+
+			await expect(init).rejects.toThrowError(
+				"The function 'distance' received a value that does not represent GPS coordinates"
+			);
+		});
+	});
 });

--- a/packages/xpath/src/error/JRCompatibleError.ts
+++ b/packages/xpath/src/error/JRCompatibleError.ts
@@ -1,0 +1,6 @@
+/**
+ * @todo This is intended as a temporary placeholder, so we can identify cases
+ * where we've reused JavaRosa error messaging, especially if it's not clear
+ * whether that reuse makes sense.
+ */
+export class JRCompatibleError extends Error {}

--- a/packages/xpath/src/error/JRCompatibleGeoValueError.ts
+++ b/packages/xpath/src/error/JRCompatibleGeoValueError.ts
@@ -1,0 +1,7 @@
+import { JRCompatibleError } from './JRCompatibleError.ts';
+
+export class JRCompatibleGeoValueError extends JRCompatibleError {
+	constructor() {
+		super("The function 'distance' received a value that does not represent GPS coordinates");
+	}
+}

--- a/packages/xpath/src/error/JRCompatibleGeoValueError.ts
+++ b/packages/xpath/src/error/JRCompatibleGeoValueError.ts
@@ -1,7 +1,13 @@
 import { JRCompatibleError } from './JRCompatibleError.ts';
 
+// prettier-ignore
+type JRCompatibleFallibleGeoFunction =
+	| 'distance'
+	| 'geofence' // TODO!
+	;
+
 export class JRCompatibleGeoValueError extends JRCompatibleError {
-	constructor() {
-		super("The function 'distance' received a value that does not represent GPS coordinates");
+	constructor(geoFunction: JRCompatibleFallibleGeoFunction) {
+		super(`The function '${geoFunction}' received a value that does not represent GPS coordinates`);
 	}
 }

--- a/packages/xpath/src/evaluator/functions/FunctionImplementation.ts
+++ b/packages/xpath/src/evaluator/functions/FunctionImplementation.ts
@@ -39,7 +39,7 @@ export class InvalidArgumentError extends Error {
 	}
 }
 
-export type ParameterArityType = 'optional' | 'required' | 'variadic' | 'variadic+';
+export type ParameterArityType = 'optional' | 'required' | 'variadic';
 
 export type ParameterTypeHint =
 	// | 'lazy' // TODO: it might be good to *explicitly* mark certain parameters
@@ -122,12 +122,6 @@ export class FunctionImplementation {
 					case 'variadic':
 						return {
 							min: acc.min,
-							max: Infinity,
-						};
-
-					case 'variadic+':
-						return {
-							min: acc.min + 1,
 							max: Infinity,
 						};
 

--- a/packages/xpath/src/evaluator/functions/FunctionImplementation.ts
+++ b/packages/xpath/src/evaluator/functions/FunctionImplementation.ts
@@ -39,7 +39,7 @@ export class InvalidArgumentError extends Error {
 	}
 }
 
-export type ParameterArityType = 'optional' | 'required' | 'variadic';
+export type ParameterArityType = 'optional' | 'required' | 'variadic' | 'variadic+';
 
 export type ParameterTypeHint =
 	// | 'lazy' // TODO: it might be good to *explicitly* mark certain parameters
@@ -122,6 +122,12 @@ export class FunctionImplementation {
 					case 'variadic':
 						return {
 							min: acc.min,
+							max: Infinity,
+						};
+
+					case 'variadic+':
+						return {
+							min: acc.min + 1,
 							max: Infinity,
 						};
 

--- a/packages/xpath/src/functions/xforms/geo.ts
+++ b/packages/xpath/src/functions/xforms/geo.ts
@@ -1,6 +1,7 @@
 import { pairwise } from 'itertools-ts/lib/single';
 import type { XPathNode } from '../../adapter/interface/XPathNode.ts';
 import { EvaluationContext } from '../../context/EvaluationContext.ts';
+import { JRCompatibleError } from '../../error/JRCompatibleError.ts';
 import type { EvaluableArgument } from '../../evaluator/functions/FunctionImplementation.ts';
 import { NumberFunction } from '../../evaluator/functions/NumberFunction.ts';
 
@@ -213,7 +214,9 @@ export const distance = new NumberFunction(
 		const lines = evaluateLines(context, args);
 
 		if (lines.some(isInvalidLine)) {
-			return NaN;
+			throw new JRCompatibleError(
+				"The function 'distance' received a value that does not represent GPS coordinates"
+			);
 		}
 
 		const distances = lines.map(geodesicDistance);

--- a/packages/xpath/src/functions/xforms/geo.ts
+++ b/packages/xpath/src/functions/xforms/geo.ts
@@ -84,10 +84,9 @@ const INVALID_LINE: Line = {
 
 const evaluateLines = <T extends XPathNode>(
 	context: EvaluationContext<T>,
-	expression: EvaluableArgument
+	expression: readonly EvaluableArgument[]
 ): Line[] => {
-	const points = evaluatePoints(context, expression);
-
+	const points = expression.flatMap((el) => evaluatePoints(context, el));
 	if (points.length < 2) {
 		return [INVALID_LINE];
 	}
@@ -172,7 +171,7 @@ export const area = new NumberFunction(
 	'area',
 	[{ arityType: 'required' }],
 	(context, [expression]) => {
-		const lines = evaluateLines(context, expression!);
+		const lines = evaluateLines(context, [expression!]);
 
 		if (lines.some(isInvalidLine)) {
 			return NaN;
@@ -209,9 +208,9 @@ const sum = (values: readonly number[]) => {
 
 export const distance = new NumberFunction(
 	'distance',
-	[{ arityType: 'required' }],
-	(context, [expression]) => {
-		const lines = evaluateLines(context, expression!);
+	[{ arityType: 'variadic' }],
+	(context, args) => {
+		const lines = evaluateLines(context, args);
 
 		if (lines.some(isInvalidLine)) {
 			return NaN;

--- a/packages/xpath/src/functions/xforms/geo.ts
+++ b/packages/xpath/src/functions/xforms/geo.ts
@@ -208,7 +208,7 @@ const sum = (values: readonly number[]) => {
 
 export const distance = new NumberFunction(
 	'distance',
-	[{ arityType: 'variadic' }],
+	[{ arityType: 'variadic+' }],
 	(context, args) => {
 		const lines = evaluateLines(context, args);
 

--- a/packages/xpath/src/functions/xforms/geo.ts
+++ b/packages/xpath/src/functions/xforms/geo.ts
@@ -208,7 +208,7 @@ const sum = (values: readonly number[]) => {
 
 export const distance = new NumberFunction(
 	'distance',
-	[{ arityType: 'variadic+' }],
+	[{ arityType: 'required' }, { arityType: 'variadic' }],
 	(context, args) => {
 		const lines = evaluateLines(context, args);
 

--- a/packages/xpath/src/lib/geo/EncodeGeoValueStubError.ts
+++ b/packages/xpath/src/lib/geo/EncodeGeoValueStubError.ts
@@ -1,0 +1,7 @@
+import type { GeoValueType } from './GeoValueCodec.ts';
+
+export class EncodeGeoValueStubError extends Error {
+	constructor(valueType: GeoValueType) {
+		super(`Encoding "${valueType}" values is not implemented here.`);
+	}
+}

--- a/packages/xpath/src/lib/geo/GeoValueCodec.ts
+++ b/packages/xpath/src/lib/geo/GeoValueCodec.ts
@@ -1,0 +1,44 @@
+// prettier-ignore
+export type GeoValueType =
+	| 'geopoint'
+	| 'geoshape'
+	| 'geotrace';
+
+export type GeoValueEncoder<RuntimeInputValue> = (input: RuntimeInputValue) => string;
+
+export type GeoValueDecoder<RuntimeValue> = (value: string) => RuntimeValue;
+
+/**
+ * @todo This is based on the same concepts expressed by the extant
+ * `@getodk/xforms-engine` `ValueCodec` class. It has been stripped down a more
+ * minimal interface, which might form a basis for shared responsibilities for
+ * value type support between packages. Its introduction now anticipates an
+ * imminent opportunity for sharing logic for the following data types:
+ *
+ * - {@link https://getodk.github.io/xforms-spec/#data-type:geopoint | geopoint}
+ * - {@link https://getodk.github.io/xforms-spec/#data-type:geotrace | geotrace}
+ * - {@link https://getodk.github.io/xforms-spec/#data-type:geoshape | geoshape}
+ *
+ * It makes sense to consider how we share this responsibility as we expand the
+ * Web Forms project's support for geo-related features, as there are mutually
+ * dependent responsibilities for encoding/decoding between the `@getodk/xpath`
+ * and `@getodk/xforms-engine` packages.
+ *
+ * It's also worth considering how we might address similar shared
+ * responsibilities for:
+ *
+ * - non-geo data types, and potential nuances of how those types are expected
+ *   to behave at the boundary between an ODK XForm's model, and the XPath
+ *   expressions operating on that model's nodes
+ * - XPath casting semantics, and whether/how that responsiblity intersects with
+ *   those ODK XForms data types
+ */
+export interface GeoValueCodec<
+	V extends GeoValueType,
+	RuntimeValue extends RuntimeInputValue,
+	RuntimeInputValue = RuntimeValue,
+> {
+	readonly valueType: V;
+	readonly encodeValue: GeoValueEncoder<RuntimeInputValue>;
+	readonly decodeValue: GeoValueDecoder<RuntimeValue>;
+}

--- a/packages/xpath/src/lib/geo/Geopoint.ts
+++ b/packages/xpath/src/lib/geo/Geopoint.ts
@@ -1,0 +1,93 @@
+import { JRCompatibleGeoValueError } from '../../error/JRCompatibleGeoValueError.ts';
+
+// prettier-ignore
+type GeopointNodeSubstringValues = readonly [
+	latitude: string,
+	longitude: string,
+	altitude?: string,
+	accuracy?: string,
+];
+
+type AssertGeopointNodeSubstringValues = (
+	values: ReadonlyArray<string | undefined>
+) => asserts values is GeopointNodeSubstringValues;
+
+const assertGeopointNodeSubstringValues: AssertGeopointNodeSubstringValues = (values) => {
+	if (values[0] == null || values[1] == null || values.length > 4) {
+		throw new JRCompatibleGeoValueError();
+	}
+};
+
+const DEGREES_MAX = {
+	latitude: 90,
+	longitude: 180,
+} as const;
+
+type GeographicAngleCoordinate = keyof typeof DEGREES_MAX;
+
+const decodeDegrees = (coordinate: GeographicAngleCoordinate, value: string): number => {
+	const degrees = Number(value);
+	const absolute = Math.abs(degrees);
+	const max = DEGREES_MAX[coordinate];
+
+	if (absolute > max) {
+		throw new JRCompatibleGeoValueError();
+	}
+
+	return degrees;
+};
+
+export interface GeopointCoordinates {
+	readonly latitude: number;
+	readonly longitude: number;
+}
+
+const decodeGeopointCoordinates = (nodeValue: string): GeopointCoordinates => {
+	const substringValues = nodeValue.split(/\s+/);
+
+	assertGeopointNodeSubstringValues(substringValues);
+
+	const [latitudeValue, longitudeValue] = substringValues;
+
+	const latitude = decodeDegrees('latitude', latitudeValue);
+	const longitude = decodeDegrees('longitude', longitudeValue);
+
+	return {
+		latitude,
+		longitude,
+	};
+};
+
+/**
+ * @todo this is derived from an interface that was introduced _internally_, to
+ * support the initial implementation of these related geo functions:
+ *
+ * - {@link https://getodk.github.io/xforms-spec/#fn:area | area}
+ * - {@link https://getodk.github.io/xforms-spec/#fn:distance | distance}
+ *
+ * It has been extracted here as a class as a potential basis for sharing
+ * geo-related functionality between Web Forms packages.
+ *
+ * **IMPORTANT:** it's likely that we'll reconsider how we model a
+ * {@link https://getodk.github.io/xforms-spec/#data-type:geopoint | geopoint}
+ * value, as we consider several shared responsibilities between `@getodk/xpath`
+ * and `@getodk/xforms-engine`. Notably, the engine already has a conflicting
+ * structural runtime representation and encoding behavior, in its support for
+ * {@link https://getodk.github.io/xforms-spec/#secondary-instances---external | external secondary instances}
+ * with a {@link https://geojson.org/ | GeoJSON format}.
+ */
+export class Geopoint implements GeopointCoordinates {
+	static fromNodeValue(nodeValue: string): Geopoint {
+		const coordinates = decodeGeopointCoordinates(nodeValue);
+
+		return new this(coordinates);
+	}
+
+	readonly latitude: number;
+	readonly longitude: number;
+
+	private constructor(coordinates: GeopointCoordinates) {
+		this.latitude = coordinates.latitude;
+		this.longitude = coordinates.longitude;
+	}
+}

--- a/packages/xpath/src/lib/geo/Geotrace.ts
+++ b/packages/xpath/src/lib/geo/Geotrace.ts
@@ -39,9 +39,12 @@ const collectLines = (geopoints: GeotracePoints): readonly GeotraceLine[] => {
 
 export class Geotrace {
 	static fromEncodedGeotrace(encoded: string): Geotrace {
-		const geopoints = encoded.split(/\s*;\s*/).map((value) => {
-			return Geopoint.fromNodeValue(value);
-		});
+		const geopoints = encoded
+			.replace(/\s*;\s*$/, '')
+			.split(/\s*;\s*/)
+			.map((value) => {
+				return Geopoint.fromNodeValue(value);
+			});
 
 		return this.fromGeopoints(geopoints);
 	}

--- a/packages/xpath/src/lib/geo/Geotrace.ts
+++ b/packages/xpath/src/lib/geo/Geotrace.ts
@@ -39,7 +39,10 @@ const collectLines = (geopoints: GeotracePoints): readonly GeotraceLine[] => {
 export class Geotrace {
 	static fromEncodedGeotrace(encoded: string): Geotrace | null {
 		const geopoints = encoded
-			.replace(/\s*;\s*$/, '')
+			.trim()
+			// Consistency with JavaRosa: any number of trailing semicolons are
+			// ignored, with any amount of whitespace between them.
+			.replace(/(\s*;)+$/, '')
 			.split(/\s*;\s*/)
 			.map((value) => {
 				return geopointCodec.decodeValue(value);

--- a/packages/xpath/src/lib/geo/Geotrace.ts
+++ b/packages/xpath/src/lib/geo/Geotrace.ts
@@ -1,0 +1,78 @@
+import { JRCompatibleGeoValueError } from '../../error/JRCompatibleGeoValueError.ts';
+import { Geopoint } from './Geopoint.ts';
+import { GeotraceLine } from './GeotraceLine.ts';
+
+export type GeotracePoints = readonly [Geopoint, Geopoint, ...Geopoint[]];
+
+const isGeotracePoints = (geopoints: readonly Geopoint[]): geopoints is GeotracePoints => {
+	return geopoints.length >= 2;
+};
+
+type AssertGeotracePoints = (geopoints: readonly Geopoint[]) => asserts geopoints is GeotracePoints;
+
+const assertGeotracePoints: AssertGeotracePoints = (geopoints) => {
+	if (!isGeotracePoints(geopoints)) {
+		throw new JRCompatibleGeoValueError();
+	}
+};
+
+const collectLines = (geopoints: GeotracePoints): readonly GeotraceLine[] => {
+	return geopoints.reduce((acc, geopoint, i) => {
+		if (i === 0) {
+			return acc;
+		}
+
+		// Non-null assertion safe: we ensure at least 2 points, and skip index 0.
+		const start = geopoints[i - 1]!;
+		const end = geopoint;
+
+		acc.push(
+			new GeotraceLine({
+				start,
+				end,
+			})
+		);
+
+		return acc;
+	}, Array<GeotraceLine>());
+};
+
+export class Geotrace {
+	static fromEncodedGeotrace(encoded: string): Geotrace {
+		const geopoints = encoded.split(/\s*;\s*/).map((value) => {
+			return Geopoint.fromNodeValue(value);
+		});
+
+		return this.fromGeopoints(geopoints);
+	}
+
+	static fromEncodedValues(values: readonly string[]): Geotrace {
+		const [head, ...tail] = values;
+
+		if (head == null) {
+			throw new JRCompatibleGeoValueError();
+		}
+
+		if (tail.length === 0) {
+			return this.fromEncodedGeotrace(head);
+		}
+
+		const geopoints = values.map((value) => {
+			return Geopoint.fromNodeValue(value);
+		});
+
+		return this.fromGeopoints(geopoints);
+	}
+
+	static fromGeopoints(geopoints: readonly Geopoint[]): Geotrace {
+		assertGeotracePoints(geopoints);
+
+		return new this(geopoints);
+	}
+
+	readonly lines: readonly GeotraceLine[];
+
+	private constructor(readonly geopoints: GeotracePoints) {
+		this.lines = collectLines(geopoints);
+	}
+}

--- a/packages/xpath/src/lib/geo/GeotraceLine.ts
+++ b/packages/xpath/src/lib/geo/GeotraceLine.ts
@@ -1,0 +1,16 @@
+import type { Geopoint } from './Geopoint.ts';
+
+interface GeotraceLinePoints {
+	readonly start: Geopoint;
+	readonly end: Geopoint;
+}
+
+export class GeotraceLine implements GeotraceLinePoints {
+	readonly start: Geopoint;
+	readonly end: Geopoint;
+
+	constructor(points: GeotraceLinePoints) {
+		this.start = points.start;
+		this.end = points.end;
+	}
+}

--- a/packages/xpath/src/lib/geo/encodeGeoValueStubFactory.ts
+++ b/packages/xpath/src/lib/geo/encodeGeoValueStubFactory.ts
@@ -1,0 +1,10 @@
+import { EncodeGeoValueStubError } from './EncodeGeoValueStubError.ts';
+import type { GeoValueEncoder, GeoValueType } from './GeoValueCodec.ts';
+
+export const encodeValueStubFactory = <RuntimeInputValue>(
+	valueType: GeoValueType
+): GeoValueEncoder<RuntimeInputValue> => {
+	return (_: RuntimeInputValue): string => {
+		throw new EncodeGeoValueStubError(valueType);
+	};
+};

--- a/packages/xpath/src/lib/geo/geopointCodec.ts
+++ b/packages/xpath/src/lib/geo/geopointCodec.ts
@@ -2,7 +2,9 @@ import { encodeValueStubFactory } from './encodeGeoValueStubFactory.ts';
 import { Geopoint } from './Geopoint.ts';
 import type { GeoValueCodec } from './GeoValueCodec.ts';
 
-export const geopointCodec: GeoValueCodec<'geopoint', Geopoint> = {
+export type GeopointRuntimeValue = Geopoint | null;
+
+export const geopointCodec: GeoValueCodec<'geopoint', GeopointRuntimeValue> = {
 	valueType: 'geopoint',
 	encodeValue: encodeValueStubFactory('geopoint'),
 	decodeValue: (value) => {

--- a/packages/xpath/src/lib/geo/geopointCodec.ts
+++ b/packages/xpath/src/lib/geo/geopointCodec.ts
@@ -1,0 +1,11 @@
+import { encodeValueStubFactory } from './encodeGeoValueStubFactory.ts';
+import { Geopoint } from './Geopoint.ts';
+import type { GeoValueCodec } from './GeoValueCodec.ts';
+
+export const geopointCodec: GeoValueCodec<'geopoint', Geopoint> = {
+	valueType: 'geopoint',
+	encodeValue: encodeValueStubFactory('geopoint'),
+	decodeValue: (value) => {
+		return Geopoint.fromNodeValue(value);
+	},
+};

--- a/packages/xpath/test/xforms/geo.test.ts
+++ b/packages/xpath/test/xforms/geo.test.ts
@@ -43,7 +43,7 @@ describe('distance() and area() functions', () => {
 		});
 	});
 
-	describe('area with nodes', () => {
+	describe('area and distance with nodes', () => {
 		beforeEach(() => {
 			testContext = createXFormsTestContext(`
         <root>

--- a/packages/xpath/test/xforms/geo.test.ts
+++ b/packages/xpath/test/xforms/geo.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { XFormsTestContext } from '../helpers.ts';
 import { createXFormsTestContext } from '../helpers.ts';
 
@@ -30,9 +30,6 @@ describe('distance() and area() functions', () => {
 		{ argument: '0 0;0 1', expected: { area: 0.0, distance: 111318.85 } },
 		{ argument: '0 0;0 90', expected: { area: 0.0, distance: 10018696.05 } },
 		{ argument: '90 0;90 1', expected: { area: 0.0, distance: 0.0 } },
-		{ argument: '5000 5000; 5000 5000', expected: { area: NaN, distance: NaN } },
-		{ argument: 'a', expected: { area: NaN, distance: NaN } },
-		{ argument: '', expected: { area: NaN, distance: NaN } },
 	].forEach(({ argument, expected }, i) => {
 		it(`area(${argument}) works (${i + 1})`, () => {
 			testContext.assertNumberValue(`area("${argument}")`, expected.area);
@@ -40,6 +37,28 @@ describe('distance() and area() functions', () => {
 
 		it(`distance(${argument}) works (${i + 1})`, () => {
 			testContext.assertNumberValue(`distance("${argument}")`, expected.distance);
+		});
+	});
+
+	// Invalid arguments (for both distance/area functions)
+	[
+		// Invalid because points exceed supported degrees
+		'5000 5000; 5000 5000',
+		// Arbitrary string is not a valid point
+		'a',
+		// Empty/blank string is not a valid point
+		'',
+	].forEach((invalidArgument) => {
+		it(`area("${invalidArgument}") fails`, () => {
+			const evaluate = () => testContext.evaluator.evaluateNumber(`area("${invalidArgument}")`);
+
+			expect(evaluate).toThrowError();
+		});
+
+		it(`distance("${invalidArgument}") fails`, () => {
+			const evaluate = () => testContext.evaluator.evaluateNumber(`distance("${invalidArgument}")`);
+
+			expect(evaluate).toThrowError();
 		});
 	});
 

--- a/packages/xpath/test/xforms/geo.test.ts
+++ b/packages/xpath/test/xforms/geo.test.ts
@@ -49,12 +49,16 @@ describe('distance() and area() functions', () => {
 		// Empty/blank string is not a valid point
 		'',
 	].forEach((invalidArgument) => {
-		it(`area("${invalidArgument}") fails`, () => {
-			const evaluate = () => testContext.evaluator.evaluateNumber(`area("${invalidArgument}")`);
-
-			expect(evaluate).toThrowError();
+		// Note: previous iterations of this test, inherited from
+		// Enketo/openrosa-xpath-evaluator, expected `NaN`. Updated test reflects
+		// consistency with JavaRosa.
+		it(`area("${invalidArgument}") returns 0`, () => {
+			testContext.assertNumberValue(`area("${invalidArgument}")`, 0);
 		});
 
+		// Note: previous iterations of this test, inherited from
+		// Enketo/openrosa-xpath-evaluator, expected `NaN`. Updated test reflects
+		// consistency with JavaRosa.
 		it(`distance("${invalidArgument}") fails`, () => {
 			const evaluate = () => testContext.evaluator.evaluateNumber(`distance("${invalidArgument}")`);
 


### PR DESCRIPTION
Closes #118. Supersedes and closes #244.

**Please don't pay too much attention to the commit history of this branch!** It's... well, it's bananas.

I expect we'll want to squash this on merge.

## I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable

I don't **think** there should be anything browser specific that wouldn't be caught by CI running tests across targeted browsers. Happy to manually verify if we feel otherwise in review!

## What else has been done to verify that this works as intended?

- Incorporated test coverage from getodk/javarosa#761
- Added a test to clarify multi-argument type semantics
- Updated `@getodk/xpath` tests where appropriate
- Updated previously failing scenario tests to reflect related improvements

## Why is this the best possible solution? Were any other approaches considered?

This expands on the _logical changes_ in #244 with:

- a minor semantic correction, for the distinction between single-argument and variadic calls
- an incremental effort to isolate decoding logic for geographic data types, which will be pertinent for pending work to support those data types in the engine and UI
- fixes a couple of convenient related issues while working in the area

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's possible that the existing test coverage didn't exercise some previous semantic nuance that's been lost, especially in extracting the decoding logic.

## Do we need any specific form for testing your changes? If so, please attach one.

Attached.

## What's changed

### Feature: variadic `distance`

The primary purpose of this change is to support the spec expansion of the [`distance`](https://getodk.github.io/xforms-spec/#fn:distance) function, matching getodk/javarosa#761.

### Geo* groundwork

After a brief discussion, we decided it would be worthwhile to expand the scope of this change to provide some early support for upcoming feature work to support the `geopoint` data type (with `geotrace` and `geoshape` presumably soon to follow).

**Why:** The existing implementation of `area` and `distance` include logic to **decode** serialized `geopoint` values, and semicolon-separated lists thereof. This logic is quite likely going to be _very similar if not identical_ to the logic we'd use in incoming engine implementations of the geographic `ValueCodec`s (e.g. `GeopointCodec`, `GeotraceCodec`, `GeoshapeCodec`).

The change largely leaves the `xpath`-internal representations of these data types unchanged (other than making them a bit more formal, as classes).

**Note:** I don't necessarily expect these interfaces (as representations of each data/value type) to be stable or complete! In part, that's because we have corresponding **encode** behavior in the engine which could also probably be incorporated into said value codecs, in the parse-stage serialization of GeoJSON values, from [GeoJSON external secondary instances](https://github.com/getodk/web-forms/blob/81a57c3d4f5c1b511ccb6b2e0333a3767dbe7019/packages/xforms-engine/src/parse/model/SecondaryInstance/sources/GeoJSONExternalSecondaryInstance.ts).

This change is intended to call out where existing decode logic exists since I was already working on it, and to set up some WIP structures that look roughly how they might in a proper engine `ValueCodec`. But that leaves a big open question: how do we share logic between `@getodk/xpath` and `@getodk/xforms-engine`? To be determined! That's definitely out of scope for this PR.

### Related fixes

This change also addresses a couple of fixes/improvements in consistency with JavaRosa's `distance` _and `area`_ implementations:

- Trailing semicolons are now supported in `geotrace`/`geoshape` values (both of which `@getodk/xpath` really only knows about as a serialized list of `geopoint` values)
- Errors are produced for invalid arguments to `distance` (I'm reasonably certain the conditions are now consistent with JavaRosa)
- `area` now returns `0` instead of `NaN` for invalid input (definitely consistent with JavaRosa; breaking previous consistency with Enketo, as demonstrated by changes to tests inherited from `openrosa-xpath-evaluator`)