### PR TITLE
Add `cities.geojson`, external secondary instance for “all questions" demo form

### DIFF
--- a/packages/common/src/fixtures/preview-service/xforms/cities.geojson
+++ b/packages/common/src/fixtures/preview-service/xforms/cities.geojson
@@ -1,0 +1,65 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+		"title": "Warsaw",
+                "info": "Capital city of Poland",
+                "id": "1"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+		    21.0122,
+                    52.2297
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+		"title": "Berlin",
+                "info": "Capital city of Germany",
+                "id": "2"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.4050,
+		    52.5200
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+		"title": "Paris",
+                "info": "Capital city of France",
+                "id": "3"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    2.3522,
+                    48.8566
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+		"title": "Kyiv",
+                "info": "Capital city of Ukraine",
+                "id": "4"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    30.5234,
+	            50.4501
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
~~Closes #~~

## I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable

## What else has been done to verify that this works as intended?

Ran `yarn workspace @getodk/web-forms dev`, no longer see error loading the "all questions" demo form.

## Why is this the best possible solution? Were any other approaches considered?

This file wasn't included when we introduced the demo form, but we didn't yet support external secondary instances so it didn't matter much.

I haven't added any of the _other media_ resources referenced by the form here. I'm hoping that, with whatever design we end up with for supporting those other form attachments, we'll similarly be alerted that they're absent. If nothing else, I think that will be an opportunity to make sure the form itself is up to date as well.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

N/A

## Do we need any specific form for testing your changes? If so, please attach one.

This is adding a resource which was missing for the "all questions" form.

## What's changed

See above.