### PR TITLE
fix(#324): runs xpath tests with the same timezone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ defaults:
 
 env:
   TZ: 'America/Phoenix'
+  LOCALE_ID: 'en-US'
 
 jobs:
   install-and-build:

--- a/packages/xpath/test/helpers.ts
+++ b/packages/xpath/test/helpers.ts
@@ -21,8 +21,6 @@ declare global {
 	 */
 	// eslint-disable-next-line no-var
 	var TZ: string | undefined;
-	// eslint-disable-next-line no-var
-	var LOCALE_ID: string | undefined;
 	/**
 	 * The locale string defining the language and regional formatting for tests.
 	 * This follows the BCP 47 language tag format (e.g., 'en-US'). It ensures consistent formatting
@@ -30,6 +28,8 @@ declare global {
 	 *
 	 * @example 'en-US' // American English
 	 */
+	// eslint-disable-next-line no-var
+	var LOCALE_ID: string | undefined;
 	// eslint-disable-next-line no-var
 	var IMPLEMENTATION: string | undefined;
 }

--- a/packages/xpath/test/helpers.ts
+++ b/packages/xpath/test/helpers.ts
@@ -10,14 +10,33 @@ type AnyParentNode =
 	| XMLDocument;
 
 declare global {
+	/**
+	 * The timezone identifier used for all date and time operations in tests.
+	 * This string follows the IANA Time Zone Database format (e.g., 'America/Phoenix').
+	 * It determines the offset and DST behavior for `Date` objects and
+	 * related functions.
+	 *
+	 * @example 'America/Phoenix' // Fixed UTC-7, no DST
+	 * @example 'Europe/London' // UTC+0 (GMT) or UTC+1 (BST) with DST
+	 */
 	// eslint-disable-next-line no-var
 	var TZ: string | undefined;
+	// eslint-disable-next-line no-var
+	var LOCALE_ID: string | undefined;
+	/**
+	 * The locale string defining the language and regional formatting for tests.
+	 * This follows the BCP 47 language tag format (e.g., 'en-US'). It ensures consistent formatting
+	 * across tests.
+	 *
+	 * @example 'en-US' // American English
+	 */
 	// eslint-disable-next-line no-var
 	var IMPLEMENTATION: string | undefined;
 }
 
 globalThis.IMPLEMENTATION = typeof IMPLEMENTATION === 'string' ? IMPLEMENTATION : undefined;
 globalThis.TZ = typeof TZ === 'string' ? TZ : undefined;
+globalThis.LOCALE_ID = typeof LOCALE_ID === 'string' ? LOCALE_ID : undefined;
 
 const namespaces: Record<string, string> = {
 	xhtml: 'http://www.w3.org/1999/xhtml',
@@ -337,4 +356,8 @@ export const getNonNamespaceAttributes = (element: Element): readonly Attr[] => 
 	const attrs = Array.from(element.attributes);
 
 	return attrs.filter(({ name }) => name !== 'xmlns' && !name.startsWith('xmlns:'));
+};
+
+export const getDefaultDateTimeLocale = (): string => {
+	return new Date().toLocaleString(LOCALE_ID, { timeZone: TZ });
 };

--- a/packages/xpath/test/setup.ts
+++ b/packages/xpath/test/setup.ts
@@ -1,37 +1,9 @@
 import { afterEach, beforeEach } from 'vitest';
 import { vi } from 'vitest';
-
-/**
- * Global constants injected via Vite's `define` configuration option.
- * These values are replaced at build time and are available throughout
- * the test suite.
- *
- * @global
- */
-declare global {
-	/**
-	 * The timezone identifier used for all date and time operations in tests.
-	 * This string follows the IANA Time Zone Database format (e.g., 'America/Phoenix').
-	 * It determines the offset and DST behavior for `Date` objects and
-	 * related functions.
-	 *
-	 * @example 'America/Phoenix' // Fixed UTC-7, no DST
-	 * @example 'Europe/London' // UTC+0 (GMT) or UTC+1 (BST) with DST
-	 */
-	const TZ: string;
-
-	/**
-	 * The locale string defining the language and regional formatting for tests.
-	 * This follows the BCP 47 language tag format (e.g., 'en-US'). It ensures consistent formatting
-	 * across tests.
-	 *
-	 * @example 'en-US' // American English
-	 */
-	const LOCALE_ID: string;
-}
+import { getDefaultDateTimeLocale } from './helpers.ts';
 
 beforeEach(() => {
-	const dateOnTimezone = new Date().toLocaleString(LOCALE_ID, { timeZone: TZ });
+	const dateOnTimezone = getDefaultDateTimeLocale();
 	vi.useFakeTimers({
 		now: new Date(dateOnTimezone).getTime(),
 	});

--- a/packages/xpath/test/setup.ts
+++ b/packages/xpath/test/setup.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach } from 'vitest';
+import { vi } from 'vitest';
+
+/**
+ * Global constants injected via Vite's `define` configuration option.
+ * These values are replaced at build time and are available throughout
+ * the test suite.
+ *
+ * @global
+ */
+declare global {
+	/**
+	 * The timezone identifier used for all date and time operations in tests.
+	 * This string follows the IANA Time Zone Database format (e.g., 'America/Phoenix').
+	 * It determines the offset and DST behavior for `Date` objects and
+	 * related functions.
+	 *
+	 * @example 'America/Phoenix' // Fixed UTC-7, no DST
+	 * @example 'Europe/London' // UTC+0 (GMT) or UTC+1 (BST) with DST
+	 */
+	const TZ: string;
+
+	/**
+	 * The locale string defining the language and regional formatting for tests.
+	 * This follows the BCP 47 language tag format (e.g., 'en-US'). It ensures consistent formatting
+	 * across tests.
+	 *
+	 * @example 'en-US' // American English
+	 */
+	const locale: string;
+}
+
+beforeEach(() => {
+	const dateOnTimezone = new Date().toLocaleString(locale, { timeZone: TZ });
+	vi.useFakeTimers({
+		now: new Date(dateOnTimezone).getTime(),
+	});
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});

--- a/packages/xpath/test/setup.ts
+++ b/packages/xpath/test/setup.ts
@@ -27,11 +27,11 @@ declare global {
 	 *
 	 * @example 'en-US' // American English
 	 */
-	const locale: string;
+	const LOCALE_ID: string;
 }
 
 beforeEach(() => {
-	const dateOnTimezone = new Date().toLocaleString(locale, { timeZone: TZ });
+	const dateOnTimezone = new Date().toLocaleString(LOCALE_ID, { timeZone: TZ });
 	vi.useFakeTimers({
 		now: new Date(dateOnTimezone).getTime(),
 	});

--- a/packages/xpath/test/xforms/now.test.ts
+++ b/packages/xpath/test/xforms/now.test.ts
@@ -14,8 +14,6 @@ describe('#now()', () => {
 	// > including timezone offset (i.e. not normalized to UTC) as described
 	// > under the dateTime datatype.
 	it('should return a timestamp for this instant', () => {
-		// this check might fail if run at precisely midnight ;-)
-
 		// given
 		const now = new Date();
 		const today = `${now.getFullYear()}-${(1 + now.getMonth()).toString().padStart(2, '0')}-${now

--- a/packages/xpath/vite.config.ts
+++ b/packages/xpath/vite.config.ts
@@ -59,10 +59,11 @@ export default defineConfig(({ mode }) => {
 	const isTest = mode === 'test';
 
 	let timeZoneId: string | null = process.env.TZ ?? null;
-	let locale: string | null = process.env.locale ?? null;
+	let localeId: string | null = process.env.LOCALE_ID ?? null;
+
 	if (isTest) {
 		timeZoneId = timeZoneId ?? TEST_TIME_ZONE;
-		locale = locale ?? TEST_LOCALE;
+		localeId = localeId ?? TEST_LOCALE;
 	}
 
 	// `expressionParser.ts` is built as a separate entry so it can be consumed
@@ -95,7 +96,7 @@ export default defineConfig(({ mode }) => {
 		},
 		define: {
 			TZ: JSON.stringify(timeZoneId),
-			locale: JSON.stringify(locale),
+			LOCALE_ID: JSON.stringify(localeId),
 		},
 		esbuild: {
 			target: 'esnext',

--- a/packages/xpath/vite.config.ts
+++ b/packages/xpath/vite.config.ts
@@ -44,13 +44,25 @@ const TEST_ENVIRONMENT = BROWSER_ENABLED ? 'node' : 'jsdom';
  */
 const TEST_TIME_ZONE = 'America/Phoenix';
 
+/**
+ * The locale used for formatting dates and times in all test cases.
+ * This ensures consistent language and regional settings across tests.
+ * Currently set to 'en-US' (American English), which affects date formats
+ * (e.g., MM/DD/YYYY) and time separators.
+ *
+ * @constant
+ * @default 'en-US'
+ */
+const TEST_LOCALE = 'en-US';
+
 export default defineConfig(({ mode }) => {
 	const isTest = mode === 'test';
 
 	let timeZoneId: string | null = process.env.TZ ?? null;
-
+	let locale: string | null = process.env.locale ?? null;
 	if (isTest) {
 		timeZoneId = timeZoneId ?? TEST_TIME_ZONE;
+		locale = locale ?? TEST_LOCALE;
 	}
 
 	// `expressionParser.ts` is built as a separate entry so it can be consumed
@@ -83,6 +95,7 @@ export default defineConfig(({ mode }) => {
 		},
 		define: {
 			TZ: JSON.stringify(timeZoneId),
+			locale: JSON.stringify(locale),
 		},
 		esbuild: {
 			target: 'esnext',
@@ -122,7 +135,7 @@ export default defineConfig(({ mode }) => {
 				headless: true,
 				screenshotFailures: false,
 			},
-
+			setupFiles: ['test/setup.ts'],
 			environment: TEST_ENVIRONMENT,
 			globals: false,
 			include: ['test/**/*.test.ts'],


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/324

## I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable

## What else has been done to verify this works as intended?

**To reproduce the error:** 

1. Change the machine time to March 1st at 23:30 Los Angeles timezone
2. Run the test suite `yarn workspace @getodk/xpath test`
3. See the tests failing like this:

<img width="500" alt="Screenshot 2025-03-03 at 8 37 59 PM" src="https://github.com/user-attachments/assets/82601af7-f5a0-4465-80a2-1d66b6a246d5" />

**Other things done:**

After implementing the fix, I tried setting my machine in different timezones, ran the tests, and they passed. The different timezones have been passed to the ["now" function correctly](https://github.com/getodk/web-forms/blob/99295eb1d6ec78cd6a758385793e97859b6a74cc/packages/xpath/src/lib/datetime/functions.ts#L24). 

The offset is being appended to the [localDateTimeString](https://github.com/getodk/web-forms/blob/99295eb1d6ec78cd6a758385793e97859b6a74cc/packages/xpath/src/lib/datetime/functions.ts#L14)

I tried making a test about DST, but it's hard to trick reliably the test to take a different DST of the same timezone. However, I added some debugging code in [localDateTimeString](https://github.com/getodk/web-forms/blob/99295eb1d6ec78cd6a758385793e97859b6a74cc/packages/xpath/src/lib/datetime/functions.ts#L14) function, and I can see the offset switching to/from DST for the same timezone.

```
// The process.env.TZ value is America/New_York
// Current date is March 3rd

console.log(dateTime.offset); // Prints "-05:00"
const dstDate = Temporal.ZonedDateTime.from("2025-07-01T23:30:00[America/New_York]");
console.log(dstDate.offset); // Prints "-04:00"
```



## Why is this the best possible solution? Were any other approaches considered?

This ensures the tests are run in the same timezone by setting it in the `beforeEach` hook using the `useFakeTimers` utility. However, this doesn't mock the DST, which has been challenging to tick the system timer. 

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

N/A

## Do we need any specific form for testing your changes? If so, please attach one.

I don't think so

## What's changed
- Adds a global beforeEach and AfterEach hook to set the tests' timezone
- Adds a new optional environment variable for the tests' locale 
