### PR TITLE
Add `stepper-layout` prop to OdkWebForm component for Collect-like experience

### DIFF
--- a/packages/common/src/fixtures/other/multi-step.xform.xml
+++ b/packages/common/src/fixtures/other/multi-step.xform.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+  xmlns:ev="http://www.w3.org/2001/xml-events"
+  xmlns:h="http://www.w3.org/1999/xhtml"
+  xmlns:jr="http://openrosa.org/javarosa"
+  xmlns:orx="http://openrosa.org/xforms/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Multi Step XForm</h:title>
+    <model>
+      <instance>
+        <root id="minimal">
+          <first-question/>
+          <second-question/>
+          <third-question/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </root>
+      </instance>
+      <bind nodeset="/root/first-question" type="string" required="true()"/>
+      <bind nodeset="/root/second-question" type="string" required="true()"/>
+      <bind nodeset="/root/third-question" type="string" required="true()"/>
+      <bind nodeset="/root/meta/instanceID" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/root/first-question">
+      <label>First question</label>
+    </input>
+    <input ref="/root/second-question">
+      <label>Second question</label>
+    </input>
+    <input ref="/root/third-question">
+      <label>Third question</label>
+    </input>
+  </h:body>
+</h:html>

--- a/packages/web-forms/src/components/FormGroup.vue
+++ b/packages/web-forms/src/components/FormGroup.vue
@@ -4,7 +4,9 @@ import { computed } from 'vue';
 import FormPanel from './FormPanel.vue';
 import QuestionList from './QuestionList.vue';
 
-const props = defineProps<{ node: GroupNode }>();
+const props = withDefaults(defineProps<{ node: GroupNode, toggleable?: boolean }>(), {
+	toggleable: false,
+});
 
 const classes = ['group'];
 
@@ -18,7 +20,7 @@ const tableLayout = computed(() => {
 </script>
 
 <template>
-	<FormPanel :title="node.currentState.label?.asString" :no-ui="!node.currentState.label" :class="classes">
+	<FormPanel :title="node.currentState.label?.asString" :no-ui="!node.currentState.label" :toggleable="props.toggleable" :class="classes">
 		<div :class="{ 'table-layout': tableLayout, 'gap-2': !tableLayout, 'flex': true, 'flex-column': true }">
 			<QuestionList :nodes="node.currentState.children" />
 		</div>

--- a/packages/web-forms/src/components/FormPanel.vue
+++ b/packages/web-forms/src/components/FormPanel.vue
@@ -12,6 +12,7 @@ export interface PanelProps {
 	class?: string[] | string;
 	labelIcon?: string;
 	labelNumber?: number;
+    toggleable?: boolean;
 }
 
 const props = withDefaults(defineProps<PanelProps>(), {
@@ -21,6 +22,7 @@ const props = withDefaults(defineProps<PanelProps>(), {
 	class: undefined,
 	labelIcon: undefined,
 	labelNumber: undefined,
+    toggleable: false,
 });
 
 const panelClass = computed(() => [
@@ -31,7 +33,9 @@ const panelClass = computed(() => [
 const panelState = ref(false);
 
 const toggle = () => {
-	panelState.value = !panelState.value;
+    if (props.toggleable) {
+		panelState.value = !panelState.value;
+    }
 };
 
 const menu = ref<Menu & MenuState>();
@@ -40,10 +44,11 @@ const toggleMenu = (event: Event) => {
 	menu.value?.toggle(event);
 };
 </script>
+
 <template>
-	<Panel v-if="!noUi" :class="panelClass" :toggleable="true" :collapsed="panelState">
+    <Panel v-if="!noUi" :class="[panelClass, { 'toggleable-enabled': toggleable }]" :toggleable="toggleable" :collapsed="toggleable ? panelState : false">
 		<template #header>
-			<div class="panel-title" role="button" @click="toggle">
+            <div v-if="toggleable" class="panel-title" role="button" @click="toggle">
 				<h2>
 					<span class="chevron" :class="panelState ? 'icon-keyboard_arrow_down' : 'icon-keyboard_arrow_up'" />
 					<span v-if="labelNumber" class="label-number">{{ labelNumber }}</span>
@@ -51,6 +56,13 @@ const toggleMenu = (event: Event) => {
 					<span v-if="labelIcon" class="ml-2" :class="labelIcon" />
 				</h2>
 			</div>
+            <div v-else>
+                <h2>
+                    <span v-if="labelNumber" class="label-number">{{ labelNumber }}</span>
+                    <span>{{ title }}</span>
+                    <span v-if="labelIcon" class="ml-2" :class="labelIcon" />
+                </h2>
+            </div>
 		</template>
 		<template v-if="menuItems && menuItems.length > 0" #icons>
 			<Button severity="secondary" rounded class="btn-context" :class="{ 'p-focus': menu?.overlayVisible }" icon="icon-more_vert" aria-label="More" @click="toggleMenu" />
@@ -129,15 +141,19 @@ h2 {
 	}
 
 	:deep(.p-panel-content) {
-		border-left: 2px solid var(--gray-200);
+		box-shadow: none;
 		margin-left: 10px;
-		border-radius: 0;
 		padding: 0 0 0 1.5rem;
 	}
 
 	:deep(.p-panel-toggler) {
 		display: none;
 	}
+}
+
+.toggleable-enabled :deep(.p-panel-content) {
+	border-left: 2px solid var(--gray-200);
+	border-radius: 0;
 }
 
 .content-wrapper {

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -240,8 +240,9 @@ watchEffect(() => {
 				<template #content>
 					<div class="form-questions">
 						<div class="flex flex-column gap-2">
-							<QuestionList :nodes="state.root.currentState.children" />
-							<QuestionStepper v-if="stepperLayout" :nodes="state.root.currentState.children" @endOfForm="showSendButton=true" />
+							<QuestionList v-if="!stepperLayout" :nodes="state.root.currentState.children" />
+							<!-- Note that QuestionStepper has the 'Send' button integrated instead of using the button below -->
+							<QuestionStepper v-if="stepperLayout" :nodes="state.root.currentState.children" @sendFormFromStepper="handleSubmit()" />
 						</div>
 					</div>
 				</template>
@@ -252,7 +253,7 @@ watchEffect(() => {
 			</div>
 		</div>
 
-		<div class="powered-by-wrapper">
+		<div v-if="showSendButton" class="powered-by-wrapper">
 			<a class="anchor" href="https://getodk.org" target="_blank">
 				<span class="caption">Powered by</span>
 				<img

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -242,7 +242,7 @@ watchEffect(() => {
 						<div class="flex flex-column gap-2">
 							<QuestionList v-if="!stepperLayout" :nodes="state.root.currentState.children" />
 							<!-- Note that QuestionStepper has the 'Send' button integrated instead of using the button below -->
-							<QuestionStepper v-if="stepperLayout" :nodes="state.root.currentState.children" @sendFormFromStepper="handleSubmit()" />
+							<QuestionStepper v-if="stepperLayout" :nodes="state.root.currentState.children" @sendFormFromStepper="handleSubmit(state)" />
 						</div>
 					</div>
 				</template>

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -36,7 +36,7 @@ export interface OdkWebFormsProps {
 	 * with collapsable groups. This param changes to a stepper layout
 	 * closer to Collect.
 	 */
-	stepperLayout?: boolean;
+	readonly stepperLayout?: boolean;
 
 	/**
 	 * Note: this parameter must be set when subscribing to the
@@ -150,7 +150,6 @@ const emit = defineEmits<OdkWebFormEmits>();
 
 const state = initializeFormState();
 const submitPressed = ref(false);
-const showSendButton = ref(props.stepperLayout ? false : true);
 
 const init = async () => {
 	state.value = await loadFormState(props.formXml, {
@@ -240,20 +239,20 @@ watchEffect(() => {
 				<template #content>
 					<div class="form-questions">
 						<div class="flex flex-column gap-2">
-							<QuestionList v-if="!stepperLayout" :nodes="state.root.currentState.children" />
+							<QuestionList v-if="!props.stepperLayout" :nodes="state.root.currentState.children" />
 							<!-- Note that QuestionStepper has the 'Send' button integrated instead of using the button below -->
-							<QuestionStepper v-if="stepperLayout" :nodes="state.root.currentState.children" @sendFormFromStepper="handleSubmit(state)" />
+							<QuestionStepper v-if="props.stepperLayout" :nodes="state.root.currentState.children" @sendFormFromStepper="handleSubmit(state)" />
 						</div>
 					</div>
 				</template>
 			</Card>
 
-			<div v-if="showSendButton" class="footer flex justify-content-end flex-wrap gap-3">
+			<div v-if="!props.stepperLayout" class="footer flex justify-content-end flex-wrap gap-3">
 				<Button label="Send" rounded @click="handleSubmit(state)" />
 			</div>
 		</div>
 
-		<div v-if="showSendButton" class="powered-by-wrapper">
+		<div v-if="!props.stepperLayout" class="powered-by-wrapper">
 			<a class="anchor" href="https://getodk.org" target="_blank">
 				<span class="caption">Powered by</span>
 				<img

--- a/packages/web-forms/src/components/QuestionList.vue
+++ b/packages/web-forms/src/components/QuestionList.vue
@@ -45,7 +45,7 @@ const isControlNode = (node: NonStructuralNode): node is ControlNode => {
 	<template v-for="node in nodes" :key="node.nodeId">
 		<template v-if="node.currentState.relevant">
 			<!-- Render group nodes -->
-			<FormGroup v-if="isGroupNode(node)" :node="node" />
+			<FormGroup v-if="isGroupNode(node)" :node="node" toggleable />
 
 			<!-- Render repeat nodes -->
 			<RepeatRange v-else-if="isRepeatRangeNode(node)" :node="node" />

--- a/packages/web-forms/src/components/QuestionStepper.vue
+++ b/packages/web-forms/src/components/QuestionStepper.vue
@@ -60,7 +60,7 @@ const steps = computed(() =>
 
 // Handle stepper state
 const firstStep = 0;
-const finalStep = steps.value.length;
+const finalStep = computed(() => steps.value.length - 1);
 const currentStep = ref(firstStep);
 const submitPressed = ref(false);
 provide('submitPressed', submitPressed);

--- a/packages/web-forms/src/components/QuestionStepper.vue
+++ b/packages/web-forms/src/components/QuestionStepper.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { ref, computed, watch, provide } from 'vue';
+import type { ComponentPublicInstance } from 'vue';
+import type {
+	AnyControlNode,
+	AnyUnsupportedControlNode,
+	GeneralChildNode,
+	GroupNode,
+	RepeatRangeNode,
+} from '@getodk/xforms-engine';
+import FormGroup from './FormGroup.vue';
+import FormQuestion from './FormQuestion.vue';
+import RepeatRange from './RepeatRange.vue';
+import ExpectModelNode from './dev-only/ExpectModelNode.vue';
+import Steps from 'primevue/steps';
+import ProgressBar from 'primevue/progressbar';
+import Button from 'primevue/button';
+
+const props = defineProps<{ nodes: readonly GeneralChildNode[] }>();
+const emit = defineEmits(['endOfForm']);
+
+const isGroupNode = (node: GeneralChildNode): node is GroupNode => {
+	return node.nodeType === 'group';
+};
+
+type NonGroupNode = Exclude<GeneralChildNode, GroupNode>;
+
+const isRepeatRangeNode = (node: NonGroupNode): node is RepeatRangeNode => {
+	return (
+		node.nodeType === 'repeat-range:controlled' || node.nodeType === 'repeat-range:uncontrolled'
+	);
+};
+
+type NonStructuralNode = Exclude<NonGroupNode, RepeatRangeNode>;
+
+type ControlNode = AnyControlNode | AnyUnsupportedControlNode;
+
+const isControlNode = (node: NonStructuralNode): node is ControlNode => {
+	const { nodeType } = node;
+
+	return (
+		nodeType === 'input' ||
+		nodeType === 'note' ||
+		nodeType === 'select' ||
+		nodeType === 'trigger' ||
+		nodeType === 'range' ||
+		nodeType === 'rank' ||
+		nodeType === 'upload'
+	);
+};
+
+// Compute step items (only groups, repeat ranges, and control nodes should be steps)
+const relevantNodes = computed(() =>
+	props.nodes.filter(node => node.currentState.relevant)
+);
+const steps = computed(() =>
+	relevantNodes.value
+		.filter(node => isGroupNode(node) || isRepeatRangeNode(node) || isControlNode(node))
+);
+
+// Handle stepper state
+const currentStep = ref(0);
+const isCurrentStepValidated = ref(true);
+const submitPressed = ref(false);
+provide('submitPressed', submitPressed);
+
+const validateStep = () => {
+    // Manually trigger submitPressed to display error messages
+	submitPressed.value = true;
+
+    const currentNode = steps.value[currentStep.value];
+    if (isGroupNode(currentNode) && currentNode.validationState.violations.length > 0) {
+        isCurrentStepValidated.value = false;
+    } else if (currentNode.validationState.violation) {
+        isCurrentStepValidated.value = false;
+    } else {
+        isCurrentStepValidated.value = true;
+    }
+}
+const nextStep = () => {
+    validateStep();
+
+	if (isCurrentStepValidated.value && currentStep.value < steps.value.length - 1) {
+        // Reset validation triggered later in the form
+	    submitPressed.value = false;
+        // Also reset validation state of current node
+        isCurrentStepValidated.value = true;
+		currentStep.value++;
+	}
+};
+const prevStep = () => {
+	if (currentStep.value > 0) {
+		currentStep.value--;
+	}
+};
+const isLastStep = computed(() => currentStep.value === steps.value.length - 1);
+watch(isLastStep, (newValue) => {
+    emit('endOfForm', newValue);
+});
+
+// // Calculate stepper progress
+// const totalNodes = computed(() => 
+// 	Math.max(relevantNodes.value.length - 1, 1) // Ensure at least 1 to avoid division by zero
+// );
+// 
+// const currentNodeIndex = computed(() => {
+//    const activeNode = steps.value[currentStep.value];
+//    if (!activeNode) return 0;
+//
+//    // Find the current node's position among relevant nodes
+//    const index = relevantNodes.value.findIndex(node => node.nodeId === activeNode.nodeId);
+//    return Math.max(index, 0); // Ensure it starts at 0
+// });
+//
+// const progress = computed(() => {
+// 	if (totalNodes.value === 1) return 100; // If there's only one relevant node, treat it as complete
+// 	return (currentNodeIndex.value / totalNodes.value) * 100;
+// });
+</script>
+
+<template>
+    <!-- TODO -->
+    <!-- <ProgressBar :value="progress"></ProgressBar> -->
+
+	<div class="stepper-container">
+		<div v-for="(step, index) in steps" :key="step.nodeId">
+			<template v-if="index === currentStep">
+				<!-- Render group nodes -->
+				<FormGroup v-if="isGroupNode(step)" :node="step" />
+
+				<!-- Render repeat nodes -->
+				<RepeatRange v-else-if="isRepeatRangeNode(step)" :node="step" />
+
+				<!-- Render individual questions -->
+				<FormQuestion v-else-if="isControlNode(step)" :question="step" />
+
+				<ExpectModelNode v-else :node="step" />
+			</template>
+		</div>
+
+		<div class="navigation-buttons">
+			<Button label="Previous" @click="prevStep" :disabled="currentStep === 0" />
+			<Button label="Next" @click="nextStep" :disabled="isCurrentStepValidated && currentStep === steps.length - 1" />
+		</div>
+	</div>
+</template>
+
+<style scoped lang="scss">
+.navigation-buttons {
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+	margin-top: 1rem;
+}
+</style>

--- a/packages/web-forms/src/components/QuestionStepper.vue
+++ b/packages/web-forms/src/components/QuestionStepper.vue
@@ -144,10 +144,16 @@ const prevStep = () => {
 
     <div class="navigation-button-group">
         <!-- If swapping to arrows: 🡨 🡪 -->
-        <Button v-if="currentStep > firstStep" class="navigation-button" label="Back" @click="prevStep" rounded outlined />
-        <Button v-if="currentStep === finalStep" class="navigation-button" label="Send" @click="allFieldsValid ? emit('sendFormFromStepper') : null" rounded />
+        <Button v-if="currentStep > firstStep" class="navigation-button" @click="prevStep" rounded outlined>
+					<span class="icon-keyboard_arrow_left"></span>
+				</Button>
+        <Button v-if="currentStep === finalStep" class="navigation-button" @click="allFieldsValid ? emit('sendFormFromStepper') : null" rounded>
+					<span class="icon-cloud_upload"></span>
+				</Button>
         <!-- Note the button ordering is important here as we use a last-child selector for styling -->
-        <Button v-if="currentStep < finalStep" class="navigation-button" label="Next" @click="nextStep" rounded outlined />
+        <Button v-if="currentStep < finalStep" class="navigation-button" @click="nextStep" rounded outlined>
+					<span class="icon-keyboard_arrow_right"></span>
+				</Button>
     </div>
 </template>
 
@@ -190,5 +196,10 @@ const prevStep = () => {
     padding-left: 3rem;
     padding-right: 3rem;
     font-size: 1rem;
+}
+
+.navigation-button > span {
+		font-weight: bold;
+		font-size: 30px;	
 }
 </style>


### PR DESCRIPTION
## I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Not applicable

## What else has been done to verify that this works as intended?

- Tested the original 'list' view layout works too.

## Why is this the best possible solution? Were any other approaches considered?

- I tried my best to not add new superfluous code.
- It's mostly either:
  - Using built-in PrimeVue components.
  - Using existing functionality built into web-forms already (such as the validation code).

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- No change for the default view - the stepper has to be enabled by a prop.

## Do we need any specific form for testing your changes? If so, please attach one.

I was testing with this one:
[mdp_fmtm_xlsform.xlsx](https://github.com/user-attachments/files/19163618/mdp_fmtm_xlsform.xlsx)

## What's changed

### Included

- I added a new component `QuestionStepper` that mirrors the `QuestionList` component.
- It's enabled by simply passing the `stepper-layout` prop to `OdkWebForm`.
- Instead of displaying questions and groups via collapsible panels, instead a PrimeVue Stepper component is introduced, displaying one question or group of questions per page.
- I kind of abused the `submitPressed` dependency to trigger the existing validation logic, without needing to add extra code - it seems to work nicely.
- Video is in desktop view for easier recording, but mobile view is the preferred way to use the stepper:

https://github.com/user-attachments/assets/132bafd7-0177-4a1a-9b09-cb39d5ee0669

### Things I didn't do

  - [ ] I updated the `FormPanel` to have an optional `toggleable` prop. This allows us to disable the panel collapsing behaviour for the stepper. I didn't update RepeatInstance and RepeatRange to have a toggleable prop passed through to FormPanel too, but assume this may be needed?
  - [ ] I attempted to add a PrimeVue ProgressBar to the stepper. It works well in the layout, however, it's pretty tricky to assess the percentage complete for the form. This needs to be done via the available nodes, but based on `relevant` fields, additional nodes can be added causing the percentage complete to drop. I need to look into this in more detail - it's probably doable - if this is a desired feature.
- [ ] I had to hide the 'Powered by ODK' button when using the stepper, as it has absolute positioning below the question panel. This could be fixed somehow if needed.

### Note on the FormPanel border

  - I removed this entirely for the stepper based view, as it's not necessary imo:
    Stepper view:
    ![image](https://github.com/user-attachments/assets/981e4a53-a088-455b-a7d8-760608fc3717)
    List view:
    ![image](https://github.com/user-attachments/assets/15e188ad-fd6d-42c6-93cb-58861334d30e)
  - I kept the left border on collapsible FormPanel as it nicely demarcates where each group starts and ends.
    - I assume that was why it is present? Else, easily removable via `box-shadow` CSS.

### Extra notes

- Styling is a mix of https://www.figma.com/design/KFi9hIQdrRgo0rLqIC7Sg8/ODK-Collect?node-id=5504-114737 and trying to keep in line with Collect - let me know your thoughts! @lognaturel @DanielJDufour 
- The send button displays in center screen on Collect, but here I added it in place of the next button on the stepper instead.
  - This could be changed, but it complicates things a bit.




