### PR TITLE
Automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,4 @@ jobs:
         run: yarn changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,22 @@ on:
 
 jobs:
   publish:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/yarn
+            **/node_modules
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Publish packages
+
+on:
+  push:
+    tags:
+      - '*@[0-9]+.[0-9]+'
+      - '*@[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Publish packages
+        run: yarn changeset publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Publish packages
 on:
   push:
     tags:
-      - '*@[0-9]+.[0-9]+'
-      - '*@[0-9]+.[0-9]+.[0-9]+'
+      - '*@[0-9]+.[0-9]+.[0-9]+' 
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -423,3 +423,4 @@ If you'd like to try the functionality available on `main`, see the preview [on 
 1. Run `yarn changeset version` to generate changelog files and version bumps from the changeset files
 1. Verify that the changelogs look good, commit changes, open a PR, merge the PR
 1. Push tags for each package in the format `package@x.x.x`. A Github action will publish the packages on NPM
+1. Update dependencies to kick off the new release cycle. We do this so that dependency updates get verified implicitly during development.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 With ODK Web Forms, you can define forms with powerful logic using the spreadsheet-based [XLSForm standard](https://docs.getodk.org/xlsform/). Use [our Vue-based frontend](/packages/web-forms/) or build your own user experience around [the engine](/packages/xforms-engine/)!
 
-You can try a preview [on the ODK website](https://getodk.org/web-forms-preview/).
+You can try a preview [on the ODK website](https://getodk.org/web-forms-preview/). This gets updated nightly to reflect `main`.
 
 > [!IMPORTANT]
 > ODK Web Forms is currently pre-release. We don't yet guarantee that its interfaces are stable and it is missing many features that are available in XLSForm form definitions.
@@ -19,7 +19,7 @@ https://github.com/getodk/web-forms/assets/447837/9b25e1bc-d209-462c-8e9e-3259bd
 - [xpath](/packages/xpath): XPath evaluator with ODK XForms extensions
 - [scenario](/packages/scenario): engine client used to express tests on forms
 
-We use [Volta](https://volta.sh/) to ensure consistent `node` and `yarn` versions.
+We use [Volta](https://volta.sh/) to ensure consistent `node` and `yarn` versions. Published packages are available [on NPM](https://www.npmjs.com/search?q=getodk).
 
 Run the preview with `yarn workspace @getodk/web-forms dev`.
 
@@ -413,3 +413,13 @@ We will be adding color and more styling soon. We intend to expose a way to do b
 
 - [Orbeon forms](https://www.orbeon.com/) is a web form system that uses the W3C XForms standard.
 - [Fore](https://github.com/Jinntec/Fore) is an XForms-inspired framework for defining frontend applications.
+
+## Releases
+
+If you'd like to try the functionality available on `main`, see the preview [on the ODK website](https://getodk.org/web-forms-preview/) which is updated daily. We try to release frequently and if there's functionality on `main` that you need but isn't released yet, please file an issue to request a release!
+
+### Release process
+
+1. Run `yarn changeset version` to generate changelog files and version bumps from the changeset files
+1. Verify that the changelogs look good, commit changes, open a PR, merge the PR
+1. Push tags for each package in the format `package@x.x.x`. A Github action will publish the packages on NPM

--- a/packages/scenario/package.json
+++ b/packages/scenario/package.json
@@ -54,8 +54,5 @@
     "solid-js": "^1.9.3",
     "vite": "^5.4.11",
     "vitest": "^2.1.8"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/scenario/package.json
+++ b/packages/scenario/package.json
@@ -54,5 +54,8 @@
     "solid-js": "^1.9.3",
     "vite": "^5.4.11",
     "vitest": "^2.1.8"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/tree-sitter-xpath/package.json
+++ b/packages/tree-sitter-xpath/package.json
@@ -47,5 +47,8 @@
   "resolutions": {
     "**/tree-sitter": "0.22.1",
     "@asgerf/dts-tree-sitter/tree-sitter": "0.22.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -76,5 +76,8 @@
   },
   "dependencies": {
     "vue-draggable-plus": "^0.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/xforms-engine/package.json
+++ b/packages/xforms-engine/package.json
@@ -80,5 +80,8 @@
     "solid-js": {
       "optional": true
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/xpath/package.json
+++ b/packages/xpath/package.json
@@ -73,5 +73,8 @@
     "vite-plugin-no-bundle": "^4.0.0",
     "vitest": "^2.1.8",
     "web-tree-sitter": "0.24.5"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Closes #

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable

### What else has been done to verify that this works as intended?
Nothing! Unfortunately I think we just have to try this one.

## Why is this the best possible solution? Were any other approaches considered?
I considered automating more but I think this is a good balance of keeping a human in the loop and automating the tedious. We'll still do a PR to generate and verify the changelogs. Then once that gets merged we'll push tags and that will trigger automatic publish. We can add more automation later if we want.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Should have no effect other than incentivizing us to release more!

## Do we need any specific form for testing your changes? If so, please attach one.

## What's changed
