### PR TITLE
chore: removes IF condition in the publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,10 @@ name: Publish packages
 on:
   push:
     tags:
-      - '*@[0-9]+.[0-9]+.[0-9]+' 
+      - '*@[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
@@ -34,4 +33,3 @@ jobs:
         run: yarn changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          


### PR DESCRIPTION
After pushing a tag in the last commit `@0.7.0` (already removed) the job was triggered but skipped: 

<img width="705" alt="Screenshot 2025-03-13 at 7 13 16 PM" src="https://github.com/user-attachments/assets/68427579-5e01-48df-a767-317356a43f3b" />

I believe it's because of the IF condition. 


## I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable

## What's changed
- Removes IF condition in publish workflow
