### PR TITLE
Match patterns including /

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish packages
 on:
   push:
     tags:
-      - '*@[0-9]+.[0-9]+.[0-9]+'
+      - '**@[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish:


### PR DESCRIPTION
`*` in Github's glob-like matching matches patterns without '/': https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet 