### PR TITLE
Initial support for editing submissions, resetting form state after submission

### DIFF
--- a/.changeset/lemon-pumpkins-smile.md
+++ b/.changeset/lemon-pumpkins-smile.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': minor
+---
+
+Support resetting form state after submission

--- a/.changeset/silly-candles-battle.md
+++ b/.changeset/silly-candles-battle.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': minor
+---
+
+Support for editing submissions

--- a/packages/web-forms/src/index.ts
+++ b/packages/web-forms/src/index.ts
@@ -1,5 +1,6 @@
 import { webFormsPlugin } from './WebFormsPlugin';
 import OdkWebForm from './components/OdkWebForm.vue';
+import { POST_SUBMIT__NEW_INSTANCE } from './lib/constants/control-flow.ts';
 
 import '@fontsource/roboto/300.css';
 import './assets/css/icomoon.css';
@@ -8,4 +9,8 @@ import './themes/2024-light/theme.scss';
 // TODO/sk: Purge it - using postcss-purgecss
 import 'primeflex/primeflex.css';
 
-export { OdkWebForm, webFormsPlugin };
+/**
+ * @todo there are almost certainly types we should be exporting from the
+ * package entrypoint!
+ */
+export { OdkWebForm, POST_SUBMIT__NEW_INSTANCE, webFormsPlugin };

--- a/packages/web-forms/src/lib/constants/control-flow.ts
+++ b/packages/web-forms/src/lib/constants/control-flow.ts
@@ -1,0 +1,10 @@
+/**
+ * Sentinel value, which may be used by a host application, once it has handled
+ * submission of a form instance, indicating that Web Forms should create a new
+ * instance of the currently loaded form.
+ */
+// In other words, if we get this from a host app like Central, we call
+// `form.createInstance()` and replace the current form's instance state with
+// the newly created instance.
+export const POST_SUBMIT__NEW_INSTANCE = Symbol('POST_SUBMIT__NEW_INSTANCE');
+export type POST_SUBMIT__NEW_INSTANCE = typeof POST_SUBMIT__NEW_INSTANCE;

--- a/packages/web-forms/src/lib/init/FormState.ts
+++ b/packages/web-forms/src/lib/init/FormState.ts
@@ -1,0 +1,63 @@
+import type {
+	AnyFormInstance,
+	LoadFormSuccessResult,
+	LoadFormWarningResult,
+	RootNode,
+} from '@getodk/xforms-engine';
+import type { FormInitializationError } from '../error/FormInitializationError.ts';
+
+/**
+ * @todo We should probably export a type for this in the engine, both as a
+ * convenience and to assign a stable name to the concept (which will probably
+ * evolve when we address
+ * {@link https://github.com/getodk/web-forms/issues/202 | error conditions} as
+ * a holistic concern).
+ */
+export type InstantiableForm = LoadFormSuccessResult | LoadFormWarningResult;
+
+export type FormStateFailureStatus = 'FORM_STATE_FAILURE';
+export type FormStateLoadingStatus = 'FORM_STATE_LOADING';
+export type FormStateSuccessStatus = 'FORM_STATE_SUCCESS';
+
+export type FormStateStatus =
+	| FormStateFailureStatus
+	| FormStateLoadingStatus
+	| FormStateSuccessStatus;
+
+interface FormStateResult {
+	readonly status: FormStateStatus;
+	readonly error: FormInitializationError | null;
+	readonly form: InstantiableForm | null;
+	readonly instance: AnyFormInstance | null;
+	readonly root: RootNode | null;
+}
+
+export interface FormStateFailureResult extends FormStateResult {
+	readonly status: FormStateFailureStatus;
+	readonly error: FormInitializationError;
+	readonly form: null;
+	readonly instance: null;
+	readonly root: null;
+}
+
+export interface FormStateLoadingResult extends FormStateResult {
+	readonly status: FormStateLoadingStatus;
+	readonly error: null;
+	readonly form: null;
+	readonly instance: null;
+	readonly root: null;
+}
+
+export interface FormStateSuccessResult extends FormStateResult {
+	readonly status: FormStateSuccessStatus;
+	readonly error: null;
+	readonly form: InstantiableForm;
+	readonly instance: AnyFormInstance;
+	readonly root: RootNode;
+}
+
+// prettier-ignore
+export type FormState =
+	| FormStateFailureResult
+	| FormStateLoadingResult
+	| FormStateSuccessResult;

--- a/packages/web-forms/src/lib/init/engine-config.ts
+++ b/packages/web-forms/src/lib/init/engine-config.ts
@@ -1,0 +1,6 @@
+import type { FormInstanceConfig } from '@getodk/xforms-engine';
+import { reactive } from 'vue';
+
+export const ENGINE_FORM_INSTANCE_CONFIG: FormInstanceConfig = {
+	stateFactory: reactive,
+};

--- a/packages/web-forms/src/lib/init/initializeFormState.ts
+++ b/packages/web-forms/src/lib/init/initializeFormState.ts
@@ -1,0 +1,37 @@
+import type { Ref } from 'vue';
+import { ref } from 'vue';
+import type { FormState, FormStateLoadingResult } from './FormState.ts';
+
+/**
+ * If this seems silly: Yes. Absolutely. It is totally silly!
+ *
+ * This is a workaround for the much more obvious thing that doesn't work:
+ *
+ * ```ts
+ * const state = ref<FormState>({
+ *  ...LITERALLY_ANY_VALUE_AT_ALL,
+ * });
+ * ```
+ *
+ * Why doesn't that work? Vue's own types? Some Vue-related tooling? Who knows!
+ *
+ * Whatever the cause, when combining...
+ *
+ * - an explicit `FormState` type parameter
+ * - an explicit default value
+ *
+ * ... the ref's `value` is:
+ *
+ * - Not nullish. (Good! That's why we pass a default value!)
+ * - Not assignable **to or from** `FormState` (Bad! That's why we would pass an
+ *   explicit type parameter!)
+ */
+export const initializeFormState = (): Ref<FormState> => {
+	return ref({
+		status: 'FORM_STATE_LOADING',
+		error: null,
+		form: null,
+		instance: null,
+		root: null,
+	} satisfies FormStateLoadingResult);
+};

--- a/packages/web-forms/src/lib/init/loadFormState.ts
+++ b/packages/web-forms/src/lib/init/loadFormState.ts
@@ -1,0 +1,119 @@
+import type {
+	AnyFormInstance,
+	FetchFormAttachment,
+	FetchResourceResponse,
+	FormResource,
+	MissingResourceBehavior,
+	ResolvableFormInstance,
+	ResolvableFormInstanceInput,
+} from '@getodk/xforms-engine';
+import { loadForm } from '@getodk/xforms-engine';
+import { FormInitializationError } from '../error/FormInitializationError.ts';
+import type {
+	FormState,
+	FormStateFailureResult,
+	FormStateSuccessResult,
+	InstantiableForm,
+} from './FormState.ts';
+import { ENGINE_FORM_INSTANCE_CONFIG } from './engine-config.ts';
+
+interface FormOptions {
+	readonly fetchFormAttachment: FetchFormAttachment;
+	readonly missingResourceBehavior?: MissingResourceBehavior;
+}
+
+export type ResolveInstanceAttachment = (fileName: string) => Promise<FetchResourceResponse>;
+
+export interface EditInstanceOptions {
+	readonly resolveInstance: ResolvableFormInstance;
+	readonly attachmentFileNames: readonly string[];
+	readonly resolveAttachment: ResolveInstanceAttachment;
+}
+
+/**
+ * Converts host app-facing {@link EditInstanceOptions} to engine's
+ * {@link ResolveFormInstanceResource}, by mapping... a mapping... to a
+ * {@link Map}.
+ */
+const resolvableFormInstanceInput = (options: EditInstanceOptions): ResolvableFormInstanceInput => {
+	const {
+		/**
+		 * We can pass this through directly...
+		 */
+		resolveInstance,
+
+		/**
+		 * ... but we need to take these keys that the host application gave us,
+		 * and ask the host application for the values associated with those keys.
+		 *
+		 * (Per feedback from Central team.)
+		 */
+		attachmentFileNames,
+		resolveAttachment,
+	} = options;
+
+	return {
+		inputType: 'FORM_INSTANCE_INPUT_RESOLVABLE',
+		resolveInstance,
+		attachments: new Map(
+			attachmentFileNames.map((fileName) => {
+				return [fileName, () => resolveAttachment(fileName)];
+			})
+		),
+	};
+};
+
+interface LoadFormStateOptions {
+	readonly form: FormOptions;
+	readonly editInstance?: EditInstanceOptions | null;
+}
+
+const failure = (error: FormInitializationError): FormStateFailureResult => {
+	return {
+		status: 'FORM_STATE_FAILURE',
+		error,
+		form: null,
+		instance: null,
+		root: null,
+	};
+};
+
+const success = (form: InstantiableForm, instance: AnyFormInstance): FormStateSuccessResult => {
+	return {
+		status: 'FORM_STATE_SUCCESS',
+		error: null,
+		form,
+		instance,
+		root: instance.root,
+	};
+};
+
+export const loadFormState = async (
+	formResource: FormResource,
+	options: LoadFormStateOptions
+): Promise<FormState> => {
+	const form = await loadForm(formResource, options.form);
+
+	if (form.status === 'failure') {
+		return failure(FormInitializationError.fromError(form.error));
+	}
+
+	if (options.editInstance == null) {
+		try {
+			const instance = form.createInstance(ENGINE_FORM_INSTANCE_CONFIG);
+
+			return success(form, instance);
+		} catch (cause) {
+			return failure(FormInitializationError.from(cause));
+		}
+	}
+
+	try {
+		const instanceOptions = resolvableFormInstanceInput(options.editInstance);
+		const instance = await form.editInstance(instanceOptions, ENGINE_FORM_INSTANCE_CONFIG);
+
+		return success(form, instance);
+	} catch (cause) {
+		return failure(FormInitializationError.from(cause));
+	}
+};

--- a/packages/web-forms/src/lib/init/updateSubmittedFormState.ts
+++ b/packages/web-forms/src/lib/init/updateSubmittedFormState.ts
@@ -1,0 +1,33 @@
+import { POST_SUBMIT__NEW_INSTANCE } from '../constants/control-flow.ts';
+import type { OptionalHostSubmissionResult } from '../submission/HostSubmissionResultCallback.ts';
+import { ENGINE_FORM_INSTANCE_CONFIG } from './engine-config.ts';
+import type { FormStateSuccessResult } from './FormState.ts';
+
+/**
+ * @todo Clean up {@link currentState}'s {@link FormStateSuccessResult.instance}
+ * before creating a new one. (Requires engine support, but will need to be
+ * invoked here!)
+ */
+const resetInstanceState = (currentState: FormStateSuccessResult): FormStateSuccessResult => {
+	const { form } = currentState;
+	const instance = form.createInstance(ENGINE_FORM_INSTANCE_CONFIG);
+
+	return {
+		status: 'FORM_STATE_SUCCESS',
+		error: null,
+		form,
+		instance,
+		root: instance.root,
+	};
+};
+
+export const updateSubmittedFormState = (
+	submissionResult: OptionalHostSubmissionResult,
+	currentState: FormStateSuccessResult
+): FormStateSuccessResult => {
+	if (submissionResult?.next === POST_SUBMIT__NEW_INSTANCE) {
+		return resetInstanceState(currentState);
+	}
+
+	return currentState;
+};

--- a/packages/web-forms/src/lib/submission/HostSubmissionResultCallback.ts
+++ b/packages/web-forms/src/lib/submission/HostSubmissionResultCallback.ts
@@ -1,0 +1,15 @@
+import type { Awaitable } from '@getodk/common/types/helpers.js';
+import type { POST_SUBMIT__NEW_INSTANCE } from '../constants/control-flow.ts';
+
+export interface HostSubmissionResult {
+	readonly next?: POST_SUBMIT__NEW_INSTANCE;
+}
+
+export type OptionalHostSubmissionResult = HostSubmissionResult | null | void;
+
+export type OptionalAwaitableHostSubmissionResult = Awaitable<OptionalHostSubmissionResult>;
+
+export type HostSubmissionResultCallback = (
+	// Everything is optional!
+	hostResult?: OptionalAwaitableHostSubmissionResult
+) => void;


### PR DESCRIPTION
All of #247 except UI/UX revisions!

## I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable

I have verified this with tests. We'd need to simulate a host app integration to verify it in browsers. I still don't think anything here would be browser specific.

## What else has been done to verify that this works as intended?

Testing:

- A quick validation that loading a form with `editInstance` input results in a form with that instance's state
- Much more validation that the solution for creating multiple instances doesn't introduce regressions (i.e. "everything is optional")

## Why is this the best possible solution? Were any other approaches considered?

Some of this involved cleaning up the states possible in `OdkWebForm` (currently the primary host app interface). It wasn't strictly necessary, but the necessary features required additive changes to possible state which I found **really hard** to reason about without making it more explicit.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

As best as I could, I exercised the regression risks I know about in tests.

## Do we need any specific form for testing your changes? If so, please attach one.

N/A

## What's changed

**Instance editing:** exposes a host app interface which is mostly a passthrough to the engine's interface of same. One difference, based on feedback from the Central team, is a slightly different representation of instance attachments.

**Creating multiple instances:** expands the emit signatures for `submit` and `submitChunked` to pass a callback, which a host app can invoke to signal:

1. That it is handling the submission (`Promise` == in progress, may also be synchronous, or may be ignored; **everything about this is optional**)
2. That it has finished handling submission (`Promise` resolution == success or failure)
3. That it wants Web Forms to create a new instance (by passing us a sentinel value which we export)

If we receive that sentinel value, we create a new instance. If any other thing happens, the current behavior is unchanged: pass an `InstancePayload` to host app, do nothing afterward.