### PR TITLE
Skip CI if-and-only-if run from a non-fork PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,31 +24,21 @@ env:
   LOCALE_ID: 'en-US'
 
 jobs:
-  check-run:
+  ci-conditions:
+    name: 'CI conditions'
     runs-on: 'ubuntu-latest'
     outputs:
-      should-skip: ${{ steps.check.outputs.should-skip }}
+      IS_FORK: ${{ github.repository_owner != 'getodk' }}
+      IS_PR: ${{ github.event_name == 'pull_request' }}
+
     steps:
-      - name: Check for duplicate push event with PR
-        id: check
-        if: github.event_name == 'push'
-        run: |
-          # Check if this push is tied to an open PR
-          PR_NUMBER=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" | \
-            jq -r '.[0].number // "none"')
-          if [ "$PR_NUMBER" != "none" ]; then
-            echo "This push (commit ${{ github.sha }}) is part of PR #$PR_NUMBER, skipping to avoid duplication with pull_request event."
-            echo "should-skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "No associated PR found, proceeding with CI for this push."
-            echo "should-skip=false" >> $GITHUB_OUTPUT
-          fi
+      - name: Capture CI conditions
+        id: capture-ci-conditions
+        run: exit 0
 
   install-and-build:
-    needs: check-run
-    if: ${{ needs.check-run.outputs.should-skip != 'true' }}
+    needs: ci-conditions
+    if: ${{ needs.ci-conditions.outputs.IS_PR != 'true' || needs.ci-conditions.outputs.IS_FORK == 'true' }}
     name: 'Install dependencies and build packages'
     runs-on: 'ubuntu-latest'
 


### PR DESCRIPTION
Fixes failure to produce a build artifact on merge to `main`. (Or at least, I think it fixes that!)

Closes # (do we have an issue for this?)

## I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [x] Not applicable
- [x] GitHub Actions

## What else has been done to verify that this works as intended?

After the first failed attempt in #368, I did a bunch of trial and error in a private personal repo. Note: I haven't validated the fork-specific logic (because no fork of private personal repo)! But I have validated that jobs predicated on that condition run as expected (and don't run for a negative predicate result).

## Why is this the best possible solution? Were any other approaches considered?

It probably isn't the best possible solution!

- I briefly considered investigating other CI solutions but we don't want that.
- We discussed making the build -> upload artifact job more explicit. I think we should do that but don't want to block a pragmatic fix over it.

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I could imagine a few hundred ways this breaks assumptions we have about CI. But the real risk is the ways I can't imagine. Such is the nature of GitHub Actions!

## Do we need any specific form for testing your changes? If so, please attach one.

N/A

## What's changed

CI will now be skipped if triggered by a `pull_request` event, except if the PR is from a fork... where "from a fork" is defined as `repository_owner` being some value other than `'getodk'`.