### PR TITLE
Substantially narrower design for adding media to label interfaces

### DIFF
--- a/packages/xforms-engine/src/client/media/AudioMediaResource.ts
+++ b/packages/xforms-engine/src/client/media/AudioMediaResource.ts
@@ -1,0 +1,6 @@
+import type { MediaResourceTypeAudio } from './BaseMediaResource.ts';
+import type { BaseStreamableMediaResource } from './BaseStreamableMediaResource.ts';
+
+export interface AudioMediaResource extends BaseStreamableMediaResource {
+	readonly resourceType: MediaResourceTypeAudio;
+}

--- a/packages/xforms-engine/src/client/media/BaseMediaResource.ts
+++ b/packages/xforms-engine/src/client/media/BaseMediaResource.ts
@@ -1,0 +1,21 @@
+import type { Awaitable } from '@getodk/common/types/helpers.js';
+
+export type MediaResourceTypeAudio = 'MEDIA_RESOURCE_TYPE_AUDIO';
+export type MediaResourceTypeVideo = 'MEDIA_RESOURCE_TYPE_VIDEO';
+export type MediaResourceTypeImage = 'MEDIA_RESOURCE_TYPE_IMAGE';
+
+export type MediaResourceType =
+	| MediaResourceTypeAudio
+	| MediaResourceTypeImage
+	| MediaResourceTypeVideo;
+
+export interface BaseMediaResourceDetail {
+	readonly fileName: string;
+
+	getResourceData(): Awaitable<Blob>;
+}
+
+export interface BaseMediaResource {
+	readonly resourceType: MediaResourceType;
+	readonly detail: BaseMediaResourceDetail;
+}

--- a/packages/xforms-engine/src/client/media/BaseStreamableMediaResource.ts
+++ b/packages/xforms-engine/src/client/media/BaseStreamableMediaResource.ts
@@ -1,0 +1,18 @@
+import type { UnknownObject } from '@getodk/common/lib/type-assertions/assertUnknownObject.ts';
+import type { Awaitable } from '@getodk/common/types/helpers.d.ts';
+import type { BaseMediaResource, BaseMediaResourceDetail } from './BaseMediaResource.ts';
+import type { MediaResourceURL } from './MediaResourceURL.ts';
+
+export interface BaseStreamableMediaResourceDetail
+	extends BaseMediaResourceDetail,
+		// Note: we still have research to do into how we'll support streaming! Even
+		// this interface is fairly speculative. It exists mainly to signal intent,
+		// and as a baseline of the minimum expected surface/responsibilities.
+		UnknownObject {
+	getStream(): Awaitable<ReadableStream>;
+	getURL(): Awaitable<MediaResourceURL>;
+}
+
+export interface BaseStreamableMediaResource extends BaseMediaResource {
+	readonly detail: BaseStreamableMediaResourceDetail;
+}

--- a/packages/xforms-engine/src/client/media/ImageMediaResource.ts
+++ b/packages/xforms-engine/src/client/media/ImageMediaResource.ts
@@ -1,0 +1,16 @@
+import type {
+	BaseMediaResource,
+	BaseMediaResourceDetail,
+	MediaResourceTypeImage,
+} from './BaseMediaResource.ts';
+import type { MediaResourceURL } from './MediaResourceURL.ts';
+
+export interface ImageMediaResourceDetail extends BaseMediaResourceDetail {
+	readonly url: MediaResourceURL;
+	readonly bigImageURL: MediaResourceURL | null;
+}
+
+export interface ImageMediaResource extends BaseMediaResource {
+	readonly resourceType: MediaResourceTypeImage;
+	readonly detail: ImageMediaResourceDetail;
+}

--- a/packages/xforms-engine/src/client/media/MediaResource.ts
+++ b/packages/xforms-engine/src/client/media/MediaResource.ts
@@ -1,0 +1,15 @@
+import type { AudioMediaResource } from './AudioMediaResource.ts';
+import type { MediaResourceType } from './BaseMediaResource.ts';
+import type { ImageMediaResource } from './ImageMediaResource.ts';
+import type { VideoMediaResource } from './VideoMediaResource.ts';
+
+interface MediaResourceByTypeSuffix {
+	readonly MEDIA_RESOURCE_TYPE_AUDIO: AudioMediaResource;
+	readonly MEDIA_RESOURCE_TYPE_IMAGE: ImageMediaResource;
+	readonly MEDIA_RESOURCE_TYPE_VIDEO: VideoMediaResource;
+}
+
+// prettier-ignore
+export type MediaResource<
+	ResourceType extends MediaResourceType = MediaResourceType,
+> = MediaResourceByTypeSuffix[ResourceType];

--- a/packages/xforms-engine/src/client/media/MediaResourceURL.ts
+++ b/packages/xforms-engine/src/client/media/MediaResourceURL.ts
@@ -1,0 +1,5 @@
+import type { PartiallyKnownString } from '@getodk/common/types/string/PartiallyKnownString.ts';
+
+export interface MediaResourceURL extends URL {
+	readonly protocol: PartiallyKnownString<'blob:' | 'data:'>;
+}

--- a/packages/xforms-engine/src/client/media/VideoMediaResource.ts
+++ b/packages/xforms-engine/src/client/media/VideoMediaResource.ts
@@ -1,0 +1,6 @@
+import type { MediaResourceTypeVideo } from './BaseMediaResource.ts';
+import type { BaseStreamableMediaResource } from './BaseStreamableMediaResource.ts';
+
+export interface VideoMediaResource extends BaseStreamableMediaResource {
+	readonly resourceType: MediaResourceTypeVideo;
+}


### PR DESCRIPTION
I was working on this yesterday but didn't get it quite there before an early EOD, but I wanted to make it visible this morning while I have the opportunity. I can write this up, and we could decide on the best approach to resolving it as a design decision and/or artifact. Opening as draft for now.

This is an alternative approach, incrementally working towards designs in #373. This design would be additive, leaving much of the work done in the previous design to be handled as later steps in a sequence. A couple of notes are added in JSDoc as breadcrumbs about how this design could evolve toward that one. Another note is added, as a hint to implementation, regarding how the current `jr:itext` behavior could be preserved while media support is added, leaving #121 to be addressed in a followup rather than as two-birds-one-stone.

<!-- Closes #

## I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Not applicable

## What else has been done to verify that this works as intended?

## Why is this the best possible solution? Were any other approaches considered?

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

## Do we need any specific form for testing your changes? If so, please attach one.

## What's changed
