### PR TITLE
fix(#383): validates NaN in NumberEvaluation

### DIFF
--- a/packages/xpath/src/evaluations/NumberEvaluation.ts
+++ b/packages/xpath/src/evaluations/NumberEvaluation.ts
@@ -18,6 +18,6 @@ export class NumberEvaluation<T extends XPathNode> extends ValueEvaluation<T, 'N
 
 		this.booleanValue = value !== 0 && !Number.isNaN(value);
 		this.numberValue = value;
-		this.stringValue = String(value);
+		this.stringValue = value == null || Number.isNaN(value) ? '' : String(value);
 	}
 }

--- a/packages/xpath/test/evaluator/Evaluator.test.ts
+++ b/packages/xpath/test/evaluator/Evaluator.test.ts
@@ -72,6 +72,8 @@ describe('Evaluator convenience methods', () => {
 			{ expression: '2', expected: '2' },
 			{ expression: '/root/a', expected: '3' },
 			{ expression: '/root/b', expected: '' },
+			{ expression: '/root/b', expected: '' },
+			{ expression: '3 div abc ', expected: '' },
 		])('evaluates $expression to boolean $expected', ({ expression, expected }) => {
 			const actual = evaluator.evaluateString(expression);
 


### PR DESCRIPTION
Closes #383

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [x] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
