### PR TITLE
feat(#301): Add support for a multiline text question type.

### DIFF
--- a/.changeset/icy-llamas-fail.md
+++ b/.changeset/icy-llamas-fail.md
@@ -1,0 +1,4 @@
+---
+'@getodk/web-forms': minor
+---
+Add support for a multiline text question type.

--- a/packages/web-forms/src/components/controls/Input/InputText.vue
+++ b/packages/web-forms/src/components/controls/Input/InputText.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { StringInputNode, TemporaryStringValueInputNode } from '@getodk/xforms-engine';
 import InputText from 'primevue/inputtext';
+import Textarea from 'primevue/textarea';
 import { computed, inject } from 'vue';
 
 // prettier-ignore
@@ -21,23 +22,50 @@ const setValue = (value = '') => {
 const doneAnswering = inject<boolean>('doneAnswering');
 const submitPressed = inject<boolean>('submitPressed');
 const invalid = computed(() => props.node.validationState.violation?.valid === false);
+const rows = computed(() => {
+	const options = props.node.nodeOptions;
+	if (options && 'rows' in options) {
+		return options.rows ?? 0;
+	}
+	return 0;
+});
 </script>
 
 <template>
-	<InputText
-		:id="node.nodeId"
-		:required="node.currentState.required"
-		:disabled="node.currentState.readonly"
-		:class="{'inside-highlighted': invalid && submitPressed}"
-		:model-value="node.currentState.value"
-		@update:model-value="setValue"
-		@input="doneAnswering = false"
-		@blur="doneAnswering = true"
-	/>
+	<template v-if="rows > 0">
+		<Textarea
+			:id="node.nodeId"
+			:required="node.currentState.required"
+			:disabled="node.currentState.readonly"
+			:class="{'inside-highlighted': invalid && submitPressed}"
+			:model-value="node.currentState.value"
+			:rows="rows"
+			@update:model-value="setValue"
+			@input="doneAnswering = false"
+			@blur="doneAnswering = true"
+		/>
+	</template>
+	<template v-else>
+		<InputText
+			:id="node.nodeId"
+			:required="node.currentState.required"
+			:disabled="node.currentState.readonly"
+			:class="{'inside-highlighted': invalid && submitPressed}"
+			:model-value="node.currentState.value"
+			@update:model-value="setValue"
+			@input="doneAnswering = false"
+			@blur="doneAnswering = true"
+		/>
+	</template>
 </template>
 
 <style scoped>
 .p-inputtext {
 	width: 100%;
+}
+
+.p-textarea {
+	width: 100%;
+	resize: none;
 }
 </style>


### PR DESCRIPTION
Closes #301

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?
<details><summary>Happy path and required state</summary>

https://github.com/user-attachments/assets/8e4f2783-0b2b-4661-8ffb-1d1c42c9bc6a

</details>

<details><summary>Disabled state</summary>

<img width="963" alt="Screenshot 2025-05-13 at 1 52 26 PM" src="https://github.com/user-attachments/assets/a825c58d-4951-4180-a5fa-df8532c3df36" />

</details>

<details><summary>Firefox & Safari Desktop</summary>

<img width="1728" alt="Screenshot 2025-05-13 at 1 55 43 PM" src="https://github.com/user-attachments/assets/9ff81c77-b6da-4685-8155-a9a12233328f" />
<img width="1722" alt="Screenshot 2025-05-13 at 1 54 41 PM" src="https://github.com/user-attachments/assets/1c057e26-d2f5-44fc-8bc9-8a9ecb3e9fa2" />

</details>

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

Needs testing in mobile

### What's changed
- Adds Text Area input that is displayed if `rows` has a value greater than zero
  - Multiline appearance will be done later 
