### PR TITLE
Prepare release with support for rows attribute on text

### DIFF
--- a/.changeset/icy-llamas-fail.md
+++ b/.changeset/icy-llamas-fail.md
@@ -1,4 +1,0 @@
----
-'@getodk/web-forms': minor
----
-Add support for a multiline text question type.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This section is auto generated. Please update `feature-matrix.json` and then run
   <summary>
 
 <!-- prettier-ignore -->
-  #####  $\texttt{Parameters\hspace{43mm}\color{green}██████\color{LightGray}█████████ \color{initial} 44\\%}$
+  #####  $\texttt{Parameters\hspace{43mm}\color{green}██████████\color{LightGray}█████ \color{initial} 70\\%}$
 
   </summary>
   <br/>
@@ -160,8 +160,9 @@ This section is auto generated. Please update `feature-matrix.json` and then run
 | -------------------------------------------------------------------------------------------------------------------------------- | :------: |
 | randomize                                                                                                                        |    ✅    |
 | seed                                                                                                                             |    ✅    |
-| value                                                                                                                            |          |
-| label                                                                                                                            |          |
+| value                                                                                                                            |    ✅    |
+| label                                                                                                                            |    ✅    |
+| rows                                                                                                                             |    ✅    |
 | geopoint capture-accuracy, warning-accur<br/>acy, allow-mock-accuracy                                                            |    ✅    |
 | range start, end, step                                                                                                           |    ✅    |
 | image max-pixels                                                                                                                 |          |

--- a/feature-matrix.json
+++ b/feature-matrix.json
@@ -82,8 +82,9 @@
   "Parameters": {
     "randomize": "✅",
     "seed": "✅",
-    "value": "",
-    "label": "",
+    "value": "✅",
+    "label": "✅",
+    "rows": "✅",
     "geopoint capture-accuracy, warning-accuracy, allow-mock-accuracy": "✅",
     "range start, end, step": "✅",
     "image max-pixels": "",

--- a/packages/web-forms/CHANGELOG.md
+++ b/packages/web-forms/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @getodk/web-forms
 
+## 0.11.0
+
+### Minor Changes
+
+- 3aedccb: Add support for a multiline text question type.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/web-forms",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "description": "ODK Web Forms",
   "author": "getodk",


### PR DESCRIPTION
Prepares release

I added the `rows` parameter and in doing so noticed that the `label` and `value` parameters were marked as incomplete. I verified that they are fully supported with the following form: 
[external-data(1).csv](https://github.com/user-attachments/files/20197341/external-data.1.csv)
[select-one-file(1).xlsx](https://github.com/user-attachments/files/20197342/select-one-file.1.xlsx)
