### PR TITLE
feat(#412): removes print button

### DIFF
--- a/.changeset/fifty-plums-live.md
+++ b/.changeset/fifty-plums-live.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': minor
+---
+
+Removes print button

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ This section is auto generated. Please update `feature-matrix.json` and then run
 | -------------------------- | :------: |
 | grid                       |          |
 | pages                      |          |
-| print                      |          |
 | logo                       |          |
 | theme color                |          |
 | Submissions                |          |

--- a/feature-matrix.json
+++ b/feature-matrix.json
@@ -124,7 +124,6 @@
   "Theme and Layouts": {
     "grid": "",
     "pages": "",
-    "print": "",
     "logo": "",
     "theme color": "",
     "Submissions": "",

--- a/packages/web-forms/src/assets/css/reset.scss
+++ b/packages/web-forms/src/assets/css/reset.scss
@@ -30,7 +30,7 @@ h6,
 b,
 strong {
 	font-weight: bolder;
-	line-height: 1.1;
+	line-height: 1.15;
 }
 
 p,

--- a/packages/web-forms/src/components/FormHeader.vue
+++ b/packages/web-forms/src/components/FormHeader.vue
@@ -1,29 +1,24 @@
 <script setup lang="ts">
-import IconSVG from '@/components/widgets/IconSVG.vue';
 import {
 	type FormLanguage,
 	type RootNode,
 	type SyntheticDefaultLanguage,
 } from '@getodk/xforms-engine';
-import Button from 'primevue/button';
 import Card from 'primevue/card';
-import Menu from 'primevue/menu';
 import { ref } from 'vue';
-import FormLanguageDialog from './FormLanguageDialog.vue';
 import FormLanguageMenu from './FormLanguageMenu.vue';
 
 const props = defineProps<{ form: RootNode }>();
 const languageDialogState = ref(false);
-const menu = ref<InstanceType<typeof Menu>>();
 
 const isFormLanguage = (lang: FormLanguage | SyntheticDefaultLanguage): lang is FormLanguage => {
 	return !lang.isSyntheticDefault;
 };
 
+type DropdownItem = Array<{ label: string; icon: string; command: () => void }>;
+const items = ref<DropdownItem>([]);
+
 const languages = props.form.languages.filter(isFormLanguage);
-
-const items = ref([]);
-
 if (languages.length > 0) {
 	items.value.unshift({
 		// TODO: translations

--- a/packages/web-forms/src/components/FormHeader.vue
+++ b/packages/web-forms/src/components/FormHeader.vue
@@ -22,16 +22,7 @@ const isFormLanguage = (lang: FormLanguage | SyntheticDefaultLanguage): lang is 
 
 const languages = props.form.languages.filter(isFormLanguage);
 
-const print = () => window.print();
-
-const items = ref([
-	{
-		// TODO: translations
-		label: 'Print',
-		icon: 'mdiPrinter',
-		command: print,
-	},
-]);
+const items = ref([]);
 
 if (languages.length > 0) {
 	items.value.unshift({
@@ -51,9 +42,6 @@ const handleLanguageChange = (event: FormLanguage) => {
 	<!-- for desktop -->
 	<div class="hidden lg:inline larger-screens">
 		<div class="flex justify-content-end flex-wrap gap-3">
-			<Button class="print-button" severity="secondary" rounded @click="print">
-				<IconSVG name="mdiPrinter" />
-			</Button>
 			<FormLanguageMenu
 				:active-language="form.currentState.activeLanguage"
 				:languages="languages"
@@ -77,40 +65,12 @@ const handleLanguageChange = (event: FormLanguage) => {
 		</h1>
 
 		<div class="form-options">
-			<!-- if Form is not multilingual then we always show print button -->
-			<Button v-if="languages.length === 0" class="print-button" severity="secondary" rounded @click="print">
-				<IconSVG name="mdiPrinter" />
-			</Button>
-
-			<!-- show either hamburger or (print button and language changer) based on container size -->
-			<div v-else class="multilingual">
-				<Button class="btn-menu" text rounded aria-label="Menu" @click="menu?.toggle">
-					<IconSVG name="mdiMenu" />
-				</Button>
-				<Menu id="overlay_menu" ref="menu" :model="items" :popup="true">
-					<template #item="{ item }">
-						<a v-if="item.command != null" class="p-menu-item-link" @click="(event) => item.command && item.command({ originalEvent: event, item })">
-							<IconSVG v-if="item.icon != null" :name="item.icon" />
-							<span>{{ item.label }}</span>
-						</a>
-					</template>
-				</Menu>
-				<FormLanguageDialog
-					v-model:state="languageDialogState"
-					:active-language="form.currentState.activeLanguage"
-					:languages="languages"
-					@update:active-language="handleLanguageChange"
-				/>
-
-				<Button class="print-button" severity="secondary" rounded @click="print">
-					<IconSVG name="mdiPrinter" />
-				</Button>
-				<FormLanguageMenu
-					:active-language="form.currentState.activeLanguage"
-					:languages="languages"
-					@update:active-language="handleLanguageChange"
-				/>
-			</div>
+			<FormLanguageMenu
+				v-if="languages.length > 0"
+				:active-language="form.currentState.activeLanguage"
+				:languages="languages"
+				@update:active-language="handleLanguageChange"
+			/>
 		</div>
 	</div>
 </template>
@@ -171,40 +131,31 @@ const handleLanguageChange = (event: FormLanguage) => {
 		container-type: size;
 		container-name: formOptionsContainer;
 		height: 40px;
-		margin-top: 11px;
+		margin-top: 10px;
 
-		.multilingual {
+		.language-changer {
 			display: flex;
 			justify-content: end;
+			width: 45px;
 			gap: 0.5rem;
 
-			.btn-menu :deep(.odk-icon) path {
-				transform: scale(1.1) translate(-3px, -3px);
+			:deep(.p-select-label) {
+				text-overflow: unset;
 			}
 
-			.print-button {
+			:deep(.p-select-label) span,
+			:deep(.p-select-dropdown) {
 				display: none;
 			}
 
-			.language-changer {
-				display: none;
+			:deep(.odk-icon) {
+				margin-right: 0;
 			}
 		}
 
 		@container formOptionsContainer (min-width: 260px) {
-			.multilingual {
-				.btn-menu {
-					display: none;
-				}
-
-				.print-button {
-					display: flex;
-				}
-
-				.language-changer {
-					display: flex;
-					max-width: 220px;
-				}
+			.language-changer {
+				max-width: 220px;
 			}
 		}
 	}

--- a/packages/web-forms/src/components/FormLanguageMenu.vue
+++ b/packages/web-forms/src/components/FormLanguageMenu.vue
@@ -31,12 +31,10 @@ defineEmits(['update:activeLanguage']);
 </template>
 
 <style scoped lang="scss">
-.language-changer {
-	display: flex;
-}
-
 .p-select.language-changer {
+	display: flex;
 	border: none;
+	box-shadow: none;
 	width: max-content;
 	max-width: 220px;
 	color: var(--odk-text-color);
@@ -46,7 +44,8 @@ defineEmits(['update:activeLanguage']);
 	}
 
 	:deep(.p-select-label) {
-		padding: 5px 12px;
+		padding: 10px 12px;
+
 		span {
 			vertical-align: middle;
 		}
@@ -54,14 +53,6 @@ defineEmits(['update:activeLanguage']);
 
 	.odk-icon {
 		margin-right: 0.5rem;
-	}
-}
-</style>
-
-<style>
-@media print {
-	.p-menu {
-		display: none;
 	}
 }
 </style>

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -327,16 +327,6 @@ watchEffect(() => {
 		min-height: 40px;
 	}
 
-	:deep(.print-button.p-button) {
-		display: flex;
-		height: var(--p-button-icon-only-width);
-		width: var(--p-button-icon-only-width);
-		padding-inline-start: 0;
-		padding-inline-end: 0;
-		gap: 0;
-		border-radius: 50%;
-	}
-
 	.footer {
 		margin: 1.5rem 0 0rem 0;
 
@@ -354,7 +344,7 @@ watchEffect(() => {
 
 		.anchor {
 			color: var(--odk-muted-text-color);
-			font-size: 24px;
+			font-size: 18px;
 			font-weight: 400;
 			text-decoration: none;
 
@@ -364,17 +354,17 @@ watchEffect(() => {
 
 			img.logo {
 				vertical-align: middle;
-				width: 49px;
-				margin-left: 7px;
+				width: 40px;
+				margin-left: 4px;
 				margin-top: -4px;
 			}
 		}
 
 		.version {
-			font-size: 18px;
+			font-size: 14px;
 			font-weight: 300;
 			color: var(--odk-muted-text-color);
-			margin-top: 10px;
+			margin-top: 5px;
 		}
 	}
 }
@@ -430,6 +420,19 @@ watchEffect(() => {
 
 	.odk-form .powered-by-wrapper {
 		padding-top: 100px;
+
+		.anchor {
+			font-size: 14px;
+
+			img.logo {
+				width: 30px;
+			}
+		}
+
+		.version {
+			font-size: 11px;
+			margin-top: 2px;
+		}
 	}
 }
 </style>


### PR DESCRIPTION
Closes #412

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Tested in Central, Blank project, and Preview page

<details><summary>Resizes "Powered by"</summary>

![Screenshot 2025-05-20 at 2 24 47 PM](https://github.com/user-attachments/assets/7b781ad6-ce94-4eb3-b006-2d126ce902d9)
![Screenshot 2025-05-20 at 2 18 27 PM](https://github.com/user-attachments/assets/ee4711a5-6d6a-4711-8da8-ce50b70d825a)

</details>

<details><summary>Language dropdown in Central</summary>

https://github.com/user-attachments/assets/1019d043-8132-4870-a650-5894e406e9e5

</details>

<details><summary>Language dropdown - desktop, mobile</summary>

<img width="421" alt="Screenshot 2025-05-20 at 3 25 11 PM" src="https://github.com/user-attachments/assets/88b38746-9253-4ab9-b255-f9fd79da7271" />
<img width="1169" alt="Screenshot 2025-05-20 at 3 22 03 PM" src="https://github.com/user-attachments/assets/0fe15625-dfaf-4dfd-88ee-2fe1e91ee0be" />

</details>

### Why is this the best possible solution? Were any other approaches considered?

Simplifies user experience

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

They cannot print the form, but that's fine; we will observe user feedback and evaluate if it adds value.  

### Do we need any specific form for testing your changes? If so, please attach one.
No

### What's changed
- Removes print button
- Resizes "Powered by" based on Yaw and Aly's feedback
- Removes hamburger menu and uses dropdown language in mobile view
