### PR TITLE
chore(#413): improves rank's visual highlight

### DIFF
--- a/.changeset/green-coins-change.md
+++ b/.changeset/green-coins-change.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': patch
+---
+
+Improves rank's highlight effect when an option is moved to a new position

--- a/packages/web-forms/src/components/controls/RankControl.vue
+++ b/packages/web-forms/src/components/controls/RankControl.vue
@@ -29,7 +29,7 @@ const highlight: HighlightOption = {
 /**
  * Delay in ms to show the highlight styles on rank's UI.
  */
-const HIGHLIGHT_DELAY = 500;
+const HIGHLIGHT_DELAY = 1200;
 
 /**
  * Delay in ms to hold an item before dragging, avoids accidental reordering on swipe.
@@ -103,6 +103,12 @@ const swapItems = (index: number, newPosition: number) => {
 
 	setHighlight(newPosition);
 };
+
+const onDragEnd = (oldIndex: number | undefined, newIndex: number | undefined) => {
+	if (newIndex != null && newIndex !== oldIndex) {
+		setHighlight(newIndex);
+	}
+};
 </script>
 
 <template>
@@ -126,6 +132,7 @@ const swapItems = (index: number, newPosition: number) => {
 			ghost-class="fade-moving"
 			class="rank-control"
 			:class="{ disabled: disabled }"
+			:on-end="(event) => onDragEnd(event.oldIndex, event.newIndex)"
 		>
 			<div
 				v-for="(value, index) in values"


### PR DESCRIPTION
Closes #413

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Manual testing - video: 

https://github.com/user-attachments/assets/44b05a2a-f25e-48f4-8f11-8552146d82d4

### Why is this the best possible solution? Were any other approaches considered?

Reuses existing code

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- Better visual feedback of the option's new position in the list 

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
- Doubles the time of the highlight effect after an option is moved to a new position 
- Adds the highlight effect after an option is dragged to a new position 
