### PR TITLE
fix(#422): select's search filters by label

### DIFF
--- a/.changeset/puny-peaches-listen.md
+++ b/.changeset/puny-peaches-listen.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': patch
+---
+
+Fixes select's search to filter by label

--- a/packages/web-forms/src/components/widgets/MultiselectDropdown.vue
+++ b/packages/web-forms/src/components/widgets/MultiselectDropdown.vue
@@ -13,21 +13,21 @@ const props = defineProps<MultiselectDropdownProps>();
 defineEmits(['update:modelValue', 'change']);
 
 const options = computed(() => {
-	return props.question.currentState.valueOptions.map((option) => option.value);
+	return props.question.currentState.valueOptions.map((option) => {
+		const label = props.question.getValueOption(option.value);
+		if (label == null) {
+			throw new Error(`Failed to find option for value: ${option.value}`);
+		}
+
+		return {
+			value: option.value,
+			label: option.label.asString,
+		};
+	});
 });
 
 const selectValues = (values: readonly string[]) => {
 	props.question.selectValues(values);
-};
-
-const getOptionLabel = (value: string) => {
-	const option = props.question.getValueOption(value);
-
-	if (option == null) {
-		throw new Error(`Failed to find option for value: ${value}`);
-	}
-
-	return option.label.asString;
 };
 
 let panelClass = 'multi-select-dropdown-panel';
@@ -46,10 +46,12 @@ if (props.question.appearances['no-buttons']) {
 		class="multi-select-dropdown"
 		:input-id="question.nodeId"
 		:filter="question.appearances.autocomplete"
+		filter-match-mode="contains"
 		:auto-filter-focus="question.appearances.autocomplete"
 		:show-toggle-all="false"
 		:options="options"
-		:option-label="getOptionLabel"
+		option-label="label"
+		option-value="value"
 		:panel-class="panelClass"
 		:model-value="question.currentState.value"
 		@update:model-value="selectValues"

--- a/packages/web-forms/src/components/widgets/SearchableDropdown.vue
+++ b/packages/web-forms/src/components/widgets/SearchableDropdown.vue
@@ -13,21 +13,21 @@ const props = defineProps<SearchableDropdownProps>();
 defineEmits(['update:modelValue', 'change']);
 
 const options = computed(() => {
-	return props.question.currentState.valueOptions.map((option) => option.value);
+	return props.question.currentState.valueOptions.map((option) => {
+		const label = props.question.getValueOption(option.value);
+		if (label == null) {
+			throw new Error(`Failed to find option for value: ${option.value}`);
+		}
+
+		return {
+			value: option.value,
+			label: option.label.asString,
+		};
+	});
 });
 
 const selectValue = (value: string) => {
 	props.question.selectValue(value);
-};
-
-const getOptionLabel = (value: string) => {
-	const option = props.question.getValueOption(value);
-
-	if (option == null) {
-		throw new Error(`Failed to find option for value: ${value}`);
-	}
-
-	return option.label.asString;
 };
 </script>
 
@@ -36,10 +36,12 @@ const getOptionLabel = (value: string) => {
 		:id="question.nodeId"
 		class="dropdown"
 		:filter="question.appearances.autocomplete"
+		filter-match-mode="contains"
 		:auto-filter-focus="true"
 		:model-value="question.currentState.value[0]"
 		:options="options"
-		:option-label="getOptionLabel"
+		option-label="label"
+		option-value="value"
 		@update:model-value="selectValue"
 		@change="$emit('change')"
 	/>


### PR DESCRIPTION
Closes #422

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Test video:


https://github.com/user-attachments/assets/8746e975-5478-4d6e-a2e9-a357e3c3cd6d


### Why is this the best possible solution? Were any other approaches considered?

- Proper use of select's filter. The label can't be a function; it breaks the filter. 

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- Search now filters by label

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
- Process label when getting options 
- Search is by `contains` and case-insensitive 
