### PR TITLE
feat(#425): adds support for multiline appearance in input text

### DIFF
--- a/.changeset/afraid-dogs-march.md
+++ b/.changeset/afraid-dogs-march.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': patch
+---
+
+Adds support for multiline appearance in input text

--- a/packages/web-forms/src/components/controls/Input/InputText.vue
+++ b/packages/web-forms/src/components/controls/Input/InputText.vue
@@ -4,6 +4,8 @@ import InputText from 'primevue/inputtext';
 import Textarea from 'primevue/textarea';
 import { computed, inject } from 'vue';
 
+const MULTILINE_APPEARANCE_ROW_SIZE = 4;
+
 // prettier-ignore
 type TextInputNode =
 	| StringInputNode
@@ -24,9 +26,14 @@ const submitPressed = inject<boolean>('submitPressed');
 const invalid = computed(() => props.node.validationState.violation?.valid === false);
 const rows = computed(() => {
 	const options = props.node.nodeOptions;
-	if (options && 'rows' in options) {
-		return options.rows ?? 0;
+	if (options && 'rows' in options && options.rows != null) {
+		return options.rows;
 	}
+
+	if (props.node.appearances.multiline) {
+		return MULTILINE_APPEARANCE_ROW_SIZE;
+	}
+
 	return 0;
 });
 </script>
@@ -65,7 +72,7 @@ const rows = computed(() => {
 }
 
 .p-textarea {
-	width: 100%;
-	resize: none;
+	width: 100% !important; /* Overrides forced width when resize is set to vertical */
+	resize: vertical;
 }
 </style>


### PR DESCRIPTION
Closes #425

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Test videos

- Regular input text without appearance and input text with `multiline` appearance


https://github.com/user-attachments/assets/462db7d7-38dc-42c8-bfd5-3065d5462fb6


- Input text with `rows` property 


https://github.com/user-attachments/assets/d015f8ef-8c31-4245-bf10-2e1676efb444


### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed

- Adds support for `multiline` appearance 
