### PR TITLE
turbo: disable telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   ],
   "scripts": {
     "preinstall": "npx only-allow yarn",
-    "test": "turbo run test",
-    "build": "turbo run build",
-    "types": "turbo run types",
+    "test": "TURBO_TELEMETRY_DISABLED=1 turbo run test",
+    "build": "TURBO_TELEMETRY_DISABLED=1 turbo run build",
+    "types": "TURBO_TELEMETRY_DISABLED=1 turbo run types",
     "bump": "changeset add",
     "format": "npm-run-all --print-name format:vue format:prettier",
     "format:prettier": "prettier -w \"**/*\" --ignore-unknown --cache",


### PR DESCRIPTION
Prevents:

```
Attention:
Turborepo now collects completely anonymous telemetry regarding usage.
This information is used to shape the Turborepo roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://turbo.build/repo/docs/telemetry

turbo 2.5.0
```

See: https://turborepo.com/docs/telemetry#disable

Closes #434

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [x] Not applicable

### What else has been done to verify that this works as intended?

Nothing, although checking in CI might be good.

### Why is this the best possible solution? Were any other approaches considered?

It would have been nice if turbo allowed setting this in `turbo.json`, but this is not documented.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should not affect.

### Do we need any specific form for testing your changes? If so, please attach one.

I don't think so.

### What's changed

Prevents:

```
Attention:
Turborepo now collects completely anonymous telemetry regarding usage.
This information is used to shape the Turborepo roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://turbo.build/repo/docs/telemetry

turbo 2.5.0
```

See: https://turborepo.com/docs/telemetry#disable

Closes #434