### PR TITLE
web-forms/sass: replace deprecated global map-get with map.get

### DIFF
--- a/packages/web-forms/src/assets/css/style.scss
+++ b/packages/web-forms/src/assets/css/style.scss
@@ -4,6 +4,7 @@
  */
 
 @use 'primeflex/primeflex.scss' as pf;
+@use 'sass:map';
 
 /**
  * ODK CSS Variables

--- a/packages/web-forms/src/assets/css/style.scss
+++ b/packages/web-forms/src/assets/css/style.scss
@@ -12,15 +12,15 @@
 :root {
 	--odk-font-family: Roboto, sans-serif;
 
-	--odk-base-font-size: #{map-get(pf.$font-size-props, 'text-base')};
-	--odk-heading-font-size: #{map-get(pf.$font-size-props, 'text-4xl')};
-	--odk-title-font-size: #{map-get(pf.$font-size-props, 'text-3xl')};
-	--odk-top-group-font-size: #{map-get(pf.$font-size-props, 'text-2xl')};
-	--odk-sub-group-font-size: #{map-get(pf.$font-size-props, 'text-xl')};
-	--odk-dialog-title-font-size: #{map-get(pf.$font-size-props, 'text-xl')};
-	--odk-question-font-size: #{map-get(pf.$font-size-props, 'text-lg')};
-	--odk-answer-font-size: #{map-get(pf.$font-size-props, 'text-base')};
-	--odk-hint-font-size: #{map-get(pf.$font-size-props, 'text-sm')};
+	--odk-base-font-size: #{map.get(pf.$font-size-props, 'text-base')};
+	--odk-heading-font-size: #{map.get(pf.$font-size-props, 'text-4xl')};
+	--odk-title-font-size: #{map.get(pf.$font-size-props, 'text-3xl')};
+	--odk-top-group-font-size: #{map.get(pf.$font-size-props, 'text-2xl')};
+	--odk-sub-group-font-size: #{map.get(pf.$font-size-props, 'text-xl')};
+	--odk-dialog-title-font-size: #{map.get(pf.$font-size-props, 'text-xl')};
+	--odk-question-font-size: #{map.get(pf.$font-size-props, 'text-lg')};
+	--odk-answer-font-size: #{map.get(pf.$font-size-props, 'text-base')};
+	--odk-hint-font-size: #{map.get(pf.$font-size-props, 'text-sm')};
 
 	--odk-primary-text-color: var(--p-primary-500);
 	--odk-primary-light-background-color: var(--p-primary-100);


### PR DESCRIPTION
Possible fix for #438.

---

See https://sass-lang.com/documentation/breaking-changes/import/

Closes #438

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

- [ ] ran tests

### Why is this the best possible solution? Were any other approaches considered?

No other options considered.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

### Do we need any specific form for testing your changes? If so, please attach one.

No.

### What's changed

replaced deprecated global map-get with map.get