### PR TITLE
fix(#425): fixes select question type when read-only is true

### DIFF
--- a/.changeset/tidy-dragons-brake.md
+++ b/.changeset/tidy-dragons-brake.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': patch
+---
+
+Fixes select question type when read-only is true

--- a/packages/web-forms/src/assets/css/select-options.scss
+++ b/packages/web-forms/src/assets/css/select-options.scss
@@ -31,7 +31,8 @@
 		background-color: var(--odk-primary-lighter-background-color);
 	}
 
-	&.active {
+	&.active,
+	&.active:hover {
 		outline: 2px solid var(--odk-primary-border-color);
 		background-color: var(--odk-primary-lighter-background-color);
 	}
@@ -39,10 +40,11 @@
 	&.disabled,
 	&.disabled label {
 		cursor: not-allowed;
+		opacity: 0.5;
 
-		&:hover {
+		&:not(.active):hover {
 			outline-color: var(--odk-border-color);
-			background-color: unset;
+			background: var(--odk-base-background-color);
 		}
 	}
 
@@ -91,9 +93,4 @@
 	background: var(--odk-light-background-color);
 	align-content: flex-start;
 	flex-wrap: wrap;
-
-	&.disabled,
-	&.disabled label {
-		opacity: 0.5;
-	}
 }

--- a/packages/web-forms/src/components/widgets/MultiselectDropdown.vue
+++ b/packages/web-forms/src/components/widgets/MultiselectDropdown.vue
@@ -49,6 +49,7 @@ if (props.question.appearances['no-buttons']) {
 		filter-match-mode="contains"
 		:auto-filter-focus="question.appearances.autocomplete"
 		:show-toggle-all="false"
+		:disabled="props.question.currentState.readonly"
 		:options="options"
 		option-label="label"
 		option-value="value"

--- a/packages/web-forms/src/components/widgets/SearchableDropdown.vue
+++ b/packages/web-forms/src/components/widgets/SearchableDropdown.vue
@@ -39,6 +39,7 @@ const selectValue = (value: string) => {
 		filter-match-mode="contains"
 		:auto-filter-focus="true"
 		:model-value="question.currentState.value[0]"
+		:disabled="props.question.currentState.readonly"
 		:options="options"
 		option-label="label"
 		option-value="value"

--- a/vendor-types/primevue/multiselect.d.ts
+++ b/vendor-types/primevue/multiselect.d.ts
@@ -1,6 +1,0 @@
-declare module 'primevue/multiselect' {
-	interface MultiSelectProps {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		options?: any[] | readonly any[];
-	}
-}


### PR DESCRIPTION
Closes #

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Test video:


https://github.com/user-attachments/assets/ee5b0284-99e8-4623-a01d-38aedb267698


### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
- Fixes select question type when read-only is true
- Removes the type file that prevents linking to original PrimeVue type. That type file was unnecessary 