### PR TITLE
feat(#390): Improves error dialog style and message

### DIFF
--- a/.changeset/stupid-clocks-spend.md
+++ b/.changeset/stupid-clocks-spend.md
@@ -1,0 +1,6 @@
+---
+'@getodk/xforms-engine': patch
+'@getodk/web-forms': patch
+---
+
+Improves error dialog message and style.

--- a/packages/web-forms/src/components/FormLoadFailureDialog.vue
+++ b/packages/web-forms/src/components/FormLoadFailureDialog.vue
@@ -47,42 +47,55 @@ const detail = computed((): FormLoadErrorDetail | null => {
 		:keep-in-viewport="true"
 	>
 		<div class="content">
-			<Message severity="error" class="message" :closable="false">
+			<Message severity="error" class="message" :closable="false" :unstyled="true">
 				{{ error.message }}
 			</Message>
 
 			<details v-if="detail != null" class="initialize-form-failure-details">
 				<summary>{{ FORM_LOAD_ERROR_TEXT.DETAILS_SUMMARY_LABEL }}</summary>
 
-				<pre v-if="detail.unknownCauseDetail != null">{{
-				detail.unknownCauseDetail
-				}}</pre>
+				<pre v-if="detail.unknownCauseDetail != null">{{ detail.unknownCauseDetail }}</pre>
 
-				<pre v-if="detail.stack != null">{{
-				detail.stack
-				}}</pre>
+				<pre v-if="detail.stack != null">{{ detail.stack }}</pre>
 			</details>
 		</div>
 	</Dialog>
 </template>
 
-<style scoped>
-.form-load-failure-dialog .content {
-	width: calc(100dvw - 6rem) !important;
-}
-
+<style lang="scss" scoped>
 .form-load-failure-dialog .message {
-	margin-top: 0;
+	margin: 10px 0 30px 0;
+	color: var(--odk-error-text-color);
+	font-size: var(--odk-base-font-size);
 }
 
 .initialize-form-failure-details {
 	display: block;
 	position: relative;
 	max-width: 100%;
-	overflow: auto;
+	overflow: hidden;
+	font-size: var(--odk-base-font-size);
 }
 
 .initialize-form-failure-details summary {
 	cursor: pointer;
+}
+
+.initialize-form-failure-details pre {
+	overflow: auto;
+}
+</style>
+
+<style lang="scss">
+@use 'primeflex/core/_variables.scss' as pf;
+
+.p-dialog {
+	width: 50vw;
+}
+
+@media screen and (max-width: #{pf.$sm}) {
+	.p-dialog {
+		width: 80vw;
+	}
 }
 </style>

--- a/packages/web-forms/src/components/FormLoadFailureDialog.vue
+++ b/packages/web-forms/src/components/FormLoadFailureDialog.vue
@@ -67,6 +67,7 @@ const detail = computed((): FormLoadErrorDetail | null => {
 	margin: 10px 0 30px 0;
 	color: var(--odk-error-text-color);
 	font-size: var(--odk-base-font-size);
+	white-space: pre-wrap;
 }
 
 .initialize-form-failure-details {

--- a/packages/xforms-engine/src/error/LoadFormFailureError.ts
+++ b/packages/xforms-engine/src/error/LoadFormFailureError.ts
@@ -77,38 +77,17 @@ const formResourceMetadata = (resource: FormResource): FormResourceMetadata => {
  */
 export class LoadFormFailureError extends AggregateError {
 	constructor(resource: FormResource, errors: readonly Error[]) {
-		const { description, rawData } = formResourceMetadata(resource);
-		const messageLines: string[] = [
-			`Failed to load form resource: ${description}`,
-			'\n',
-
-			...errors.map((error) => {
-				const aggregatedMessage = error.message;
-
-				if (aggregatedMessage == null) {
-					return '- Unknown error';
-				}
-
-				return `- ${aggregatedMessage}`;
-			}),
-		];
-
-		if (rawData != null) {
-			messageLines.push('\n- - -\n', 'Raw resource data:', rawData);
-		}
-
-		const message = messageLines.join('\n');
+		const { description } = formResourceMetadata(resource);
+		const message = 'Failed to load form resource.';
 
 		super(errors, message);
 
 		const [head, ...tail] = errors;
+		const stack =
+			typeof head?.stack === 'string' && !tail.length ? head.stack : 'No error trace available.';
 
-		if (head != null && tail.length === 0) {
-			const { stack } = head;
-
-			if (typeof stack === 'string') {
-				this.stack = stack;
-			}
-		}
+		this.stack = [description, errors.map((error) => error.message ?? 'Unknown error'), stack].join(
+			'\n'
+		);
 	}
 }

--- a/packages/xforms-engine/src/error/LoadFormFailureError.ts
+++ b/packages/xforms-engine/src/error/LoadFormFailureError.ts
@@ -49,7 +49,7 @@ interface FormResourceMetadata {
 	readonly rawData: string | null;
 }
 
-const formResourceMetadata = (resource: FormResource): FormResourceMetadata => {
+const formResourceMetadata = (resource: FormResource): FormResourceMetadata | undefined => {
 	if (resource instanceof Blob) {
 		return {
 			description: blobDescription(resource),
@@ -64,10 +64,7 @@ const formResourceMetadata = (resource: FormResource): FormResourceMetadata => {
 		};
 	}
 
-	return {
-		description: 'Raw string data',
-		rawData: resource,
-	};
+	return;
 };
 
 /**
@@ -77,17 +74,15 @@ const formResourceMetadata = (resource: FormResource): FormResourceMetadata => {
  */
 export class LoadFormFailureError extends AggregateError {
 	constructor(resource: FormResource, errors: readonly Error[]) {
-		const { description } = formResourceMetadata(resource);
-		const message = 'Failed to load form resource.';
-
+		const metadata = formResourceMetadata(resource);
+		const errorMessages = errors.map((error) => error.message || 'Unknown error').join('\n');
+		const message = metadata?.description
+			? `Form source: ${metadata.description}\n${errorMessages}`
+			: errorMessages;
 		super(errors, message);
 
 		const [head, ...tail] = errors;
-		const stack =
+		this.stack =
 			typeof head?.stack === 'string' && !tail.length ? head.stack : 'No error trace available.';
-
-		this.stack = [description, errors.map((error) => error.message ?? 'Unknown error'), stack].join(
-			'\n'
-		);
 	}
 }


### PR DESCRIPTION
Closes #390

Before the improvements:

- Printing a long message in red
- Hard to scroll to the technical details

https://github.com/user-attachments/assets/51d3a768-79d8-4dce-81ad-d2810252a695



### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Video showing the new user experience: 
- Moves technical details to a collapsible section, keeping the message for the user simple.
- The dialog is less wide
- The font isn't bold

https://github.com/user-attachments/assets/a4fc8d8a-02a4-4db4-b1d1-3ce048778491



### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
- Updated dialog styles as per [designer notes](https://getodk.slack.com/archives/C051L6AKG4F/p1752011473893869). 
- Removed the raw data from the message, which was printing the entire XML, resulting in a lengthy wall of red text.
- Moved the error message to the technical section and part of the stack info. 
