### PR TITLE
fix: CSS for dialogs and Geopoint's readonly value

### DIFF
--- a/packages/web-forms/src/components/FormLoadFailureDialog.vue
+++ b/packages/web-forms/src/components/FormLoadFailureDialog.vue
@@ -90,12 +90,12 @@ const detail = computed((): FormLoadErrorDetail | null => {
 <style lang="scss">
 @use 'primeflex/core/_variables.scss' as pf;
 
-.p-dialog {
+.p-dialog.form-load-failure-dialog {
 	width: 50vw;
 }
 
 @media screen and (max-width: #{pf.$sm}) {
-	.p-dialog {
+	.p-dialog.form-load-failure-dialog {
 		width: 80vw;
 	}
 }

--- a/packages/web-forms/src/components/common/GeopointFormattedValue.vue
+++ b/packages/web-forms/src/components/common/GeopointFormattedValue.vue
@@ -43,6 +43,7 @@ const value = computed<GeopointValue>(() => {
 .geopoint-formatted-value > span {
 	margin-right: 10px;
 	font-size: var(--odk-answer-font-size);
+	font-weight: 300;
 }
 
 @media screen and (max-width: #{pf.$sm}) {


### PR DESCRIPTION
### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?


<details><summary>Dialogs showing correct UI and sizes:</summary>
<br />

<img width="700" height="980" alt="Screenshot 2025-07-23 at 8 19 27 PM" src="https://github.com/user-attachments/assets/24c6e40e-ba94-416a-b589-ea37816cc764" />

<img width="700" height="973" alt="Screenshot 2025-07-23 at 8 18 55 PM" src="https://github.com/user-attachments/assets/e7a64673-6d7a-4d12-8d83-f76b1abf7beb" />

<img width="700" height="980" alt="Screenshot 2025-07-23 at 8 20 20 PM" src="https://github.com/user-attachments/assets/d031e23c-7b0d-4ebf-a947-59f9fa02950f" />

<img width="700" height="979" alt="Screenshot 2025-07-23 at 8 20 03 PM" src="https://github.com/user-attachments/assets/8cca54ff-d6f5-4d00-99d3-c2eaf9f28738" />


</details>

<details><summary>Geopoint's readonly value is the same as other notes:</summary>
<br />

<img width="700" height="983" alt="Screenshot 2025-07-23 at 8 19 45 PM" src="https://github.com/user-attachments/assets/7367f3bf-2711-4b4e-9094-c468e3d817e4" />

<img width="700" height="979" alt="Screenshot 2025-07-23 at 8 21 32 PM" src="https://github.com/user-attachments/assets/554f688c-9a5f-43f7-9fc5-9fb8a82c7a47" />

<img width="700" height="978" alt="Screenshot 2025-07-23 at 8 21 52 PM" src="https://github.com/user-attachments/assets/c2665aee-be78-4109-9b14-68ea3aaa1cbf" />

</details>


### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
- Scope CSS to error dialog
- Make Geopoint's readonly value style consistent with other question types 
