### PR TITLE
fix: enable CI for pull requests from forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: 'CI conditions'
     runs-on: 'ubuntu-latest'
     outputs:
-      IS_FORK: ${{ github.repository_owner != 'getodk' }}
+      IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
       IS_PR: ${{ github.event_name == 'pull_request' }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - "**/*.md"
       - ".github/ISSUE_TEMPLATE/**"
 
-# Automatically cancel older in-progress jobs on the same branch
+# Automatically cancel older in-progress jobs on the same branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
The CI was initially set up to trigger on both `push` and `pull_request` events. Later, to streamline things and avoid duplicate runs, we decided to limit `push` triggers to commits merged into `main` and keep `pull_request` triggers for PRs only. However, PRs from forks weren’t triggering the CI at all, and this PR fixes that issue.

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [x] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
- Fixes condition to detect forks
