### PR TITLE
fix(#375): show error highlight on required questions

### DIFF
--- a/.changeset/heavy-crabs-share.md
+++ b/.changeset/heavy-crabs-share.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': patch
+---
+
+Fix error style for required questions


### PR DESCRIPTION
Closes #375

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Test video:

https://github.com/user-attachments/assets/ee757889-514b-4fe0-90eb-edb4cd06d92a

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed

- Detect changes in the question’s value and apply error styles when the question is required.
