### PR TITLE
fix(#460): long labels in list table

### DIFF
--- a/.changeset/khaki-plants-fix.md
+++ b/.changeset/khaki-plants-fix.md
@@ -2,4 +2,4 @@
 '@getodk/web-forms': patch
 ---
 
-Fixed display of list table
+Fix display of list table's labels

--- a/.changeset/khaki-plants-fix.md
+++ b/.changeset/khaki-plants-fix.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': patch
+---
+
+Fixed display of list table

--- a/packages/web-forms/src/components/appearances/FieldListTable.vue
+++ b/packages/web-forms/src/components/appearances/FieldListTable.vue
@@ -28,7 +28,7 @@ defineProps<{ appearances: SelectNodeAppearances }>();
 	}
 
 	.first-col {
-		flex-grow: 2;
+		flex: 0 0 35%;
 		text-align: left;
 		vertical-align: middle;
 	}
@@ -36,10 +36,11 @@ defineProps<{ appearances: SelectNodeAppearances }>();
 	:deep(.value-option) {
 		display: flex;
 		flex-direction: column-reverse;
+		flex: 1;
 		min-width: 50px;
 		text-align: center;
 		vertical-align: middle;
-		padding: 15px 5px;
+		padding: 15px 0;
 		outline: none;
 		background-color: unset;
 

--- a/packages/web-forms/src/components/appearances/FieldListTable.vue
+++ b/packages/web-forms/src/components/appearances/FieldListTable.vue
@@ -15,7 +15,10 @@ defineProps<{ appearances: SelectNodeAppearances }>();
 
 <style lang="scss" scoped>
 .table-row {
-	display: table-row;
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: center;
+	justify-content: flex-start;
 	border-radius: var(--odk-radius);
 	margin-bottom: 6px;
 	padding-left: 10px;
@@ -25,14 +28,14 @@ defineProps<{ appearances: SelectNodeAppearances }>();
 	}
 
 	.first-col {
-		display: table-cell;
-		width: 100%;
+		flex-grow: 2;
 		text-align: left;
 		vertical-align: middle;
 	}
 
 	:deep(.value-option) {
-		display: table-cell;
+		display: flex;
+		flex-direction: column-reverse;
 		min-width: 50px;
 		text-align: center;
 		vertical-align: middle;
@@ -50,12 +53,11 @@ defineProps<{ appearances: SelectNodeAppearances }>();
 		}
 
 		span.text-content {
-			display: block;
-			min-width: fit-content;
-			word-break: normal;
-			margin: 0 auto;
+			display: table;
+			margin: 0;
 			color: var(--odk-text-color);
 			font-size: var(--odk-base-font-size);
+			word-break: normal;
 		}
 	}
 }
@@ -110,18 +112,13 @@ defineProps<{ appearances: SelectNodeAppearances }>();
 
 	:deep(.value-option) {
 		position: relative;
+		gap: 10px;
+		justify-content: center;
 
 		.p-checkbox,
-		.p-radiobutton {
-			position: relative;
-			top: 26px;
-		}
-
+		.p-radiobutton,
 		.text-content {
 			position: relative;
-			top: -20px;
-			margin-bottom: 10px;
-			white-space: nowrap;
 		}
 	}
 }

--- a/packages/web-forms/src/components/common/CheckboxWidget.vue
+++ b/packages/web-forms/src/components/common/CheckboxWidget.vue
@@ -13,6 +13,9 @@ defineEmits(['update:modelValue', 'change']);
 const props = defineProps<CheckboxWidgetProps>();
 
 const selectValues = (values: readonly string[]) => {
+	if (props.question.appearances.label) {
+		return;
+	}
 	props.question.selectValues(values);
 };
 </script>

--- a/packages/web-forms/src/components/common/RadioButton.vue
+++ b/packages/web-forms/src/components/common/RadioButton.vue
@@ -12,6 +12,9 @@ defineEmits(['update:modelValue', 'change']);
 const props = defineProps<RadioButtonProps>();
 
 const selectValue = (value: string) => {
+	if (props.question.appearances.label) {
+		return;
+	}
 	props.question.selectValue(value);
 };
 </script>


### PR DESCRIPTION
Closes #460

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Test video:


https://github.com/user-attachments/assets/90fa491b-8769-4a9f-bfef-a2d57f41da97


### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
- Labels (the first column in each row) use 35% and options evenly divide up the rest on a wide screen for both Desktop and Mobile
- Prevents selecting options when `label` appearance is present
