### PR TITLE
feat(#22): support output in translation text

### DIFF
--- a/.changeset/old-shoes-wonder.md
+++ b/.changeset/old-shoes-wonder.md
@@ -1,0 +1,5 @@
+---
+'@getodk/xforms-engine': minor
+---
+
+Support output in translation text

--- a/packages/scenario/test/repeat-output.test.ts
+++ b/packages/scenario/test/repeat-output.test.ts
@@ -316,72 +316,69 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 					).toBe('Position: 2');
 				});
 
-				it.fails(
-					'produces the output of an expression with a relative reference (alternate #2)',
-					async () => {
-						const scenario = await Scenario.init(
-							'<output> with relative ref in translation',
-							html(
-								head(
-									title('output with relative ref in translation'),
-									model(
+				it('produces the output of an expression with a relative reference (alternate #2)', async () => {
+					const scenario = await Scenario.init(
+						'<output> with relative ref in translation',
+						html(
+							head(
+								title('output with relative ref in translation'),
+								model(
+									t(
+										'itext',
 										t(
-											'itext',
+											'translation lang="Français"',
 											t(
-												'translation lang="Français"',
-												t(
-													'text id="/data/repeat/position_in_label:label"',
-													t('value', 'Position: <output value="../position"/>')
-												)
+												'text id="/data/repeat/position_in_label:label"',
+												t('value', 'Position: <output value="../position"/>')
 											)
-										),
-										mainInstance(
-											t(
-												'data id="relative-output"',
-												t('repeat jr:template=""', t('position'), t('position_in_label'))
-											)
-										),
-										bind('/data/repeat/position').type('int').calculate('position(..)'),
-										bind('/data/repeat/position_in_label').type('int')
-									)
-								),
-								body(
-									repeat(
-										'/data/repeat',
-										input(
-											'/data/repeat/position_in_label',
-											labelRef("jr:itext('/data/repeat/position_in_label:label')")
 										)
+									),
+									mainInstance(
+										t(
+											'data id="relative-output"',
+											t('repeat jr:template=""', t('position'), t('position_in_label'))
+										)
+									),
+									bind('/data/repeat/position').type('int').calculate('position(..)'),
+									bind('/data/repeat/position_in_label').type('int')
+								)
+							),
+							body(
+								repeat(
+									'/data/repeat',
+									input(
+										'/data/repeat/position_in_label',
+										labelRef("jr:itext('/data/repeat/position_in_label:label')")
 									)
 								)
 							)
-						);
+						)
+					);
 
-						scenario.next('/data/repeat');
-						scenario.createNewRepeat({
-							assertCurrentReference: '/data/repeat',
-						});
-						scenario.next('/data/repeat[1]/position_in_label');
+					scenario.next('/data/repeat');
+					scenario.createNewRepeat({
+						assertCurrentReference: '/data/repeat',
+					});
+					scenario.next('/data/repeat[1]/position_in_label');
 
-						expect(
-							scenario.proposed_getQuestionLabelText({
-								assertCurrentReference: '/data/repeat[1]/position_in_label',
-							})
-						).toBe('Position: 1');
+					expect(
+						scenario.proposed_getQuestionLabelText({
+							assertCurrentReference: '/data/repeat[1]/position_in_label',
+						})
+					).toBe('Position: 1');
 
-						scenario.next('/data/repeat');
-						scenario.createNewRepeat({
-							assertCurrentReference: '/data/repeat',
-						});
-						scenario.next('/data/repeat[2]/position_in_label');
+					scenario.next('/data/repeat');
+					scenario.createNewRepeat({
+						assertCurrentReference: '/data/repeat',
+					});
+					scenario.next('/data/repeat[2]/position_in_label');
 
-						expect(
-							scenario.proposed_getQuestionLabelText({
-								assertCurrentReference: '/data/repeat[2]/position_in_label',
-							})
-						).toBe('Position: 2');
-					}
-				);
+					expect(
+						scenario.proposed_getQuestionLabelText({
+							assertCurrentReference: '/data/repeat[2]/position_in_label',
+						})
+					).toBe('Position: 2');
+				});
 			});
 		});
 	});

--- a/packages/scenario/test/repeat-output.test.ts
+++ b/packages/scenario/test/repeat-output.test.ts
@@ -160,27 +160,10 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 			 *   discrepancy, an **additional alternate** test is included which fully
 			 *   exercises the test's apparent intent.
 			 *
-			 * - (Prediction) At time of writing, it is anticipated that the first
-			 *   alternate will pass, and the second alternate will fail. This is
-			 *   because we do not yet support `<output>` in itext definitions at all.
-			 *
-			 * - (Confirmation) The first alternate did pass, and second did fail, as
-			 *   expected. A minor surprise detail was also discovered: because web
-			 *   forms does not yet support `<output>` in itext translations, it was
-			 *   expected that the first label text assertion would fail with:
-			 *
-			 *     - Expected: "Position: 1"
-			 *     - Received: "Position:"
-			 *
-			 *     It initially failed with:
-			 *
-			 *     - Expected: "Position: 1"
-			 *     - Received: ""
-			 *
-			 *     This is because the form fixture (as ported) is defined without
-			 *     closing the itext item's `id` attribute. The resulting XML produced
-			 *     by the fixture DSL causes that `id` attribute to be truncated,
-			 *     losing its last character.
+			 * - The form fixture (as ported) is defined without closing the itext
+			 *   item's `id` attribute. The resulting XML produced by the fixture DSL
+			 *   causes that `id` attribute to be truncated, losing its last
+			 *   character.
 			 *
 			 * - It's recommended that JavaRosa update this test, both to fully
 			 *   exercise the apparently intended `jr:itext` functionality, and to

--- a/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
@@ -52,7 +52,7 @@ const createTextChunks = (
 						const formAttribute = itextForm.getAttributeValue('form');
 						if (!formAttribute) {
 							itextForm.children.forEach((child) => {
-								if (child.nodeType === 'static-element') {
+								if (child instanceof StaticElement) {
 									const value = child.getAttributeValue('value');
 									if (value) {
 										const evaluatedValue = context.evaluator.evaluateString(value, context);

--- a/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
@@ -50,10 +50,19 @@ const createTextChunks = (
 				computed.forEach((itextForm) => {
 					if (isEngineXPathElement(itextForm) && itextForm instanceof StaticElement) {
 						const formAttribute = itextForm.getAttributeValue('form');
-
 						if (!formAttribute) {
-							const defaultFormValue = itextForm.getXPathValue();
-							chunks.push(new TextChunk(context, chunkExpression.source, defaultFormValue));
+							itextForm.children.forEach((child) => {
+								if (child.nodeType === 'static-element') {
+									const value = child.getAttributeValue('value');
+									if (value) {
+										const evaluatedValue = context.evaluator.evaluateString(value, context);
+										chunks.push(new TextChunk(context, chunkExpression.source, evaluatedValue));
+										return;
+									}
+								}
+								const defaultFormValue = child.getXPathValue();
+								chunks.push(new TextChunk(context, chunkExpression.source, defaultFormValue));
+							});
 						} else if (['image', 'video', 'audio'].includes(formAttribute)) {
 							const formValue = itextForm.getXPathValue();
 

--- a/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
@@ -29,7 +29,6 @@ const evaluateChildValue = (context: EvaluationContext, child: StaticChildNode):
 	if (child instanceof StaticElement) {
 		const value = child.getAttributeValue('value');
 		if (value) {
-			const lang = context.getActiveLanguage(); // listen for changes in active language
 			return context.evaluator.evaluateString(value, context);
 		}
 	}
@@ -77,7 +76,6 @@ const createTextChunks = (
 				if (isEngineXPathElement(itextForm) && itextForm instanceof StaticElement) {
 					const formAttribute = itextForm.getAttributeValue('form');
 					if (!formAttribute) {
-						context.getActiveLanguage(); // listen for changes in active language
 						itextForm.children.forEach((child) => {
 							const value = evaluateChildValue(context, child);
 							chunks.push(createLiteralChunk(context, chunkExpression.source, value));


### PR DESCRIPTION
Closes #22
Closes #418

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

An additional scenario test has been enabled and passes.

I tested multiple forms with translation text in repeats, labels, constraints, required, and value.

### Why is this the best possible solution? Were any other approaches considered?

I tried updating the value, which worked but it's designed to be immutable so may have had unintended consequences. It also required reducing the results that could be cached which would have been worse for performance than this solution.

I also looked at updating the xpath package instead but that was spreading the translation code across packages. This way the code is co-located in the engine.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The change may have affected images in select options.

### Do we need any specific form for testing your changes? If so, please attach one.

Form which includes output in constraint and required message: 
[ref_in_message.xlsx](https://github.com/user-attachments/files/22069748/ref_in_message.xlsx)

### What's changed

Now when building the text instead of just assuming it's a single element and evaluating it, this change checks for children and evaluates them as well, with the result as the concatenation of the strings of all children in order.