### PR TITLE
feat(#22): support output in translation text

### DIFF
--- a/.changeset/real-peas-hear.md
+++ b/.changeset/real-peas-hear.md
@@ -1,0 +1,7 @@
+---
+'@getodk/xforms-engine': minor
+'@getodk/scenario': patch
+'@getodk/common': patch
+---
+
+evaluate output elements in itext translations

--- a/.changeset/real-peas-hear.md
+++ b/.changeset/real-peas-hear.md
@@ -4,4 +4,4 @@
 '@getodk/common': patch
 ---
 
-evaluate output elements in itext translations
+Support references to form fields in translated form text

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ This section is auto generated. Please update `feature-matrix.json` and then run
   <summary>
 
 <!-- prettier-ignore -->
-  ##### Descriptions and Annotations<br/>🟩🟩🟩⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 21\%
+  ##### Descriptions and Annotations<br/>🟩🟩🟩🟩⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 28\%
 
   </summary>
   <br/>
@@ -199,7 +199,7 @@ This section is auto generated. Please update `feature-matrix.json` and then run
 | hint                                           |    ✅    |
 | guidance hint                                  |          |
 | form translations                              |    ✅    |
-| form translations with ref to other fiel<br/>d |          |
+| form translations with ref to other fiel<br/>d |    ✅    |
 | Markdown                                       |          |
 | Inline HTML                                    |          |
 | Form attachments                               |          |

--- a/feature-matrix.json
+++ b/feature-matrix.json
@@ -111,7 +111,7 @@
     "hint": "✅",
     "guidance hint": "",
     "form translations": "✅",
-    "form translations with ref to other field": "",
+    "form translations with ref to other field": "✅",
     "Markdown": "",
     "Inline HTML": "",
     "Form attachments": "",

--- a/packages/common/src/jr-resources/JRResourceURL.ts
+++ b/packages/common/src/jr-resources/JRResourceURL.ts
@@ -3,11 +3,11 @@ type JRResourceURLProtocol = typeof JR_RESOURCE_URL_PROTOCOL;
 
 export type JRResourceURLString = `${JRResourceURLProtocol}${string}`;
 
-const All_RESOURCE_TYPES = ['image', 'audio', 'video'] as const;
-export type ResourceType = (typeof All_RESOURCE_TYPES)[number];
+const ALL_RESOURCE_TYPES = ['image', 'audio', 'video'] as const;
+export type ResourceType = (typeof ALL_RESOURCE_TYPES)[number];
 
 export const isResourceType = (string: string): string is ResourceType => {
-	return All_RESOURCE_TYPES.includes(string as ResourceType);
+	return ALL_RESOURCE_TYPES.includes(string as ResourceType);
 };
 
 interface ValidatedJRResourceURL extends URL {

--- a/packages/common/src/jr-resources/JRResourceURL.ts
+++ b/packages/common/src/jr-resources/JRResourceURL.ts
@@ -4,7 +4,7 @@ type JRResourceURLProtocol = typeof JR_RESOURCE_URL_PROTOCOL;
 export type JRResourceURLString = `${JRResourceURLProtocol}${string}`;
 
 const All_RESOURCE_TYPES = ['image', 'audio', 'video'] as const;
-export type ResourceType = typeof All_RESOURCE_TYPES[number];
+export type ResourceType = (typeof All_RESOURCE_TYPES)[number];
 
 export const isResourceType = (string: string): string is ResourceType => {
 	return All_RESOURCE_TYPES.includes(string as ResourceType);

--- a/packages/common/src/jr-resources/JRResourceURL.ts
+++ b/packages/common/src/jr-resources/JRResourceURL.ts
@@ -3,6 +3,13 @@ type JRResourceURLProtocol = typeof JR_RESOURCE_URL_PROTOCOL;
 
 export type JRResourceURLString = `${JRResourceURLProtocol}${string}`;
 
+const All_RESOURCE_TYPES = ['image', 'audio', 'video'] as const;
+export type ResourceType = typeof All_RESOURCE_TYPES[number];
+
+export const isResourceType = (string: string): string is ResourceType => {
+	return All_RESOURCE_TYPES.includes(string as ResourceType);
+};
+
 interface ValidatedJRResourceURL extends URL {
 	readonly protocol: JRResourceURLProtocol;
 	readonly href: JRResourceURLString;

--- a/packages/scenario/test/message-output.test.ts
+++ b/packages/scenario/test/message-output.test.ts
@@ -1,0 +1,115 @@
+import {
+	bind,
+	body,
+	head,
+	html,
+	input,
+	label,
+	mainInstance,
+	model,
+	t,
+	title,
+} from '@getodk/common/test/fixtures/xform-dsl/index.ts';
+import type { LeafNodeValidationState } from '@getodk/xforms-engine';
+import { describe, expect, it } from 'vitest';
+import { AnswerResult, Scenario } from '../src/jr/Scenario.ts';
+import { ANSWER_REQUIRED_BUT_EMPTY } from '../src/jr/validation/ValidateOutcome.ts';
+
+describe('Translation text can contain `<output>`', () => {
+	it.each(['relative', 'absolute'])('resolves $0 references', async (ref) => {
+		const path = ref === 'relative' ? '../name' : '/data/name';
+		const scenario = await Scenario.init(
+			'translation text with <output> with absolute ref',
+			html(
+				head(
+					title('output with absolute ref'),
+					model(
+						t(
+							'itext',
+							t(
+								'translation lang="default"',
+								t('text id="/data/name:label"', t('value', 'Name')),
+								t(
+									'text id="/data/value:jr:constraintMsg"',
+									t('value', `Hey, <output value=" ${path} " />, that value is too small!`)
+								),
+								t(
+									'text id="/data/date:jr:requiredMsg"',
+									t('value', `Dear <output value=" ${path} " />, please fill me in`)
+								)
+							),
+							t(
+								'translation lang="fr"',
+								t('text id="/data/name:label"', t('value', 'Nom')),
+								t(
+									'text id="/data/value:jr:constraintMsg"',
+									t('value', `Hé, <output value=" ${path} " />, cette valeur est trop petite!`)
+								),
+								t(
+									'text id="/data/date:jr:requiredMsg"',
+									t('value', `Cher <output value=" ${path} " />, s\'il te plaît, renseigne-moi`)
+								)
+							)
+						),
+						mainInstance(t('data id="ref_in_message"', t('name'), t('value'), t('date'))),
+						bind('/data/name').type('string'),
+						bind('/data/value')
+							.type('int')
+							.constraint('. &gt; 5')
+							.withAttribute(
+								'jr',
+								'constraintMsg',
+								`jr:itext(concat('/data/value:jr:', 'constraintMsg'))`
+							),
+						bind('/data/date')
+							.type('date')
+							.required()
+							.withAttribute('jr', 'requiredMsg', `jr:itext('/data/date:jr:requiredMsg')`)
+					)
+				),
+				body(
+					input('/data/name', t(`label ref="jr:itext('/data/name:label')"`)),
+					input('/data/value', label('Value')),
+					input('/data/date', label('Date'))
+				)
+			)
+		);
+
+		let result;
+		let validate;
+
+		scenario.next('/data/name');
+		scenario.answer('Alice');
+		scenario.next('/data/value');
+
+		result = scenario.answer('1');
+		expect(result).toHaveConstraintMessage('Hey, Alice, that value is too small!');
+
+		result = scenario.answer('6');
+		expect(result).toHaveValidityStatus(AnswerResult.OK);
+
+		validate = scenario.getValidationOutcome();
+		expect(validate.failedPrompt?.node?.currentState.reference).toBe('/data/date');
+		expect(
+			(validate.failedPrompt?.node?.validationState as LeafNodeValidationState).required.message
+				?.asString
+		).toBe('Dear Alice, please fill me in');
+		expect(validate.outcome).toBe(ANSWER_REQUIRED_BUT_EMPTY);
+
+		scenario.setLanguage('fr');
+
+		result = scenario.answer('2');
+		expect(result).toHaveConstraintMessage('Hé, Alice, cette valeur est trop petite!');
+
+		result = scenario.answer('6');
+		expect(result).toHaveValidityStatus(AnswerResult.OK);
+
+		validate = scenario.getValidationOutcome();
+		expect(validate.failedPrompt?.node?.currentState.reference).toBe('/data/date');
+		expect(
+			(validate.failedPrompt?.node?.validationState as LeafNodeValidationState).required.message
+				?.asString
+		).toBe(`Cher Alice, s'il te plaît, renseigne-moi`);
+		expect(validate.outcome).toBe(ANSWER_REQUIRED_BUT_EMPTY);
+	});
+});

--- a/packages/scenario/test/message-output.test.ts
+++ b/packages/scenario/test/message-output.test.ts
@@ -19,10 +19,10 @@ describe('Translation text can contain `<output>`', () => {
 	it.each(['relative', 'absolute'])('resolves $0 references', async (ref) => {
 		const path = ref === 'relative' ? '../name' : '/data/name';
 		const scenario = await Scenario.init(
-			'translation text with <output> with absolute ref',
+			'translation text with <output>',
 			html(
 				head(
-					title('output with absolute ref'),
+					title('translation text with <output>'),
 					model(
 						t(
 							'itext',

--- a/packages/scenario/test/message-output.test.ts
+++ b/packages/scenario/test/message-output.test.ts
@@ -22,7 +22,7 @@ describe('Translation text can contain `<output>`', () => {
 			'translation text with <output>',
 			html(
 				head(
-					title('translation text with <output>'),
+					title('translation text with output'),
 					model(
 						t(
 							'itext',

--- a/packages/scenario/test/message-output.test.ts
+++ b/packages/scenario/test/message-output.test.ts
@@ -47,7 +47,7 @@ describe('Translation text can contain `<output>`', () => {
 								),
 								t(
 									'text id="/data/date:jr:requiredMsg"',
-									t('value', `Cher <output value=" ${path} " />, s\'il te plaît, renseigne-moi`)
+									t('value', `Cher <output value=" ${path} " />, s'il te plaît, renseigne-moi`)
 								)
 							)
 						),

--- a/packages/scenario/test/repeat-output.test.ts
+++ b/packages/scenario/test/repeat-output.test.ts
@@ -316,7 +316,7 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 					).toBe('Position: 2');
 				});
 
-				it.fails(
+				it(
 					'produces the output of an expression with a relative reference (alternate #2)',
 					async () => {
 						const scenario = await Scenario.init(

--- a/packages/scenario/test/repeat-output.test.ts
+++ b/packages/scenario/test/repeat-output.test.ts
@@ -160,28 +160,6 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 			 *   discrepancy, an **additional alternate** test is included which fully
 			 *   exercises the test's apparent intent.
 			 *
-			 * - (Prediction) At time of writing, it is anticipated that the first
-			 *   alternate will pass, and the second alternate will fail. This is
-			 *   because we do not yet support `<output>` in itext definitions at all.
-			 *
-			 * - (Confirmation) The first alternate did pass, and second did fail, as
-			 *   expected. A minor surprise detail was also discovered: because web
-			 *   forms does not yet support `<output>` in itext translations, it was
-			 *   expected that the first label text assertion would fail with:
-			 *
-			 *     - Expected: "Position: 1"
-			 *     - Received: "Position:"
-			 *
-			 *     It initially failed with:
-			 *
-			 *     - Expected: "Position: 1"
-			 *     - Received: ""
-			 *
-			 *     This is because the form fixture (as ported) is defined without
-			 *     closing the itext item's `id` attribute. The resulting XML produced
-			 *     by the fixture DSL causes that `id` attribute to be truncated,
-			 *     losing its last character.
-			 *
 			 * - It's recommended that JavaRosa update this test, both to fully
 			 *   exercise the apparently intended `jr:itext` functionality, and to
 			 *   correct the fixture definition to close that itext `id` attribute.
@@ -316,72 +294,69 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 					).toBe('Position: 2');
 				});
 
-				it(
-					'produces the output of an expression with a relative reference (alternate #2)',
-					async () => {
-						const scenario = await Scenario.init(
-							'<output> with relative ref in translation',
-							html(
-								head(
-									title('output with relative ref in translation'),
-									model(
+				it('produces the output of an expression with a relative reference (alternate #2)', async () => {
+					const scenario = await Scenario.init(
+						'<output> with relative ref in translation',
+						html(
+							head(
+								title('output with relative ref in translation'),
+								model(
+									t(
+										'itext',
 										t(
-											'itext',
+											'translation lang="Français"',
 											t(
-												'translation lang="Français"',
-												t(
-													'text id="/data/repeat/position_in_label:label"',
-													t('value', 'Position: <output value="../position"/>')
-												)
+												'text id="/data/repeat/position_in_label:label"',
+												t('value', 'Position: <output value="../position"/>')
 											)
-										),
-										mainInstance(
-											t(
-												'data id="relative-output"',
-												t('repeat jr:template=""', t('position'), t('position_in_label'))
-											)
-										),
-										bind('/data/repeat/position').type('int').calculate('position(..)'),
-										bind('/data/repeat/position_in_label').type('int')
-									)
-								),
-								body(
-									repeat(
-										'/data/repeat',
-										input(
-											'/data/repeat/position_in_label',
-											labelRef("jr:itext('/data/repeat/position_in_label:label')")
 										)
+									),
+									mainInstance(
+										t(
+											'data id="relative-output"',
+											t('repeat jr:template=""', t('position'), t('position_in_label'))
+										)
+									),
+									bind('/data/repeat/position').type('int').calculate('position(..)'),
+									bind('/data/repeat/position_in_label').type('int')
+								)
+							),
+							body(
+								repeat(
+									'/data/repeat',
+									input(
+										'/data/repeat/position_in_label',
+										labelRef("jr:itext('/data/repeat/position_in_label:label')")
 									)
 								)
 							)
-						);
+						)
+					);
 
-						scenario.next('/data/repeat');
-						scenario.createNewRepeat({
-							assertCurrentReference: '/data/repeat',
-						});
-						scenario.next('/data/repeat[1]/position_in_label');
+					scenario.next('/data/repeat');
+					scenario.createNewRepeat({
+						assertCurrentReference: '/data/repeat',
+					});
+					scenario.next('/data/repeat[1]/position_in_label');
 
-						expect(
-							scenario.proposed_getQuestionLabelText({
-								assertCurrentReference: '/data/repeat[1]/position_in_label',
-							})
-						).toBe('Position: 1');
+					expect(
+						scenario.proposed_getQuestionLabelText({
+							assertCurrentReference: '/data/repeat[1]/position_in_label',
+						})
+					).toBe('Position: 1');
 
-						scenario.next('/data/repeat');
-						scenario.createNewRepeat({
-							assertCurrentReference: '/data/repeat',
-						});
-						scenario.next('/data/repeat[2]/position_in_label');
+					scenario.next('/data/repeat');
+					scenario.createNewRepeat({
+						assertCurrentReference: '/data/repeat',
+					});
+					scenario.next('/data/repeat[2]/position_in_label');
 
-						expect(
-							scenario.proposed_getQuestionLabelText({
-								assertCurrentReference: '/data/repeat[2]/position_in_label',
-							})
-						).toBe('Position: 2');
-					}
-				);
+					expect(
+						scenario.proposed_getQuestionLabelText({
+							assertCurrentReference: '/data/repeat[2]/position_in_label',
+						})
+					).toBe('Position: 2');
+				});
 			});
 		});
 	});

--- a/packages/xforms-engine/src/client/TextRange.ts
+++ b/packages/xforms-engine/src/client/TextRange.ts
@@ -63,7 +63,8 @@ export type TextChunkSource =
 	| 'literal'
 	| 'output'
 	| 'reference'
-	| 'translation';
+	| 'translation'
+	| 'image'; // TODO replace this - probably it shouldn't be a TextChunkExpression, but a MediaChunkExpression or similar
 
 /**
  * @todo This (and everything else to do with {@link TextRange}s is for

--- a/packages/xforms-engine/src/client/TextRange.ts
+++ b/packages/xforms-engine/src/client/TextRange.ts
@@ -48,15 +48,6 @@ import type { ActiveLanguage } from './FormLanguage.ts';
  *   - `h:body//hint/@ref[not(is-translation-expr())]`
  *
  *   (See notes above for clarification of `is-translation-expr()`.)
- *
- * @todo It's unclear whether this will all become simpler or more compelex when
- * we add support for outputs in translations. In theory, the actual translation
- * `<text>` nodes map quite well to the `TextRange` concept (i.e. they are a
- * range of static and output chunks, just like labels and hints). The potential
- * for complications arise from XPath implementation details being largely
- * opaque (as in, the `jr:itext` implementation is encapsulated in the `xpath`
- * package, and the engine doesn't really deal with itext translations at the
- * node level at all).
  */
 // prettier-ignore
 export type TextChunkSource =

--- a/packages/xforms-engine/src/client/TextRange.ts
+++ b/packages/xforms-engine/src/client/TextRange.ts
@@ -63,8 +63,7 @@ export type TextChunkSource =
 	| 'literal'
 	| 'output'
 	| 'reference'
-	| 'translation'
-	| 'image'; // TODO replace this - probably it shouldn't be a TextChunkExpression, but a MediaChunkExpression or similar
+	| 'translation';
 
 /**
  * @todo This (and everything else to do with {@link TextRange}s is for

--- a/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
@@ -46,7 +46,7 @@ const createTextChunks = <Role extends TextRole>(
 			);
 		} else {
 			// only translations have 'nodes' chunks
-			chunkExpressions = definition.chunks as TextChunkExpression<'string'>[];
+			chunkExpressions = definition.chunks as Array<TextChunkExpression<'string'>>;
 		}
 
 		chunkExpressions.forEach((chunkExpression) => {

--- a/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
@@ -34,13 +34,9 @@ const createTextChunks = <Role extends TextRole>(
 		const chunks: TextChunk[] = [];
 		const mediaSources: MediaSources = {};
 
-		let chunkExpressions: ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>;
+		let chunkExpressions: ReadonlyArray<TextChunkExpression<'string'>>;
 
-		if (
-			definition.isTranslated &&
-			definition.chunks[0] &&
-			definition.chunks[0].source === 'translation'
-		) {
+		if (definition.chunks[0]?.source === 'translation') {
 			const itextId = context.evaluator.evaluateString(definition.chunks[0].toString()!, {
 				contextNode: context.contextNode,
 			});
@@ -49,7 +45,8 @@ const createTextChunks = <Role extends TextRole>(
 				context.getActiveLanguage()
 			);
 		} else {
-			chunkExpressions = definition.chunks;
+			// only translations have 'nodes' chunks
+			chunkExpressions = definition.chunks as TextChunkExpression<'string'>[];
 		}
 
 		chunkExpressions.forEach((chunkExpression) => {
@@ -66,14 +63,7 @@ const createTextChunks = <Role extends TextRole>(
 			}
 
 			const computed = createComputedExpression(context, chunkExpression)();
-
-			if (typeof computed === 'string') {
-				// not a translation expression
-				chunks.push(new TextChunk(context, chunkExpression.source, computed));
-				return;
-			} else {
-				throw new Error('should not get here');
-			}
+			chunks.push(new TextChunk(context, chunkExpression.source, computed));
 		});
 
 		return { chunks, mediaSources };

--- a/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
@@ -1,4 +1,7 @@
-import { JRResourceURL, type JRResourceURLString } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import {
+	JRResourceURL,
+	type JRResourceURLString,
+} from '@getodk/common/jr-resources/JRResourceURL.ts';
 import type { Accessor } from 'solid-js';
 import { createMemo } from 'solid-js';
 import type { TextRole } from '../../../client/TextRange.ts';
@@ -33,16 +36,27 @@ const createTextChunks = <Role extends TextRole>(
 
 		let chunkExpressions: ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>;
 
-		if (definition.isTranslated && definition.chunks[0] && definition.chunks[0].source === 'translation') {
-			const itextId = context.evaluator.evaluateString(definition.chunks[0].toString()!, { contextNode: context.contextNode });
-			chunkExpressions = definition.form.model.getTranslationChunks(itextId, context.getActiveLanguage());
+		if (
+			definition.isTranslated &&
+			definition.chunks[0] &&
+			definition.chunks[0].source === 'translation'
+		) {
+			const itextId = context.evaluator.evaluateString(definition.chunks[0].toString()!, {
+				contextNode: context.contextNode,
+			});
+			chunkExpressions = definition.form.model.getTranslationChunks(
+				itextId,
+				context.getActiveLanguage()
+			);
 		} else {
 			chunkExpressions = definition.chunks;
 		}
 
 		chunkExpressions.forEach((chunkExpression) => {
 			if (chunkExpression.resourceType) {
-				mediaSources[chunkExpression.resourceType] = JRResourceURL.from(chunkExpression.stringValue as JRResourceURLString);
+				mediaSources[chunkExpression.resourceType] = JRResourceURL.from(
+					chunkExpression.stringValue as JRResourceURLString
+				);
 				return;
 			}
 

--- a/packages/xforms-engine/src/parse/body/control/ItemsetDefinition.ts
+++ b/packages/xforms-engine/src/parse/body/control/ItemsetDefinition.ts
@@ -6,8 +6,8 @@ import { ItemsetLabelDefinition } from '../../text/ItemsetLabelDefinition.ts';
 import type { XFormDefinition } from '../../XFormDefinition.ts';
 import { parseNodesetReference } from '../../xpath/reference-parsing.ts';
 import { BodyElementDefinition } from '../BodyElementDefinition.ts';
-import type { AnySelectControlDefinition } from './SelectControlDefinition.ts';
 import { RankControlDefinition } from './RankControlDefinition.ts';
+import type { AnySelectControlDefinition } from './SelectControlDefinition.ts';
 
 export class ItemsetDefinition extends BodyElementDefinition<'itemset'> {
 	override readonly category = 'support';
@@ -28,7 +28,7 @@ export class ItemsetDefinition extends BodyElementDefinition<'itemset'> {
 
 		const nodesetExpression = parseNodesetReference(parent, element, 'nodeset');
 
-		this.nodes = new ItemsetNodesetExpression(this, nodesetExpression);
+		this.nodes = new ItemsetNodesetExpression(nodesetExpression);
 		this.reference = nodesetExpression;
 
 		const valueElement = getValueElement(element);

--- a/packages/xforms-engine/src/parse/expression/BindComputationExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/BindComputationExpression.ts
@@ -47,17 +47,15 @@ export class BindComputationExpression<
 			return null as BindComputationFactoryResult<Type>;
 		}
 
-		return new this(bind, computation, expression);
+		return new this(computation, expression);
 	}
 
 	readonly isDefaultExpression: boolean;
 
 	protected constructor(
-		bind: BindDefinition,
 		readonly computation: Computation,
 		expression: string | null
 	) {
-		const ignoreContextReference = computation === 'constraint';
 
 		let isDefaultExpression: boolean;
 		let resolvedExpression: string;
@@ -75,9 +73,7 @@ export class BindComputationExpression<
 			resolvedExpression = expression;
 		}
 
-		super(bind, bindComputationResultTypes[computation], resolvedExpression, {
-			ignoreContextReference,
-		});
+		super(bindComputationResultTypes[computation], resolvedExpression);
 
 		this.isDefaultExpression = isDefaultExpression;
 	}

--- a/packages/xforms-engine/src/parse/expression/BindComputationExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/BindComputationExpression.ts
@@ -56,7 +56,6 @@ export class BindComputationExpression<
 		readonly computation: Computation,
 		expression: string | null
 	) {
-
 		let isDefaultExpression: boolean;
 		let resolvedExpression: string;
 

--- a/packages/xforms-engine/src/parse/expression/ItemsetNodesetExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/ItemsetNodesetExpression.ts
@@ -1,8 +1,7 @@
-import type { ItemsetDefinition } from '../body/control/ItemsetDefinition.ts';
 import { DependentExpression } from './abstract/DependentExpression.ts';
 
 export class ItemsetNodesetExpression extends DependentExpression<'nodes'> {
-	constructor(itemset: ItemsetDefinition, nodesetExpression: string) {
-		super(itemset.parent, 'nodes', nodesetExpression);
+	constructor(nodesetExpression: string) {
+		super('nodes', nodesetExpression);
 	}
 }

--- a/packages/xforms-engine/src/parse/expression/ItemsetValueExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/ItemsetValueExpression.ts
@@ -6,6 +6,6 @@ export class ItemsetValueExpression extends DependentExpression<'string'> {
 		readonly itemset: ItemsetDefinition,
 		expression: string
 	) {
-		super(itemset, 'string', expression);
+		super('string', expression);
 	}
 }

--- a/packages/xforms-engine/src/parse/expression/RepeatCountControlExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/RepeatCountControlExpression.ts
@@ -23,7 +23,7 @@ export class RepeatCountControlExpression extends DependentExpression<'number'> 
 		const { countExpression, noAddRemoveExpression } = bodyElement;
 
 		if (countExpression != null) {
-			return new this(bodyElement, countExpression);
+			return new this(countExpression);
 		}
 
 		if (noAddRemoveExpression != null && isConstantTruthyExpression(noAddRemoveExpression)) {
@@ -32,13 +32,13 @@ export class RepeatCountControlExpression extends DependentExpression<'number'> 
 			// repeat's template.
 			const fixedCountExpression = String(Math.max(initialCount, 1));
 
-			return new this(bodyElement, fixedCountExpression);
+			return new this(fixedCountExpression);
 		}
 
 		return null;
 	}
 
-	private constructor(context: RepeatElementDefinition, expression: string) {
-		super(context, 'number', expression);
+	private constructor(expression: string) {
+		super('number', expression);
 	}
 }

--- a/packages/xforms-engine/src/parse/expression/TextChunkExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/TextChunkExpression.ts
@@ -63,6 +63,13 @@ export class TextChunkExpression<T extends 'nodes' | 'string'> extends Dependent
 		return new TextChunkExpression(context, 'string', element.getAttribute('value'), 'output');
 	}
 
+	static fromImage(
+		context: AnyTextRangeDefinition,
+		url: string
+	): TextChunkExpression<'string'> {
+		return new TextChunkExpression(context, 'string', 'null', 'image', {}, url);
+	}
+
 	static fromTranslation(
 		context: AnyTextRangeDefinition,
 		maybeExpression: string

--- a/packages/xforms-engine/src/parse/expression/TextChunkExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/TextChunkExpression.ts
@@ -1,4 +1,7 @@
-import type { JRResourceURLString, ResourceType } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import type {
+	JRResourceURLString,
+	ResourceType,
+} from '@getodk/common/jr-resources/JRResourceURL.ts';
 import type { KnownAttributeLocalNamedElement } from '@getodk/common/types/dom.ts';
 import type { TextChunkSource } from '../../client/TextRange.ts';
 import type { AnyTextRangeDefinition } from '../text/abstract/TextRangeDefinition.ts';
@@ -26,7 +29,7 @@ export class TextChunkExpression<T extends 'nodes' | 'string'> extends Dependent
 		expression: string,
 		source: TextChunkSource,
 		literalValue = '',
-		options: TextChunkExpressionOptions = {},
+		options: TextChunkExpressionOptions = {}
 	) {
 		super(resultType, expression);
 
@@ -35,21 +38,15 @@ export class TextChunkExpression<T extends 'nodes' | 'string'> extends Dependent
 		this.stringValue = literalValue;
 	}
 
-	static fromLiteral(
-		stringValue: string
-	): TextChunkExpression<'string'> {
+	static fromLiteral(stringValue: string): TextChunkExpression<'string'> {
 		return new TextChunkExpression('string', 'null', 'literal', stringValue);
 	}
 
-	static fromReference(
-		ref: string
-	): TextChunkExpression<'string'> {
+	static fromReference(ref: string): TextChunkExpression<'string'> {
 		return new TextChunkExpression('string', ref, 'reference');
 	}
 
-	static fromOutput(
-		element: Element
-	): TextChunkExpression<'string'> | null {
+	static fromOutput(element: Element): TextChunkExpression<'string'> | null {
 		if (!isOutputElement(element)) {
 			return null;
 		}
@@ -57,10 +54,7 @@ export class TextChunkExpression<T extends 'nodes' | 'string'> extends Dependent
 		return new TextChunkExpression('string', element.getAttribute('value'), 'output');
 	}
 
-	static fromResource(
-		url: JRResourceURLString,
-		type: ResourceType
-	): TextChunkExpression<'string'> {
+	static fromResource(url: JRResourceURLString, type: ResourceType): TextChunkExpression<'string'> {
 		return new TextChunkExpression('string', 'null', 'literal', url, { type });
 	}
 

--- a/packages/xforms-engine/src/parse/expression/TextChunkExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/TextChunkExpression.ts
@@ -4,7 +4,6 @@ import type {
 } from '@getodk/common/jr-resources/JRResourceURL.ts';
 import type { KnownAttributeLocalNamedElement } from '@getodk/common/types/dom.ts';
 import type { TextChunkSource } from '../../client/TextRange.ts';
-import type { AnyTextRangeDefinition } from '../text/abstract/TextRangeDefinition.ts';
 import { getTranslationExpression } from '../xpath/semantic-analysis.ts';
 import { DependentExpression } from './abstract/DependentExpression.ts';
 
@@ -58,13 +57,9 @@ export class TextChunkExpression<T extends 'nodes' | 'string'> extends Dependent
 		return new TextChunkExpression('string', 'null', 'literal', url, { type });
 	}
 
-	static fromTranslation(
-		context: AnyTextRangeDefinition,
-		maybeExpression: string
-	): TextChunkExpression<'nodes'> | null {
+	static fromTranslation(maybeExpression: string): TextChunkExpression<'nodes'> | null {
 		const translationExpression = getTranslationExpression(maybeExpression);
 		if (translationExpression) {
-			context.isTranslated = true;
 			return new TextChunkExpression('nodes', translationExpression, 'translation');
 		}
 

--- a/packages/xforms-engine/src/parse/expression/abstract/DependentExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/abstract/DependentExpression.ts
@@ -3,10 +3,7 @@ import type {
 	ConstantExpression,
 	ConstantTruthyExpression,
 } from '../../xpath/semantic-analysis.ts';
-import {
-	isConstantExpression,
-	isConstantTruthyExpression
-} from '../../xpath/semantic-analysis.ts';
+import { isConstantExpression, isConstantTruthyExpression } from '../../xpath/semantic-analysis.ts';
 
 const evaluatorMethodsByResultType = {
 	boolean: 'evaluateBoolean',

--- a/packages/xforms-engine/src/parse/expression/abstract/DependentExpression.ts
+++ b/packages/xforms-engine/src/parse/expression/abstract/DependentExpression.ts
@@ -5,10 +5,8 @@ import type {
 } from '../../xpath/semantic-analysis.ts';
 import {
 	isConstantExpression,
-	isConstantTruthyExpression,
-	isTranslationExpression,
+	isConstantTruthyExpression
 } from '../../xpath/semantic-analysis.ts';
-import type { DependencyContext } from './DependencyContext.ts';
 
 const evaluatorMethodsByResultType = {
 	boolean: 'evaluateBoolean',
@@ -28,22 +26,6 @@ export type DependentExpressionResult<Type extends DependentExpressionResultType
 	EngineXPathEvaluator[DependentExpressionEvaluatorMethod<Type>]
 >;
 
-interface SemanticDependencyOptions {
-	/**
-	 * @default false
-	 */
-	readonly translations?: boolean | undefined;
-}
-
-interface DependentExpressionOptions {
-	/**
-	 * @default false
-	 */
-	readonly ignoreContextReference?: boolean;
-
-	readonly semanticDependencies?: SemanticDependencyOptions;
-}
-
 export interface ConstantDependentExpression<Type extends DependentExpressionResultType>
 	extends DependentExpression<Type> {
 	readonly expression: ConstantExpression;
@@ -60,10 +42,8 @@ export abstract class DependentExpression<Type extends DependentExpressionResult
 	readonly constantTruthyExpression: ConstantTruthyExpression | null;
 
 	constructor(
-		context: DependencyContext,
 		readonly resultType: Type,
-		readonly expression: string,
-		options: DependentExpressionOptions = {}
+		readonly expression: string
 	) {
 		if (resultType === 'boolean' && isConstantTruthyExpression(expression)) {
 			this.constantTruthyExpression = expression;
@@ -77,19 +57,6 @@ export abstract class DependentExpression<Type extends DependentExpressionResult
 		}
 
 		this.evaluatorMethod = evaluatorMethodsByResultType[resultType];
-
-		const {
-			semanticDependencies = {
-				translations: false,
-			},
-		} = options;
-
-		const isTranslated = semanticDependencies.translations && isTranslationExpression(expression);
-
-		if (isTranslated) {
-			this.isTranslated = true;
-			context.isTranslated = true;
-		}
 	}
 
 	isConstantExpression(): this is ConstantDependentExpression<Type> {

--- a/packages/xforms-engine/src/parse/model/ItextTranslationsChunks.ts
+++ b/packages/xforms-engine/src/parse/model/ItextTranslationsChunks.ts
@@ -1,0 +1,60 @@
+import {
+	isResourceType,
+	type JRResourceURLString,
+	type ResourceType,
+} from '@getodk/common/jr-resources/JRResourceURL.ts';
+import { isElementNode, isTextNode } from '@getodk/common/lib/dom/predicates.ts';
+import { TextChunkExpression } from '../expression/TextChunkExpression.ts';
+import type { DOMItextTranslationElement } from '../XFormDOM.ts';
+
+const generateChunk = (node: Node): TextChunkExpression<'nodes' | 'string'> | null => {
+	if (isElementNode(node)) {
+		return TextChunkExpression.fromOutput(node);
+	}
+	if (isTextNode(node)) {
+		const formAttribute = node.parentElement!.getAttribute('form') as ResourceType;
+		if (isResourceType(formAttribute)) {
+			return TextChunkExpression.fromResource(node.data as JRResourceURLString, formAttribute);
+		}
+		return TextChunkExpression.fromLiteral(node.data);
+	}
+	return null;
+};
+
+const generateChunksForValues = (
+	valueElement: ChildNode
+): TextChunkExpression<'nodes' | 'string'>[] => {
+	return Array.from(valueElement.childNodes)
+		.map((node) => generateChunk(node))
+		.filter((chunk) => chunk !== null);
+};
+
+const generateChunksForTranslation = (
+	textElement: Element
+): TextChunkExpression<'nodes' | 'string'>[] => {
+	return Array.from(textElement.childNodes).flatMap((valueElement) =>
+		generateChunksForValues(valueElement)
+	);
+};
+
+const generateChunksForLanguage = (
+	translationElement: DOMItextTranslationElement
+): Map<string, ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>> => {
+	return new Map(
+		Array.from(translationElement.children).map((textElement) => {
+			const itextId = textElement.getAttribute('id');
+			return [itextId!, generateChunksForTranslation(textElement)] as const;
+		})
+	);
+};
+
+export const generateItextChunks = (
+	translationElements: readonly DOMItextTranslationElement[]
+): Map<string, Map<string, ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>>> => {
+	return new Map(
+		translationElements.map((translationElement) => {
+			const lang = translationElement.getAttribute('lang');
+			return [lang, generateChunksForLanguage(translationElement)] as const;
+		})
+	);
+};

--- a/packages/xforms-engine/src/parse/model/ItextTranslationsChunks.ts
+++ b/packages/xforms-engine/src/parse/model/ItextTranslationsChunks.ts
@@ -21,13 +21,15 @@ const generateChunk = (node: Node): TextChunkExpression<'string'> | null => {
 	return null;
 };
 
-const generateChunksForValues = (valueElement: ChildNode): TextChunkExpression<'string'>[] => {
+const generateChunksForValues = (valueElement: ChildNode): Array<TextChunkExpression<'string'>> => {
 	return Array.from(valueElement.childNodes)
 		.map((node) => generateChunk(node))
 		.filter((chunk) => chunk !== null);
 };
 
-const generateChunksForTranslation = (textElement: Element): TextChunkExpression<'string'>[] => {
+const generateChunksForTranslation = (
+	textElement: Element
+): Array<TextChunkExpression<'string'>> => {
 	return Array.from(textElement.childNodes).flatMap((valueElement) =>
 		generateChunksForValues(valueElement)
 	);

--- a/packages/xforms-engine/src/parse/model/ItextTranslationsChunks.ts
+++ b/packages/xforms-engine/src/parse/model/ItextTranslationsChunks.ts
@@ -7,7 +7,7 @@ import { isElementNode, isTextNode } from '@getodk/common/lib/dom/predicates.ts'
 import { TextChunkExpression } from '../expression/TextChunkExpression.ts';
 import type { DOMItextTranslationElement } from '../XFormDOM.ts';
 
-const generateChunk = (node: Node): TextChunkExpression<'nodes' | 'string'> | null => {
+const generateChunk = (node: Node): TextChunkExpression<'string'> | null => {
 	if (isElementNode(node)) {
 		return TextChunkExpression.fromOutput(node);
 	}
@@ -21,17 +21,13 @@ const generateChunk = (node: Node): TextChunkExpression<'nodes' | 'string'> | nu
 	return null;
 };
 
-const generateChunksForValues = (
-	valueElement: ChildNode
-): TextChunkExpression<'nodes' | 'string'>[] => {
+const generateChunksForValues = (valueElement: ChildNode): TextChunkExpression<'string'>[] => {
 	return Array.from(valueElement.childNodes)
 		.map((node) => generateChunk(node))
 		.filter((chunk) => chunk !== null);
 };
 
-const generateChunksForTranslation = (
-	textElement: Element
-): TextChunkExpression<'nodes' | 'string'>[] => {
+const generateChunksForTranslation = (textElement: Element): TextChunkExpression<'string'>[] => {
 	return Array.from(textElement.childNodes).flatMap((valueElement) =>
 		generateChunksForValues(valueElement)
 	);
@@ -39,7 +35,7 @@ const generateChunksForTranslation = (
 
 const generateChunksForLanguage = (
 	translationElement: DOMItextTranslationElement
-): Map<string, ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>> => {
+): Map<string, ReadonlyArray<TextChunkExpression<'string'>>> => {
 	return new Map(
 		Array.from(translationElement.children).map((textElement) => {
 			const itextId = textElement.getAttribute('id');
@@ -50,7 +46,7 @@ const generateChunksForLanguage = (
 
 export const generateItextChunks = (
 	translationElements: readonly DOMItextTranslationElement[]
-): Map<string, Map<string, ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>>> => {
+): Map<string, Map<string, ReadonlyArray<TextChunkExpression<'string'>>>> => {
 	return new Map(
 		translationElements.map((translationElement) => {
 			const lang = translationElement.getAttribute('lang');

--- a/packages/xforms-engine/src/parse/model/ModelDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/ModelDefinition.ts
@@ -1,3 +1,4 @@
+import { isResourceType, type JRResourceURLString, type ResourceType } from '@getodk/common/jr-resources/JRResourceURL.ts';
 import { isElementNode, isTextNode } from '@getodk/common/lib/dom/predicates.ts';
 import type { ActiveLanguage } from '../../client/FormLanguage.ts';
 import { ErrorProductionDesignPendingError } from '../../error/ErrorProductionDesignPendingError.ts';
@@ -47,7 +48,7 @@ export class ModelDefinition {
 				for (const val of element.childNodes!) {
 					for (const child of val.childNodes)	{
 						if (isElementNode(child)) {
-							const output = TextChunkExpression.fromOutput(this.root, child);
+							const output = TextChunkExpression.fromOutput(child);
 							if (output) {
 								chunks.push(output);
 							}
@@ -55,10 +56,10 @@ export class ModelDefinition {
 
 						if (isTextNode(child)) {
 							const formAttribute = child.parentElement!.getAttribute('form');
-							if (formAttribute === 'image') { // TODO also video and audio
-								chunks.push(TextChunkExpression.fromImage(this.root, child.data));
+							if (isResourceType(formAttribute as ResourceType)) {
+								chunks.push(TextChunkExpression.fromResource(child.data as JRResourceURLString, formAttribute as ResourceType));
 							} else {
-								chunks.push(TextChunkExpression.fromLiteral(this.root, child.data));
+								chunks.push(TextChunkExpression.fromLiteral(child.data));
 							}
 						}
 					}

--- a/packages/xforms-engine/src/parse/model/ModelDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/ModelDefinition.ts
@@ -1,4 +1,8 @@
-import { isResourceType, type JRResourceURLString, type ResourceType } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import {
+	isResourceType,
+	type JRResourceURLString,
+	type ResourceType,
+} from '@getodk/common/jr-resources/JRResourceURL.ts';
 import { isElementNode, isTextNode } from '@getodk/common/lib/dom/predicates.ts';
 import type { ActiveLanguage } from '../../client/FormLanguage.ts';
 import { ErrorProductionDesignPendingError } from '../../error/ErrorProductionDesignPendingError.ts';
@@ -22,7 +26,10 @@ export class ModelDefinition {
 	readonly itextTranslations: ItextTranslationsDefinition;
 
 	// TODO move this into the ItextTranslationsDefinition
-	readonly itextChunks: Map<string, Map<string, ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>>> = new Map();
+	readonly itextChunks: Map<
+		string,
+		Map<string, ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>>
+	> = new Map();
 
 	constructor(readonly form: XFormDefinition) {
 		const submission = new SubmissionDefinition(form.xformDOM);
@@ -46,7 +53,7 @@ export class ModelDefinition {
 				const id = element.getAttribute('id');
 				const chunks: TextChunkExpression<'nodes' | 'string'>[] = [];
 				for (const val of element.childNodes!) {
-					for (const child of val.childNodes)	{
+					for (const child of val.childNodes) {
 						if (isElementNode(child)) {
 							const output = TextChunkExpression.fromOutput(child);
 							if (output) {
@@ -57,7 +64,12 @@ export class ModelDefinition {
 						if (isTextNode(child)) {
 							const formAttribute = child.parentElement!.getAttribute('form');
 							if (isResourceType(formAttribute as ResourceType)) {
-								chunks.push(TextChunkExpression.fromResource(child.data as JRResourceURLString, formAttribute as ResourceType));
+								chunks.push(
+									TextChunkExpression.fromResource(
+										child.data as JRResourceURLString,
+										formAttribute as ResourceType
+									)
+								);
 							} else {
 								chunks.push(TextChunkExpression.fromLiteral(child.data));
 							}
@@ -95,7 +107,10 @@ export class ModelDefinition {
 		return rest;
 	}
 
-	getTranslationChunks(itextId: string, language: ActiveLanguage): ReadonlyArray<TextChunkExpression<'nodes' | 'string'>> {
+	getTranslationChunks(
+		itextId: string,
+		language: ActiveLanguage
+	): ReadonlyArray<TextChunkExpression<'nodes' | 'string'>> {
 		return this.itextChunks.get(language.language)?.get(itextId)!;
 	}
 }

--- a/packages/xforms-engine/src/parse/model/ModelDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/ModelDefinition.ts
@@ -4,7 +4,7 @@ import type { StaticDocument } from '../../integration/xpath/static-dom/StaticDo
 import { TextChunkExpression } from '../expression/TextChunkExpression.ts';
 import { parseStaticDocumentFromDOMSubtree } from '../shared/parseStaticDocumentFromDOMSubtree.ts';
 import type { XFormDefinition } from '../XFormDefinition.ts';
-import { generateItextChunks } from './ItextTranslationsChunks.ts';
+import { generateItextChunks, type ChunkExpressionsByItextId } from './generateItextChunks.ts';
 import { ItextTranslationsDefinition } from './ItextTranslationsDefinition.ts';
 import { ModelBindMap } from './ModelBindMap.ts';
 import type { AnyNodeDefinition } from './NodeDefinition.ts';
@@ -19,7 +19,7 @@ export class ModelDefinition {
 	readonly nodes: NodeDefinitionMap;
 	readonly instance: StaticDocument;
 	readonly itextTranslations: ItextTranslationsDefinition;
-	readonly itextChunks: Map<string, Map<string, ReadonlyArray<TextChunkExpression<'string'>>>>;
+	readonly itextChunks: Map<string, ChunkExpressionsByItextId>;
 
 	constructor(readonly form: XFormDefinition) {
 		const submission = new SubmissionDefinition(form.xformDOM);

--- a/packages/xforms-engine/src/parse/model/ModelDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/ModelDefinition.ts
@@ -19,10 +19,7 @@ export class ModelDefinition {
 	readonly nodes: NodeDefinitionMap;
 	readonly instance: StaticDocument;
 	readonly itextTranslations: ItextTranslationsDefinition;
-	readonly itextChunks: Map<
-		string,
-		Map<string, ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>>
-	>;
+	readonly itextChunks: Map<string, Map<string, ReadonlyArray<TextChunkExpression<'string'>>>>;
 
 	constructor(readonly form: XFormDefinition) {
 		const submission = new SubmissionDefinition(form.xformDOM);
@@ -66,7 +63,7 @@ export class ModelDefinition {
 	getTranslationChunks(
 		itextId: string,
 		activeLanguage: ActiveLanguage
-	): ReadonlyArray<TextChunkExpression<'nodes' | 'string'>> {
+	): ReadonlyArray<TextChunkExpression<'string'>> {
 		const languageMap = this.itextChunks.get(activeLanguage.language);
 		return languageMap?.get(itextId) ?? [];
 	}

--- a/packages/xforms-engine/src/parse/model/generateItextChunks.ts
+++ b/packages/xforms-engine/src/parse/model/generateItextChunks.ts
@@ -46,7 +46,8 @@ const generateChunksForLanguage = (
 	);
 };
 
-export interface ChunkExpressionsByItextId extends Map<string, ReadonlyArray<TextChunkExpression<'string'>>> {}
+export interface ChunkExpressionsByItextId
+	extends Map<string, ReadonlyArray<TextChunkExpression<'string'>>> {}
 
 export const generateItextChunks = (
 	translationElements: readonly DOMItextTranslationElement[]

--- a/packages/xforms-engine/src/parse/model/generateItextChunks.ts
+++ b/packages/xforms-engine/src/parse/model/generateItextChunks.ts
@@ -46,9 +46,11 @@ const generateChunksForLanguage = (
 	);
 };
 
+export interface ChunkExpressionsByItextId extends Map<string, ReadonlyArray<TextChunkExpression<'string'>>> {}
+
 export const generateItextChunks = (
 	translationElements: readonly DOMItextTranslationElement[]
-): Map<string, Map<string, ReadonlyArray<TextChunkExpression<'string'>>>> => {
+): Map<string, ChunkExpressionsByItextId> => {
 	return new Map(
 		translationElements.map((translationElement) => {
 			const lang = translationElement.getAttribute('lang');

--- a/packages/xforms-engine/src/parse/text/ItemsetLabelDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/ItemsetLabelDefinition.ts
@@ -3,6 +3,7 @@ import { getLabelElement } from '../../lib/dom/query.ts';
 import type { XFormDefinition } from '../../parse/XFormDefinition.ts';
 import type { ItemsetDefinition } from '../body/control/ItemsetDefinition.ts';
 import { TextChunkExpression } from '../expression/TextChunkExpression.ts';
+import { isTranslationExpression } from '../xpath/semantic-analysis.ts';
 import { TextRangeDefinition } from './abstract/TextRangeDefinition.ts';
 
 interface LabelElement extends LocalNamedElement<'label'> {}
@@ -20,6 +21,7 @@ export class ItemsetLabelDefinition extends TextRangeDefinition<'item-label'> {
 
 	readonly role = 'item-label';
 	readonly chunks: ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>;
+	readonly messageExpression: string | null = null;
 
 	private constructor(form: XFormDefinition, owner: ItemsetDefinition, element: LabelElement) {
 		super(form, owner, element);
@@ -30,9 +32,10 @@ export class ItemsetLabelDefinition extends TextRangeDefinition<'item-label'> {
 			throw new Error('<itemset><label> missing ref attribute');
 		}
 
-		const expression = TextChunkExpression.fromTranslation(this, refExpression);
-		if (expression != null) {
-			this.chunks = [expression];
+		if (isTranslationExpression(refExpression)) {
+			this.isTranslated = true;
+			this.messageExpression = /jr:itext\((.*)\)/.exec(refExpression)?.[1]!; // TODO it must match because of isTranslationExpression
+			this.chunks = [];
 		} else {
 			this.chunks = [TextChunkExpression.fromReference(this, refExpression)];
 		}

--- a/packages/xforms-engine/src/parse/text/ItemsetLabelDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/ItemsetLabelDefinition.ts
@@ -7,8 +7,6 @@ import { TextRangeDefinition } from './abstract/TextRangeDefinition.ts';
 
 interface LabelElement extends LocalNamedElement<'label'> {}
 
-// TODO have two separate abstract parents - one for translated and one not.
-// then we can use instanceof to enforce whether chunks or messageExpression is present
 export class ItemsetLabelDefinition extends TextRangeDefinition<'item-label'> {
 	static from(form: XFormDefinition, owner: ItemsetDefinition): ItemsetLabelDefinition | null {
 		const labelElement = getLabelElement(owner.element);
@@ -32,7 +30,7 @@ export class ItemsetLabelDefinition extends TextRangeDefinition<'item-label'> {
 			throw new Error('<itemset><label> missing ref attribute');
 		}
 
-		const translationChunk = TextChunkExpression.fromTranslation(this, refExpression);
+		const translationChunk = TextChunkExpression.fromTranslation(refExpression);
 		if (translationChunk) {
 			this.chunks = [translationChunk];
 		} else {

--- a/packages/xforms-engine/src/parse/text/MessageDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/MessageDefinition.ts
@@ -29,7 +29,7 @@ export class MessageDefinition<
 	) {
 		super(bind.form, bind, null);
 
-		const translationChunk = TextChunkExpression.fromTranslation(this, message);
+		const translationChunk = TextChunkExpression.fromTranslation(message);
 		if (translationChunk) {
 			this.chunks = [translationChunk];
 		} else {

--- a/packages/xforms-engine/src/parse/text/MessageDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/MessageDefinition.ts
@@ -1,6 +1,7 @@
 import { JAVAROSA_NAMESPACE_URI } from '@getodk/common/constants/xmlns.ts';
 import { TextChunkExpression } from '../expression/TextChunkExpression.ts';
 import type { BindDefinition } from '../model/BindDefinition.ts';
+import { isTranslationExpression } from '../xpath/semantic-analysis.ts';
 import type { TextBindAttributeLocalName } from './abstract/TextRangeDefinition.ts';
 import { TextRangeDefinition } from './abstract/TextRangeDefinition.ts';
 
@@ -21,6 +22,7 @@ export class MessageDefinition<
 	}
 
 	readonly chunks: ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>;
+	readonly messageExpression: string | null = null;
 
 	private constructor(
 		bind: BindDefinition,
@@ -29,9 +31,10 @@ export class MessageDefinition<
 	) {
 		super(bind.form, bind, null);
 
-		const expression = TextChunkExpression.fromTranslation(this, message);
-		if (expression != null) {
-			this.chunks = [expression];
+		if (isTranslationExpression(message)) {
+			this.isTranslated = true;
+			this.messageExpression = /jr:itext\((.*)\)/.exec(message)?.[1]!; // TODO it must match because of isTranslationExpression
+			this.chunks = [];
 		} else {
 			this.chunks = [TextChunkExpression.fromLiteral(this, message)];
 		}

--- a/packages/xforms-engine/src/parse/text/MessageDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/MessageDefinition.ts
@@ -1,7 +1,6 @@
 import { JAVAROSA_NAMESPACE_URI } from '@getodk/common/constants/xmlns.ts';
 import { TextChunkExpression } from '../expression/TextChunkExpression.ts';
 import type { BindDefinition } from '../model/BindDefinition.ts';
-import { isTranslationExpression } from '../xpath/semantic-analysis.ts';
 import type { TextBindAttributeLocalName } from './abstract/TextRangeDefinition.ts';
 import { TextRangeDefinition } from './abstract/TextRangeDefinition.ts';
 
@@ -22,7 +21,6 @@ export class MessageDefinition<
 	}
 
 	readonly chunks: ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>;
-	readonly messageExpression: string | null = null;
 
 	private constructor(
 		bind: BindDefinition,
@@ -31,12 +29,11 @@ export class MessageDefinition<
 	) {
 		super(bind.form, bind, null);
 
-		if (isTranslationExpression(message)) {
-			this.isTranslated = true;
-			this.messageExpression = /jr:itext\((.*)\)/.exec(message)?.[1]!; // TODO it must match because of isTranslationExpression
-			this.chunks = [];
+		const translationChunk = TextChunkExpression.fromTranslation(this, message);
+		if (translationChunk) {
+			this.chunks = [translationChunk];
 		} else {
-			this.chunks = [TextChunkExpression.fromLiteral(this, message)];
+			this.chunks = [TextChunkExpression.fromLiteral(message)];
 		}
 	}
 }

--- a/packages/xforms-engine/src/parse/text/abstract/TextElementDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/abstract/TextElementDefinition.ts
@@ -37,7 +37,6 @@ export abstract class TextElementDefinition<
 				return [];
 			});
 		} else {
-
 			const translationChunk = TextChunkExpression.fromTranslation(context, refExpression);
 			if (translationChunk) {
 				this.chunks = [translationChunk];

--- a/packages/xforms-engine/src/parse/text/abstract/TextElementDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/abstract/TextElementDefinition.ts
@@ -4,6 +4,7 @@ import type { XFormDefinition } from '../../../parse/XFormDefinition.ts';
 import type { ItemDefinition } from '../../body/control/ItemDefinition.ts';
 import { TextChunkExpression } from '../../expression/TextChunkExpression.ts';
 import { parseNodesetReference } from '../../xpath/reference-parsing.ts';
+import { isTranslationExpression } from '../../xpath/semantic-analysis.ts';
 import type { HintDefinition } from '../HintDefinition.ts';
 import type { ItemLabelDefinition } from '../ItemLabelDefinition.ts';
 import type { ItemsetLabelDefinition } from '../ItemsetLabelDefinition.ts';
@@ -17,6 +18,7 @@ export abstract class TextElementDefinition<
 	Role extends ElementTextRole,
 > extends TextRangeDefinition<Role> {
 	readonly chunks: ReadonlyArray<TextChunkExpression<'nodes' | 'string'>>;
+	readonly messageExpression: string | null = null;
 
 	constructor(form: XFormDefinition, owner: TextElementOwner, sourceNode: TextSourceNode<Role>) {
 		super(form, owner, sourceNode);
@@ -37,9 +39,11 @@ export abstract class TextElementDefinition<
 				return [];
 			});
 		} else {
-			const expression = TextChunkExpression.fromTranslation(context, refExpression);
-			if (expression != null) {
-				this.chunks = [expression];
+
+			if (isTranslationExpression(refExpression)) {
+				this.isTranslated = true;
+				this.messageExpression = /jr:itext\((.*)\)/.exec(refExpression)?.[1]!; // TODO it must match because of isTranslationExpression
+				this.chunks = [];
 			} else {
 				this.chunks = [TextChunkExpression.fromReference(context, refExpression)];
 			}

--- a/packages/xforms-engine/src/parse/text/abstract/TextElementDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/abstract/TextElementDefinition.ts
@@ -21,7 +21,6 @@ export abstract class TextElementDefinition<
 	constructor(form: XFormDefinition, owner: TextElementOwner, sourceNode: TextSourceNode<Role>) {
 		super(form, owner, sourceNode);
 
-		const context = this as AnyTextElementDefinition;
 		const refExpression = parseNodesetReference(owner, sourceNode, 'ref');
 
 		if (refExpression == null) {
@@ -37,7 +36,7 @@ export abstract class TextElementDefinition<
 				return [];
 			});
 		} else {
-			const translationChunk = TextChunkExpression.fromTranslation(context, refExpression);
+			const translationChunk = TextChunkExpression.fromTranslation(refExpression);
 			if (translationChunk) {
 				this.chunks = [translationChunk];
 			} else {

--- a/packages/xforms-engine/src/parse/text/abstract/TextRangeDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/abstract/TextRangeDefinition.ts
@@ -28,7 +28,7 @@ export abstract class TextRangeDefinition<Role extends TextRole> extends Depende
 
 	override get isTranslated(): boolean {
 		return (
-			this.ownerContext.isTranslated || this.chunks.some((chunk) => chunk.source === 'translation')
+			this.ownerContext.isTranslated || this.chunks.some((chunk) => chunk.source === 'translation') // TODO can remove the chunk check, right?
 		);
 	}
 

--- a/packages/xforms-engine/src/parse/text/abstract/TextRangeDefinition.ts
+++ b/packages/xforms-engine/src/parse/text/abstract/TextRangeDefinition.ts
@@ -28,7 +28,7 @@ export abstract class TextRangeDefinition<Role extends TextRole> extends Depende
 
 	override get isTranslated(): boolean {
 		return (
-			this.ownerContext.isTranslated || this.chunks.some((chunk) => chunk.source === 'translation') // TODO can remove the chunk check, right?
+			this.ownerContext.isTranslated || this.chunks.some((chunk) => chunk.source === 'translation')
 		);
 	}
 

--- a/packages/xforms-engine/src/parse/xpath/semantic-analysis.ts
+++ b/packages/xforms-engine/src/parse/xpath/semantic-analysis.ts
@@ -143,9 +143,7 @@ export const isTranslationExpression = (
 	return isTranslationFunctionCall(functionCallNode);
 };
 
-export const getTranslationExpression = (
-	expression: string
-): string | null => {
+export const getTranslationExpression = (expression: string): string | null => {
 	const functionCallNode = findFunctionPrincipalExpressionNode(expression);
 	if (!functionCallNode) {
 		return null;

--- a/packages/xforms-engine/src/parse/xpath/semantic-analysis.ts
+++ b/packages/xforms-engine/src/parse/xpath/semantic-analysis.ts
@@ -20,6 +20,7 @@ import {
 	collectTypedNodes,
 	findTypedPrincipalExpressionNode,
 	isCompleteSubExpression,
+	type TypedSyntaxNode,
 } from './syntax-traversal.ts';
 
 // prettier-ignore
@@ -106,6 +107,24 @@ const isTranslationFunctionCall = (syntaxNode: FunctionCallNode): boolean => {
 
 export type TranslationExpression = LocalNamedFunctionCallLiteral<'itext'>;
 
+const findFunctionPrincipalExpressionNode = (
+	expression: string
+): TypedSyntaxNode<'function_call'> | null => {
+	let result;
+	try {
+		result = expressionParser.parse(expression);
+	} catch {
+		return null;
+	}
+
+	const functionCallNode = findTypedPrincipalExpressionNode(['function_call'], result.rootNode);
+	if (functionCallNode == null) {
+		return null;
+	}
+
+	return functionCallNode;
+};
+
 /**
  * Determines if an arbitrary XPath expression is (in whole) a translation
  * expression (i.e. a call to `jr:itext`).
@@ -117,19 +136,31 @@ export type TranslationExpression = LocalNamedFunctionCallLiteral<'itext'>;
 export const isTranslationExpression = (
 	expression: string
 ): expression is TranslationExpression => {
-	let result;
-	try {
-		result = expressionParser.parse(expression);
-	} catch {
+	const functionCallNode = findFunctionPrincipalExpressionNode(expression);
+	if (!functionCallNode) {
 		return false;
 	}
-
-	const functionCallNode = findTypedPrincipalExpressionNode(['function_call'], result.rootNode);
-	if (functionCallNode == null) {
-		return false;
-	}
-
 	return isTranslationFunctionCall(functionCallNode);
+};
+
+export const getTranslationExpression = (
+	expression: string
+): string | null => {
+	const functionCallNode = findFunctionPrincipalExpressionNode(expression);
+	if (!functionCallNode) {
+		return null;
+	}
+
+	if (!isTranslationFunctionCall(functionCallNode)) {
+		return null;
+	}
+
+	const arg = functionCallNode.children.find((child) => child.type === 'argument');
+	if (!arg) {
+		return null;
+	}
+
+	return arg.text;
 };
 
 const isCurrentFunctionCall = (syntaxNode: FunctionCallNode): boolean => {


### PR DESCRIPTION
Closes: #22
Closes: #418

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

- Scenario enabled
- Performance profiled and found to be an improvement when switching languages, and comparable for other cases

### Why is this the best possible solution? Were any other approaches considered?

 1. During reactive evaluation. This was complex and meant rework was being done reactively.
 2. During parsing of the form. This worked well and was idiomatic but couldn't handle more complex cases like itemsets where the itext key had to be computed at runtime.
 3. During xpath eval but this was expensive and not idiomatic.
 4. Evaluating the itext elements outside of context (this PR). This is idiomatic and works in all cases I found and improves the complexity of the code. There is a risk of doing more work than necessary as it evaluates for languages that may never be selected, but performance profiling showed it to be acceptable.

More info: https://docs.google.com/document/d/1wR7st0jPaMXqZnWD4_2MWwX1gcpbUxOUQWZ3zvtX5zU/edit?pli=1&tab=t.r6zlb3rsawst

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Nothing has changed.

### Do we need any specific form for testing your changes? If so, please attach one.

- `/select/3-images-choice.xml` from fixtures for images in selects, the implementation of which was changed during this work
- `/performance/bench9.xml` from fixtures for performance
- [ref_in_message.xml](https://github.com/user-attachments/files/22266843/ref_in_message.xml) for output elements in itext

### What's changed

Instead of itext being resolved by xpath and just using the text value, now we build chunks during form load, and then look up the chunk using the itext key and current language so we can support non-text elements like outputs.