### PR TITLE
test(#475): fix unreliable test based on random number generation

### DIFF
--- a/.changeset/witty-boxes-serve.md
+++ b/.changeset/witty-boxes-serve.md
@@ -1,0 +1,5 @@
+---
+'@getodk/scenario': patch
+---
+
+resolved test unreliability by ensuring the size param is always valid

--- a/.changeset/witty-boxes-serve.md
+++ b/.changeset/witty-boxes-serve.md
@@ -2,4 +2,4 @@
 '@getodk/scenario': patch
 ---
 
-resolved test unreliability by ensuring the size param is always valid
+Resolved test unreliability by ensuring the size param is always valid

--- a/packages/scenario/test/instance-attachments/binary-output.test.ts
+++ b/packages/scenario/test/instance-attachments/binary-output.test.ts
@@ -231,7 +231,7 @@ describe('Instance attachments: binary output', () => {
 		});
 
 		it('produces instance XML if no instance attachments have been uploaded', async () => {
-			const baseMaxChunkSize = Math.floor(Math.random() * 400);
+			const baseMaxChunkSize = Math.floor(Math.random() * 400) + 1;
 
 			const instanceXML = scenario.proposed_serializeInstance();
 			const instanceXMLBytes = instanceXML.length;


### PR DESCRIPTION
Closes #475 

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?


### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
