### PR TITLE
fix(#117): throw an error when called with a ref that does not exist

### DIFF
--- a/.changeset/shy-carpets-add.md
+++ b/.changeset/shy-carpets-add.md
@@ -4,4 +4,4 @@
 '@getodk/web-forms': patch
 ---
 
-Throw an error when jr:choice_name is called with an element reference that does exist
+Throw an error when jr:choice_name is called with a reference that does not exist

--- a/.changeset/shy-carpets-add.md
+++ b/.changeset/shy-carpets-add.md
@@ -1,0 +1,7 @@
+---
+'@getodk/scenario': patch
+'@getodk/xpath': patch
+'@getodk/web-forms': patch
+---
+
+Throw an error when jr:choice_name is called with an element reference that does exist

--- a/packages/scenario/test/choice-name.test.ts
+++ b/packages/scenario/test/choice-name.test.ts
@@ -3,6 +3,7 @@ import {
 	body,
 	head,
 	html,
+	input,
 	item,
 	mainInstance,
 	model,
@@ -179,6 +180,56 @@ describe('JavaRosa ports: ChoiceNameTest.java', () => {
 			scenario.answer('/data/city', 'grenoble');
 
 			expect(scenario.answerOf('/data/city_name')).toEqualAnswer(stringAnswer('Grenoble'));
+		});
+	});
+
+	describe('error conditions', () => {
+		it('throws on unknown element', async () => {
+			await expect(async () => {
+				await Scenario.init(
+					'Simplest',
+					html(
+						head(
+							title('Simplest'),
+							model(
+								mainInstance(t('data id="simplest"', t('a'), t('select_one'))),
+								bind('/data/a')
+									.type('string')
+									.calculate("jr:choice-name('choice2', ' /data/NOT_FOUND ')")
+							)
+						),
+						body(
+							select1(
+								'/data/select_one',
+								item('choice1', 'Choice 1 label'),
+								item('choice2', 'Choice 2 label')
+							)
+						)
+					)
+				);
+			}).rejects.toThrow("No element found by evaluating ' /data/NOT_FOUND '");
+		});
+
+		it('throws when value is invalid element type', async () => {
+			await expect(async () => {
+				await Scenario.init(
+					'Simplest',
+					html(
+						head(
+							title('Simplest'),
+							model(
+								mainInstance(t('data id="simplest"', t('a'), t('select_one'))),
+								bind('/data/a')
+									.type('string')
+									.calculate("jr:choice-name('choice2', ' /data/select_one ')")
+							)
+						),
+						body(input('/data/select_one'))
+					)
+				);
+			}).rejects.toThrow(
+				"Evaluating 'jr:choice-name' on element ' /data/select_one ' which has no possible choices."
+			);
 		});
 	});
 });

--- a/packages/xpath/src/functions/javarosa/select.ts
+++ b/packages/xpath/src/functions/javarosa/select.ts
@@ -34,7 +34,7 @@ export const choiceName = new StringFunction(
 
 		const firstNode = nodes?.[0];
 		if (!firstNode) {
-			return '';
+			throw new Error(`No element found by evaluating '${value}'`);
 		}
 		if (!('getChoiceName' in firstNode)) {
 			throw new Error(


### PR DESCRIPTION
### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

New tests added to catch the error.

### Why is this the best possible solution? Were any other approaches considered?

As far as I can tell this situation indicates a form that can never be valid, so failing loudly and early is preferable to find the issue ASAP. 

Discussion: https://github.com/getodk/web-forms/pull/496#discussion_r2377274153

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Instead of invalid forms swallowing the error, it will now be thrown.

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
