### PR TITLE
feat(#62): markdown support for labels, hints, and constraint messages

### DIFF
--- a/.changeset/tidy-ties-give.md
+++ b/.changeset/tidy-ties-give.md
@@ -1,0 +1,8 @@
+---
+'@getodk/xforms-engine': minor
+'@getodk/web-forms': minor
+'@getodk/scenario': minor
+'@getodk/common': minor
+---
+
+Added support for markdown formatting in labels, hints, and constraints

--- a/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
+++ b/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
@@ -61,7 +61,7 @@
       </input>
       <input ref="/data/group/name">
         <label>What's your name?</label>
-        <hint>Type your name below</hint>
+        <hint>Type **your name** below</hint>
       </input>
       <input ref="/data/group/userentered">
         <label>*You said:&lt;span style="color:red;font-family:cursive"&gt;<output value="/data/group/name" />&lt;/span&gt;* but should it be markeddown?</label>

--- a/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
+++ b/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+  xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms"
+  xmlns:odk="http://www.opendatakit.org/xforms">
+  <h:head>
+    <h:title>Notes</h:title>
+    <model odk:xforms-version="1.0.0">
+      <instance>
+        <data id="notes" version="20240802121047">
+          <group>
+            <headings />
+            <name/>
+            <userentered/>
+          </group>
+          <meta>
+            <instanceID />
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/group/headings" readonly="true()" type="string" />
+      <bind nodeset="/data/group/name" type="string" />
+      <bind nodeset="/data/group/userentered" readonly="true()" type="string" />
+    </model>
+  </h:head>
+  <h:body>
+    <group appearance="field-list" ref="/data/group">
+      <input ref="/data/group/headings">
+        <label>
+          # Heading 1
+          ## Heading 2
+        </label>
+      </input>
+      <input ref="/data/group/name">
+        <label>What's your name?</label>
+      </input>
+      <input ref="/data/group/userentered">
+        <label>You said: *<output value="/data/group/name" />* but should it be markeddown?</label>
+      </input>
+    </group>
+  </h:body>
+</h:html>

--- a/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
+++ b/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
@@ -6,12 +6,26 @@
   <h:head>
     <h:title>Notes</h:title>
     <model odk:xforms-version="1.0.0">
+      <itext>
+        <translation lang="English">
+          <text id="q1:label">
+            <value>_Translated_</value>
+          </text>
+        </translation>
+        <translation lang="Español">
+          <text id="q1:label">
+            <value>_Traducida_</value>
+          </text>
+        </translation>
+      </itext>
       <instance>
         <data id="notes" version="20240802121047">
           <group>
             <headings />
             <name/>
             <userentered/>
+            <translated/>
+            <note/>
           </group>
           <meta>
             <instanceID />
@@ -21,18 +35,47 @@
       <bind nodeset="/data/group/headings" readonly="true()" type="string" />
       <bind nodeset="/data/group/name" type="string" />
       <bind nodeset="/data/group/userentered" readonly="true()" type="string" />
+      <bind nodeset="/data/group/translated" readonly="true()" type="string" />
+      <bind nodeset="/data/group/note" readonly="true()" type="note" />
     </model>
   </h:head>
   <h:body>
     <group appearance="field-list" ref="/data/group">
       <input ref="/data/group/headings">
-        <label>**Going** _going_ &lt;br&gt;&lt;br&gt;You can try this with other colours; most primary colours should work.</label>
+        <label>**Going** _going_ &lt;br&gt;&lt;br&gt;You can try this with other &lt;span style="color:red;font-family:cursive"&gt;colours&lt;/span&gt;; most primary colours should work.</label>
       </input>
       <input ref="/data/group/name">
         <label>What's your name?</label>
       </input>
       <input ref="/data/group/userentered">
-        <label>*You said:<output value="/data/group/name" />* but should it be markeddown?</label>
+        <label>*You said:&lt;span style="color:red;font-family:cursive"&gt;<output value="/data/group/name" />&lt;/span&gt;* but should it be markeddown?</label>
+      </input>
+      <input ref="/data/group/translated">
+        <label ref="jr:itext('q1:label')" />
+      </input>
+      <input ref="/data/group/note">
+        <label>
+# heading 1
+## heading 2
+### heading 3
+#### heading 4
+##### heading 5
+###### heading 6
+
+[get odk](http://www.getodk.org)
+&lt;br/&gt;&lt;br/&gt;
+Escaping: \*hello\*
+&lt;br/&gt;&lt;br/&gt;
+&lt;span style="color:red;font-family:cursive"&gt;hello&lt;/span&gt;
+&lt;br/&gt;&lt;br/&gt;
+&lt;p style="text-align:center"&gt;
+  centered paragraph
+&lt;/p&gt;
+&lt;br/&gt;&lt;br/&gt;
+
+
+&lt;div style="text-align:center"&gt;centered div&lt;/div&gt;
+        </label>
       </input>
     </group>
   </h:body>

--- a/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
+++ b/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
@@ -26,16 +26,13 @@
   <h:body>
     <group appearance="field-list" ref="/data/group">
       <input ref="/data/group/headings">
-        <label>
-          # Heading 1
-          ## Heading 2
-        </label>
+        <label>**Going** _going_ &lt;br&gt;&lt;br&gt;You can try this with other colours; most primary colours should work.</label>
       </input>
       <input ref="/data/group/name">
         <label>What's your name?</label>
       </input>
       <input ref="/data/group/userentered">
-        <label>You said: *<output value="/data/group/name" />* but should it be markeddown?</label>
+        <label>*You said:<output value="/data/group/name" />* but should it be markeddown?</label>
       </input>
     </group>
   </h:body>

--- a/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
+++ b/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
@@ -36,6 +36,10 @@
       <instance id="selectoptions">
         <root>
           <item>
+            <value>plain</value>
+            <label>plain text</label>
+          </item>
+          <item>
             <value>strong</value>
             <label>**strong style**</label>
           </item>
@@ -101,6 +105,17 @@ Escaping: \*hello\*
 
 &lt;div style="text-align:center"&gt;centered div&lt;/div&gt;
 
+&lt;table border="1"&gt;
+  &lt;tr&gt;
+    &lt;td&gt;name&lt;/td&gt;
+    &lt;td&gt;value&lt;/td&gt;
+  &lt;/tr&gt;
+  &lt;tr&gt;
+    &lt;td&gt;once&lt;/td&gt;
+    &lt;td&gt;twice&lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+
 - unordered list 1
 - unordered list 5
 - unordered list 3
@@ -109,6 +124,8 @@ Escaping: \*hello\*
 1. ordered list 1
 2. ordered list 2
 3. ordered list 3
+
+_styles **can &lt;span style="color:red;"&gt;be&lt;/span&gt; nested** inside_
 
         </label>
       </input>

--- a/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
+++ b/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
@@ -25,6 +25,7 @@
             <name/>
             <userentered/>
             <translated/>
+            <selected/>
             <note/>
           </group>
           <meta>
@@ -32,10 +33,23 @@
           </meta>
         </data>
       </instance>
+      <instance id="selectoptions">
+        <root>
+          <item>
+            <value>strong</value>
+            <label>**strong style**</label>
+          </item>
+          <item>
+            <value>emphasis</value>
+            <label>_italics_</label>
+          </item>
+        </root>
+      </instance>
       <bind nodeset="/data/group/headings" readonly="true()" type="string" />
       <bind nodeset="/data/group/name" type="string" />
       <bind nodeset="/data/group/userentered" readonly="true()" type="string" />
       <bind nodeset="/data/group/translated" readonly="true()" type="string" />
+      <bind nodeset="/data/group/selected" type="string" />
       <bind nodeset="/data/group/note" readonly="true()" type="note" />
     </model>
   </h:head>
@@ -43,10 +57,11 @@
   <!-- need to test in other places, like validation, select item labels, etc -->
     <group appearance="field-list" ref="/data/group">
       <input ref="/data/group/headings">
-        <label>**Going** _going_ &lt;br&gt;&lt;br&gt;You can try this with other &lt;span style="color:red;font-family:cursive"&gt;colours&lt;/span&gt;; most primary colours should work.</label>
+        <label>You _can_ try this with other &lt;span style="color:red;font-family:cursive"&gt;colours&lt;/span&gt;; **most** primary colours should work.</label>
       </input>
       <input ref="/data/group/name">
         <label>What's your name?</label>
+        <hint>Type your name below</hint>
       </input>
       <input ref="/data/group/userentered">
         <label>*You said:&lt;span style="color:red;font-family:cursive"&gt;<output value="/data/group/name" />&lt;/span&gt;* but should it be markeddown?</label>
@@ -54,6 +69,13 @@
       <input ref="/data/group/translated">
         <label ref="jr:itext('q1:label')" />
       </input>
+      <select1 ref="/data/group/selected">
+        <label>Select options</label>
+        <itemset nodeset="instance('selectoptions')/root/item">
+          <value ref="value" />
+          <label ref="label" />
+        </itemset>
+      </select1>
       <input ref="/data/group/note">
         <label>
 # heading 1
@@ -67,7 +89,7 @@
 &lt;br/&gt;&lt;br/&gt;
 Escaping: \*hello\*
 &lt;br/&gt;&lt;br/&gt;
-&lt;span style="color:red;font-family:cursive"&gt;hello&lt;/span&gt;
+&lt;span style="color:red;font-family:cursive"&gt;signature&lt;/span&gt;
 &lt;br/&gt;&lt;br/&gt;
 
 &lt;p style="text-align:center"&gt;
@@ -88,7 +110,6 @@ Escaping: \*hello\*
 2. ordered list 2
 3. ordered list 3
 
-![my image](/image.jpg "my image")
         </label>
       </input>
     </group>

--- a/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
+++ b/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
@@ -40,6 +40,7 @@
     </model>
   </h:head>
   <h:body>
+  <!-- need to test in other places, like validation, select item labels, etc -->
     <group appearance="field-list" ref="/data/group">
       <input ref="/data/group/headings">
         <label>**Going** _going_ &lt;br&gt;&lt;br&gt;You can try this with other &lt;span style="color:red;font-family:cursive"&gt;colours&lt;/span&gt;; most primary colours should work.</label>
@@ -68,13 +69,26 @@ Escaping: \*hello\*
 &lt;br/&gt;&lt;br/&gt;
 &lt;span style="color:red;font-family:cursive"&gt;hello&lt;/span&gt;
 &lt;br/&gt;&lt;br/&gt;
+
 &lt;p style="text-align:center"&gt;
   centered paragraph
 &lt;/p&gt;
+
 &lt;br/&gt;&lt;br/&gt;
 
 
 &lt;div style="text-align:center"&gt;centered div&lt;/div&gt;
+
+- unordered list 1
+- unordered list 5
+- unordered list 3
+
+
+1. ordered list 1
+2. ordered list 2
+3. ordered list 3
+
+![my image](/image.jpg "my image")
         </label>
       </input>
     </group>

--- a/packages/common/src/fixtures/select/1-static-selects.xml
+++ b/packages/common/src/fixtures/select/1-static-selects.xml
@@ -13,10 +13,10 @@
       <itext>
         <translation lang="French">
           <text id="fruit:label">
-            <value>1. Sélectionnez un fruit</value>
+            <value>`1. Sélectionnez un fruit`</value>
           </text>
           <text id="fruits:label">
-            <value>2. Sélectionnez plusieurs fruits</value>
+            <value>`2. Sélectionnez plusieurs fruits`</value>
           </text>
           <text id="fruit:mango">
             <value>mangue</value>
@@ -87,10 +87,10 @@
         </translation>
         <translation lang="English" default="true()">
           <text id="fruit:label">
-            <value>1. Select a fruit</value>
+            <value>`1. Select a fruit`</value>
           </text>
           <text id="fruits:label">
-            <value>2. Select multiple fruits</value>
+            <value>`2. Select multiple fruits`</value>
           </text>
           <text id="fruit:mango">
             <value>Mango</value>

--- a/packages/scenario/test/label-hint-text.test.ts
+++ b/packages/scenario/test/label-hint-text.test.ts
@@ -128,7 +128,7 @@ describe('`<label>` and/or `<hint>` text', () => {
 						scenario.next('/data/question');
 
 						// String innerText = scenario.getQuestionAtIndex().getLabelInnerText();
-						const text = scenario.proposed_getQuestionLabelText({
+						const text = scenario.getQuestionLabelText({
 							assertCurrentReference: '/data/question',
 						});
 

--- a/packages/scenario/test/markdown.test.ts
+++ b/packages/scenario/test/markdown.test.ts
@@ -1,0 +1,477 @@
+import {
+	bind,
+	body,
+	head,
+	html,
+	input,
+	item,
+	mainInstance,
+	model,
+	select1,
+	t,
+	title,
+} from '@getodk/common/test/fixtures/xform-dsl/index.ts';
+import { describe, expect, it } from 'vitest';
+import { Scenario } from '../src/jr/Scenario.ts';
+
+describe('Markdown', () => {
+	const run = async (given: string, ...expected: object[]) => {
+		const scenario = await Scenario.init(
+			'markdown',
+			html(
+				head(
+					title('markdown'),
+					model(mainInstance(t('data id="markdown"', t('name'))), bind('/data/name').type('string'))
+				),
+				body(input('/data/name', t('label', given)))
+			)
+		);
+		scenario.next('/data/name');
+		const label = scenario.getQuestionLabel({ assertCurrentReference: '/data/name' }).formatted;
+		expect(label.length).toEqual(expected.length);
+		expect(label).toMatchObject(expected);
+	};
+
+	it('should do nothing with plaintext', async () => {
+		await run('nothing to see here', {
+			elementName: 'p',
+			children: [{ value: 'nothing to see here' }],
+		});
+	});
+
+	it('should do nothing with escaped markdown', async () => {
+		await run('\\# nothing \\*to\\* see here', {
+			elementName: 'p',
+			children: [{ value: '# nothing *to* see here' }],
+		});
+	});
+
+	describe('should handle headings', () => {
+		it('h1', async () => {
+			await run('# big heading', { elementName: 'h1', children: [{ value: 'big heading' }] });
+		});
+		it('h2', async () => {
+			await run('## big heading', { elementName: 'h2', children: [{ value: 'big heading' }] });
+		});
+		it('h3', async () => {
+			await run('### big heading', { elementName: 'h3', children: [{ value: 'big heading' }] });
+		});
+		it('h4', async () => {
+			await run('#### big heading', { elementName: 'h4', children: [{ value: 'big heading' }] });
+		});
+		it('h5', async () => {
+			await run('##### big heading', { elementName: 'h5', children: [{ value: 'big heading' }] });
+		});
+		it('h6', async () => {
+			await run('###### big heading', { elementName: 'h6', children: [{ value: 'big heading' }] });
+		});
+		it('h7', async () => {
+			// h6 is the max
+			await run('####### big heading', {
+				elementName: 'p',
+				children: [{ value: '####### big heading' }],
+			});
+		});
+	});
+
+	describe('should handle emphasis', () => {
+		// TODO can we drop the 'p' element??
+		const expected = {
+			elementName: 'p',
+			children: [
+				{
+					elementName: 'em',
+					children: [{ value: 'emphasize' }],
+				},
+				{ value: ' me' },
+			],
+		};
+
+		it('asterisk style', async () => {
+			await run('*emphasize* me', expected);
+		});
+
+		it('underscore style', async () => {
+			await run('_emphasize_ me', expected);
+		});
+	});
+
+	describe('should handle strong', () => {
+		const expected = {
+			elementName: 'p',
+			children: [
+				{
+					elementName: 'strong',
+					children: [{ value: 'strengthen' }],
+				},
+				{ value: ' me' },
+			],
+		};
+
+		it('asterisk style', async () => {
+			await run('**strengthen** me', expected);
+		});
+
+		it('underscore style', async () => {
+			await run('__strengthen__ me', expected);
+		});
+	});
+
+	describe('should handle lists', () => {
+		it('ordered', async () => {
+			// TODO this is deeper than it probably needs to be?
+			const given = `1. first
+2. second
+3. third`;
+			const expected = {
+				elementName: 'ol',
+				children: [
+					{
+						elementName: 'li',
+						children: [{ elementName: 'p', children: [{ value: 'first' }] }],
+					},
+					{
+						elementName: 'li',
+						children: [{ elementName: 'p', children: [{ value: 'second' }] }],
+					},
+					{
+						elementName: 'li',
+						children: [{ elementName: 'p', children: [{ value: 'third' }] }],
+					},
+				],
+			};
+			await run(given, expected);
+		});
+
+		it('unordered', async () => {
+			const given = `- first
+- second
+- third`;
+			const expected = {
+				elementName: 'ul',
+				children: [
+					{
+						elementName: 'li',
+						children: [{ elementName: 'p', children: [{ value: 'first' }] }],
+					},
+					{
+						elementName: 'li',
+						children: [{ elementName: 'p', children: [{ value: 'second' }] }],
+					},
+					{
+						elementName: 'li',
+						children: [{ elementName: 'p', children: [{ value: 'third' }] }],
+					},
+				],
+			};
+			await run(given, expected);
+		});
+	});
+
+	describe('should handle html', () => {
+		it('styled span', async () => {
+			await run('can &lt;span style="color:red"&gt;style&lt;/span&gt; things', {
+				elementName: 'p',
+				children: [
+					{ value: 'can ' },
+					{
+						elementName: 'span',
+						children: [{ value: 'style' }],
+						properties: { style: { color: 'red' } },
+					},
+					{ value: ' things' },
+				],
+			});
+		});
+
+		it('styled div', async () => {
+			await run('can &lt;div style="text-align:center"&gt;style&lt;/div&gt; things', {
+				elementName: 'p',
+				children: [
+					{ value: 'can ' },
+					{
+						elementName: 'div',
+						children: [{ value: 'style' }],
+						properties: { style: { 'text-align': 'center' } },
+					},
+					{ value: ' things' },
+				],
+			});
+		});
+
+		describe('line breaks', () => {
+			it('single', async () => {
+				const given = `hello
+single line break`;
+
+				await run(given, { elementName: 'p', children: [{ value: 'hello\nsingle line break' }] });
+			});
+
+			it('double', async () => {
+				const given = `hello
+
+double line break`;
+
+				await run(
+					given,
+					{ elementName: 'p', children: [{ value: 'hello' }] },
+					{ elementName: 'p', children: [{ value: 'double line break' }] }
+				);
+			});
+		});
+	});
+
+	it('should handle nested markup', async () => {
+		await run('normal *italic __both__ italic again* back to normal', {
+			elementName: 'p',
+			children: [
+				{ value: 'normal ' },
+				{
+					elementName: 'em',
+					children: [
+						{ value: 'italic ' },
+						{
+							elementName: 'strong',
+							children: [{ value: 'both' }],
+						},
+						{ value: ' italic again' },
+					],
+				},
+				{ value: ' back to normal' },
+			],
+		});
+	});
+
+	it('should work with translated text', async () => {
+		const scenario = await Scenario.init(
+			'markdown',
+			html(
+				head(
+					title('markdown'),
+					model(
+						t(
+							'itext',
+							t(
+								'translation lang="default"',
+								t('text id="/data/name:label"', t('value', '**Name**'))
+							),
+							t('translation lang="fr"', t('text id="/data/name:label"', t('value', '*Nom*')))
+						),
+						mainInstance(t('data id="markdown"', t('name'))),
+						bind('/data/name').type('string')
+					)
+				),
+				body(input('/data/name', t(`label ref="jr:itext('/data/name:label')"`)))
+			)
+		);
+
+		scenario.next('/data/name');
+		let label;
+
+		label = scenario.getQuestionLabel({ assertCurrentReference: '/data/name' }).formatted;
+		expect(label.length).toEqual(1);
+		expect(label[0]).toMatchObject({
+			elementName: 'p',
+			children: [{ elementName: 'strong', children: [{ value: 'Name' }] }],
+		});
+
+		scenario.setLanguage('fr');
+		label = scenario.getQuestionLabel({ assertCurrentReference: '/data/name' }).formatted;
+		expect(label.length).toEqual(1);
+		expect(label[0]).toMatchObject({
+			elementName: 'p',
+			children: [{ elementName: 'em', children: [{ value: 'Nom' }] }],
+		});
+	});
+
+	describe('should handle output elements', () => {
+		const outputScenario = async () => {
+			return await Scenario.init(
+				'markdown',
+				html(
+					head(
+						title('markdown'),
+						model(
+							t(
+								'itext',
+								t(
+									'translation lang="default"',
+									t(
+										'text id="/data/name:label"',
+										t('value', `**Dear <output value=" /data/name " />!** Welcome.`)
+									)
+								)
+							),
+							mainInstance(t('data id="markdown"', t('name'))),
+							bind('/data/name').type('string')
+						)
+					),
+					body(input('/data/name', t(`label ref="jr:itext('/data/name:label')"`)))
+				)
+			);
+		};
+
+		it('style wraps output elements', async () => {
+			const scenario = await outputScenario();
+			scenario.next('/data/name');
+			scenario.answer('Alice');
+			const label = scenario.getQuestionLabel({ assertCurrentReference: '/data/name' }).formatted;
+			expect(label.length).toEqual(1);
+			expect(label[0]).toMatchObject({
+				elementName: 'p',
+				children: [
+					{
+						elementName: 'strong',
+						children: [
+							{ value: 'Dear ' },
+							{
+								elementName: 'span',
+								children: [{ elementName: 'p', children: [{ value: 'Alice' }] }],
+							},
+							{ value: '!' },
+						],
+					},
+					{ value: ' Welcome.' },
+				],
+			});
+		});
+
+		it('marks up output element content', async () => {
+			const scenario = await outputScenario();
+			scenario.next('/data/name');
+			scenario.answer('Alice _nee_ Sally');
+			const label = scenario.getQuestionLabel({ assertCurrentReference: '/data/name' }).formatted;
+			expect(label.length).toEqual(1);
+			expect(label[0]).toMatchObject({
+				elementName: 'p',
+				children: [
+					{
+						elementName: 'strong',
+						children: [
+							{ value: 'Dear ' },
+							{
+								elementName: 'span',
+								children: [
+									{
+										elementName: 'p',
+										children: [
+											{ value: 'Alice ' },
+											{ elementName: 'em', children: [{ value: 'nee' }] },
+											{ value: ' Sally' },
+										],
+									},
+								],
+							},
+							{ value: '!' },
+						],
+					},
+					{ value: ' Welcome.' },
+				],
+			});
+		});
+	});
+
+	it('should work in select options', async () => {
+		const scenario = await Scenario.init(
+			'markdown',
+			html(
+				head(title('markdown'), model(mainInstance(t("data id='select'", t('select'))))),
+				body(
+					select1(
+						'/data/select',
+						item('strong', '**option one**'),
+						item('emphasis', '_option two_'),
+						item('normal', 'option three')
+					)
+				)
+			)
+		);
+
+		scenario.next('/data/select');
+		scenario.answer('strong');
+
+		const label = scenario.getSelectedOptionLabels({
+			assertCurrentReference: '/data/select',
+		});
+		expect(label.length).toEqual(1);
+		const formatted = label[0]!.formatted;
+		expect(formatted.length).toEqual(1);
+		expect(formatted[0]).toMatchObject({
+			elementName: 'p',
+			children: [
+				{
+					elementName: 'strong',
+					children: [{ value: 'option one' }],
+				},
+			],
+		});
+	});
+
+	it('should work in select options', async () => {
+		const scenario = await Scenario.init(
+			'markdown',
+			html(
+				head(
+					title('markdown'),
+					model(mainInstance(t('data id="markdown"', t('name'))), bind('/data/name').type('string'))
+				),
+				body(
+					input(
+						'/data/name',
+						t('label', 'hint field'),
+						t('hint', 'We **strongly** recommend filling in this field')
+					)
+				)
+			)
+		);
+
+		scenario.next('/data/name');
+		const hint = scenario.getQuestionHint({ assertCurrentReference: '/data/name' }).formatted;
+		expect(hint.length).toEqual(1);
+		expect(hint[0]).toMatchObject({
+			elementName: 'p',
+			children: [
+				{ value: 'We ' },
+				{
+					elementName: 'strong',
+					children: [{ value: 'strongly' }],
+				},
+				{ value: ' recommend filling in this field' },
+			],
+		});
+	});
+
+	it('should work in constraints', async () => {
+		const scenario = await Scenario.init(
+			'Validation fixture',
+			html(
+				head(
+					title('Validation fixture'),
+					model(
+						mainInstance(
+							t('data id="validation-fixture"', t('constrained-input'), t('required-input'))
+						),
+						bind('/data/required-input')
+							.required()
+							.withAttribute('jr', 'requiredMsg', 'Field is _totally_ required')
+					)
+				),
+				body(input('/data/constrained-input'), input('/data/required-input'))
+			)
+		);
+		const result = scenario.answerOf('/data/required-input');
+		const formatted = result.node.validationState.required.message?.formatted ?? [];
+		expect(formatted.length).toEqual(1);
+		expect(formatted[0]).toMatchObject({
+			elementName: 'p',
+			children: [
+				{ value: 'Field is ' },
+				{
+					elementName: 'em',
+					children: [{ value: 'totally' }],
+				},
+				{ value: ' required' },
+			],
+		});
+	});
+});

--- a/packages/scenario/test/markdown.test.ts
+++ b/packages/scenario/test/markdown.test.ts
@@ -474,4 +474,32 @@ double line break`;
 			],
 		});
 	});
+
+	it('should work with jr:choice-name', async () => {
+		const scenario = await Scenario.init(
+			'markdown',
+			html(
+				head(
+					title('markdown'),
+					model(
+						mainInstance(t('data id="markdown"', t('name'), t('select'))),
+						bind('/data/name')
+							.type('string')
+							.calculate("jr:choice-name('choice2', ' /data/select ')")
+					)
+				),
+				body(
+					input('/data/name', t('label', 'choice bro')),
+					select1(
+						'/data/select',
+						item('choice1', '__strong__'),
+						item('choice2', '_emphasis_'),
+						item('choice3', 'normal')
+					)
+				)
+			)
+		);
+		const result = scenario.answerOf('/data/name');
+		expect(result.getValue()).toEqual('_emphasis_');
+	});
 });

--- a/packages/scenario/test/repeat-output.test.ts
+++ b/packages/scenario/test/repeat-output.test.ts
@@ -126,7 +126,7 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 					scenario.next('/data/repeat[1]/position_in_label');
 
 					expect(
-						scenario.proposed_getQuestionLabelText({
+						scenario.getQuestionLabelText({
 							assertCurrentReference: '/data/repeat[1]/position_in_label',
 						})
 					).toBe('Position: 1');
@@ -138,7 +138,7 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 					scenario.next('/data/repeat[2]/position_in_label');
 
 					expect(
-						scenario.proposed_getQuestionLabelText({
+						scenario.getQuestionLabelText({
 							assertCurrentReference: '/data/repeat[2]/position_in_label',
 						})
 					).toBe('Position: 2');
@@ -276,7 +276,7 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 					scenario.next('/data/repeat[1]/position_in_label');
 
 					expect(
-						scenario.proposed_getQuestionLabelText({
+						scenario.getQuestionLabelText({
 							assertCurrentReference: '/data/repeat[1]/position_in_label',
 						})
 					).toBe('Position: 1');
@@ -288,7 +288,7 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 					scenario.next('/data/repeat[2]/position_in_label');
 
 					expect(
-						scenario.proposed_getQuestionLabelText({
+						scenario.getQuestionLabelText({
 							assertCurrentReference: '/data/repeat[2]/position_in_label',
 						})
 					).toBe('Position: 2');
@@ -340,7 +340,7 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 					scenario.next('/data/repeat[1]/position_in_label');
 
 					expect(
-						scenario.proposed_getQuestionLabelText({
+						scenario.getQuestionLabelText({
 							assertCurrentReference: '/data/repeat[1]/position_in_label',
 						})
 					).toBe('Position: 1');
@@ -352,7 +352,7 @@ describe('Interaction between `<repeat>` and `<output>`', () => {
 					scenario.next('/data/repeat[2]/position_in_label');
 
 					expect(
-						scenario.proposed_getQuestionLabelText({
+						scenario.getQuestionLabelText({
 							assertCurrentReference: '/data/repeat[2]/position_in_label',
 						})
 					).toBe('Position: 2');

--- a/packages/tree-sitter-xpath/package.json
+++ b/packages/tree-sitter-xpath/package.json
@@ -34,6 +34,7 @@
     "test:grammar": "tree-sitter test --wasm"
   },
   "devDependencies": {
+    "@asgerf/dts-tree-sitter": "^0.1.0",
     "tree-sitter": "0.22.1",
     "tree-sitter-cli": "0.24.5",
     "vite": "^7.0.3",

--- a/packages/tree-sitter-xpath/package.json
+++ b/packages/tree-sitter-xpath/package.json
@@ -34,7 +34,6 @@
     "test:grammar": "tree-sitter test --wasm"
   },
   "devDependencies": {
-    "@asgerf/dts-tree-sitter": "^0.1.0",
     "tree-sitter": "0.22.1",
     "tree-sitter-cli": "0.24.5",
     "vite": "^7.0.3",

--- a/packages/web-forms/e2e/page-objects/controls/InputControl.ts
+++ b/packages/web-forms/e2e/page-objects/controls/InputControl.ts
@@ -10,7 +10,7 @@ export class InputControl {
 	private async getInputByLabel(label: string) {
 		const container = this.page
 			.locator('.question-container')
-			.filter({ has: this.page.locator(`.control-text label span:text-is("${label}")`) });
+			.filter({ has: this.page.locator(`.control-text label:text-is("${label}")`) });
 
 		const input = container.locator('input');
 

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -57,6 +57,7 @@
     "@fontsource/roboto": "^5.2.6",
     "@getodk/xforms-engine": "0.13.0",
     "@playwright/test": "^1.53.2",
+    "@primeuix/themes": "1.0.3",
     "@types/ramda": "^0.30.2",
     "@vitejs/plugin-vue": "^6.0.0",
     "@vitejs/plugin-vue-jsx": "^5.0.1",
@@ -64,7 +65,6 @@
     "jsdom": "^26.1.0",
     "primeflex": "^4.0.0",
     "primevue": "4.3.3",
-    "@primeuix/themes": "1.0.3",
     "ramda": "^0.31.3",
     "sass": "^1.89.2",
     "vite": "^7.0.3",
@@ -78,8 +78,9 @@
     "vue": "^3.5.18"
   },
   "dependencies": {
-    "vue-draggable-plus": "^0.6.0",
-    "@mdi/js": "^7.4.47"
+    "@mdi/js": "^7.4.47",
+    "dompurify": "^3.2.7",
+    "vue-draggable-plus": "^0.6.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/web-forms/src/assets/styles/reset.scss
+++ b/packages/web-forms/src/assets/styles/reset.scss
@@ -33,12 +33,6 @@ strong {
 	line-height: 1.15;
 }
 
-p,
-span,
-label {
-	font-weight: normal;
-}
-
 label {
 	margin: 0 !important;
 }

--- a/packages/web-forms/src/components/common/MarkdownBlock.vue
+++ b/packages/web-forms/src/components/common/MarkdownBlock.vue
@@ -10,34 +10,35 @@ const { elem } = defineProps<MarkdownProps>();
 </script>
 
 <template>
-	<span v-if="elem.elementName === 'span'" :style="{
-		color: elem.properties?.style.color,
-		'font-family': elem.properties?.style['font-family']
-	}">
-		<MarkdownBlock
-			v-for="child in elem.children"
-			:elem="child"
-		/>
+	<span
+		v-if="elem.elementName === 'span'" :style="{
+			color: elem.properties?.style.color,
+			'font-family': elem.properties?.style['font-family']
+		}"
+	>
+		<MarkdownBlock v-for="(child, index) in elem.children" :key="index" :elem="child" />
 	</span>
 	<a v-else-if="elem.elementName === 'a'" :href="elem.url" target="_blank">
 		<MarkdownBlock
-			v-for="child in elem.children"
+			v-for="(child, index) in elem.children"
+			:key="index"
 			:elem="child"
 		/>
 	</a>
 	<component :is="elem.elementName" v-else-if="elem.elementName">
 		<MarkdownBlock
-			v-for="child in elem.children"
+			v-for="(child, index) in elem.children"
+			:key="index"
 			:elem="child"
 		/>
 	</component>
 	<template v-else-if="elem.value">
-		{{elem.value}}
+		{{ elem.value }}
 	</template>
 	<MarkdownBlock
+		v-for="(child, index) in elem.children"
 		v-else
-		v-for="child in elem.children"
+		:key="index"
 		:elem="child"
-	/> 
-
+	/>
 </template>

--- a/packages/web-forms/src/components/common/MarkdownBlock.vue
+++ b/packages/web-forms/src/components/common/MarkdownBlock.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
+
+interface MarkdownProps {
+	readonly elem: any; // export MarkdownElement from client interface
+}
+
+const { elem } = defineProps<MarkdownProps>();
+</script>
+
+<template>
+	<strong v-if="elem.elementName === 'strong'">
+		<MarkdownBlock
+			v-for="child in elem.children"
+			:elem="child"
+		/>
+	</strong>
+	<em v-else-if="elem.elementName === 'em'">
+		<MarkdownBlock
+			v-for="child in elem.children"
+			:elem="child"
+		/>
+	</em>
+	<template v-else-if="elem.value">
+		{{elem.value}}
+	</template>
+	<MarkdownBlock
+		v-else
+		v-for="child in elem.children"
+		:elem="child"
+	/>
+
+</template>

--- a/packages/web-forms/src/components/common/MarkdownBlock.vue
+++ b/packages/web-forms/src/components/common/MarkdownBlock.vue
@@ -58,6 +58,6 @@ const purify = (node: HtmlMarkdownNode): string => {
 
 	<!-- any other parent element -->
 	<component :is="elem.elementName" v-else-if="elem.elementName" :style="getStylePropertyMap(elem)">
-		<MarkdownBlock v-for="(child, index) in elem.children" :key="index" :elem="child"	/>
+		<MarkdownBlock v-for="(child, index) in elem.children" :key="index" :elem="child" />
 	</component>
 </template>

--- a/packages/web-forms/src/components/common/MarkdownBlock.vue
+++ b/packages/web-forms/src/components/common/MarkdownBlock.vue
@@ -44,7 +44,7 @@ const purify = (node: HtmlMarkdownNode): string => {
 
 	<!-- unsafe html -->
 	<!-- eslint-disable-next-line vue/no-v-html -->
-	<div v-else-if="elem.role === 'html'" v-html="purify(elem)" />
+	<span v-else-if="elem.role === 'html'" v-html="purify(elem)" />
 
 	<!-- link -->
 	<a v-else-if="elem.role === 'parent' && elem.elementName === 'a'" :href="getUrl(elem)" target="_blank">

--- a/packages/web-forms/src/components/common/MarkdownBlock.vue
+++ b/packages/web-forms/src/components/common/MarkdownBlock.vue
@@ -1,26 +1,36 @@
 <script lang="ts" setup>
 import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
+import type { MarkdownNode } from '@getodk/xforms-engine';
 
 interface MarkdownProps {
-	readonly elem: any; // export MarkdownElement from client interface
+	readonly elem: MarkdownNode;
 }
 
 const { elem } = defineProps<MarkdownProps>();
 </script>
 
 <template>
-	<strong v-if="elem.elementName === 'strong'">
+	<span v-if="elem.elementName === 'span'" :style="{
+		color: elem.properties?.style.color,
+		'font-family': elem.properties?.style['font-family']
+	}">
 		<MarkdownBlock
 			v-for="child in elem.children"
 			:elem="child"
 		/>
-	</strong>
-	<em v-else-if="elem.elementName === 'em'">
+	</span>
+	<a v-else-if="elem.elementName === 'a'" :href="elem.url" target="_blank">
 		<MarkdownBlock
 			v-for="child in elem.children"
 			:elem="child"
 		/>
-	</em>
+	</a>
+	<component :is="elem.elementName" v-else-if="elem.elementName">
+		<MarkdownBlock
+			v-for="child in elem.children"
+			:elem="child"
+		/>
+	</component>
 	<template v-else-if="elem.value">
 		{{elem.value}}
 	</template>
@@ -28,6 +38,6 @@ const { elem } = defineProps<MarkdownProps>();
 		v-else
 		v-for="child in elem.children"
 		:elem="child"
-	/>
+	/> 
 
 </template>

--- a/packages/web-forms/src/components/common/MarkdownBlock.vue
+++ b/packages/web-forms/src/components/common/MarkdownBlock.vue
@@ -16,8 +16,8 @@ interface MarkdownProps {
 const { elem } = defineProps<MarkdownProps>();
 
 const getStylePropertyMap = (node: ParentMarkdownNode): StyleValue | undefined => {
-	if (node.elementName === 'span') {
-		const properties = (node as StyledMarkdownNode).properties;
+	const properties = (node as StyledMarkdownNode).properties;
+	if (properties) {
 		return properties.style as StyleValue;
 	}
 };

--- a/packages/web-forms/src/components/common/TextMedia.vue
+++ b/packages/web-forms/src/components/common/TextMedia.vue
@@ -2,6 +2,7 @@
 import ImageBlock from '@/components/common/ImageBlock.vue';
 import type { TextRange } from '@getodk/xforms-engine';
 import { computed } from 'vue';
+import MarkdownBlock from './MarkdownBlock.vue';
 
 interface TextMediaProps {
 	readonly label: TextRange<'item-label'>;
@@ -9,17 +10,20 @@ interface TextMediaProps {
 
 const props = defineProps<TextMediaProps>();
 
-const text = computed(() => props.label.asString);
+const text = computed(() => props.label.formatted);
+const alt = computed(() => props.label.asString);
 const image = computed(() => props.label.imageSource);
 const video = computed(() => props.label.videoSource);
 const audio = computed(() => props.label.audioSource);
 </script>
 
 <template>
-	<span v-if="text != null" class="text-content">{{ text }}</span>
+	<span v-if="text != null" class="text-content">
+		<MarkdownBlock v-for="(elem, index) in text" :key="index" :elem="elem" />
+	</span>
 
 	<div v-if="image || video || audio" class="media-content">
-		<ImageBlock v-if="image" :resource-url="image" :alt="text" />
+		<ImageBlock v-if="image" :resource-url="image" :alt="alt" />
 
 		<!-- TODO: Implement VideoBlock component -->
 		<span v-else-if="video">🚧 Video media type is not supported</span>

--- a/packages/web-forms/src/components/form-elements/ControlHint.vue
+++ b/packages/web-forms/src/components/form-elements/ControlHint.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
+import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
 import type { AnyControlNode as QuestionNode } from '@getodk/xforms-engine';
 defineProps<{ question: QuestionNode }>();
 </script>
 
 <template>
 	<div v-if="question.currentState.hint" class="hint">
-		{{ question.currentState.hint?.asString }}
+		<MarkdownBlock v-for="(elem, index) in question.currentState.hint?.formatted" :key="index" :elem="elem" />
 	</div>
 </template>
 

--- a/packages/web-forms/src/components/form-elements/ControlLabel.vue
+++ b/packages/web-forms/src/components/form-elements/ControlLabel.vue
@@ -5,8 +5,7 @@ const props = defineProps<{ question: QuestionNode }>();
 </script>
 
 <template>
-	<label :for="question.nodeId">
-		<span v-if="question.currentState.required" class="required">* </span>
+	<label :for="question.nodeId" :class="{ required: question.currentState.required }">
 		<MarkdownBlock v-for="(elem, index) in props.question.currentState.label?.formatted" :key="index" :elem="elem" />
 	</label>
 </template>
@@ -17,9 +16,18 @@ label {
 	font-size: var(--odk-question-font-size);
 	line-height: 1.5rem;
 	word-wrap: break-word;
+	display: inline-block;
+	width: 100%;
 
-	.required {
+	&.required::before {
+		content: '*';
 		color: var(--odk-error-text-color);
+		float: left;
+		margin-right: 5px;
+	}
+
+	:first-child {
+		margin-top: 0;
 	}
 }
 </style>

--- a/packages/web-forms/src/components/form-elements/ControlLabel.vue
+++ b/packages/web-forms/src/components/form-elements/ControlLabel.vue
@@ -6,7 +6,7 @@ const props = defineProps<{ question: QuestionNode }>();
 <template>
 	<label :for="question.nodeId">
 		<span v-if="question.currentState.required" class="required">* </span>
-		<span>{{ props.question.currentState.label?.asString }}</span>
+		<span v-html="props.question.currentState.label?.formatted"></span>
 	</label>
 </template>
 

--- a/packages/web-forms/src/components/form-elements/ControlLabel.vue
+++ b/packages/web-forms/src/components/form-elements/ControlLabel.vue
@@ -7,7 +7,7 @@ const props = defineProps<{ question: QuestionNode }>();
 <template>
 	<label :for="question.nodeId">
 		<span v-if="question.currentState.required" class="required">* </span>
-		<MarkdownBlock v-for="elem in props.question.currentState.label?.formatted" :elem="elem"/>
+		<MarkdownBlock v-for="(elem, index) in props.question.currentState.label?.formatted" :key="index" :elem="elem" />
 	</label>
 </template>
 

--- a/packages/web-forms/src/components/form-elements/ControlLabel.vue
+++ b/packages/web-forms/src/components/form-elements/ControlLabel.vue
@@ -17,7 +17,6 @@ label {
 	font-size: var(--odk-question-font-size);
 	line-height: 1.5rem;
 	word-wrap: break-word;
-	white-space: pre-wrap;
 
 	.required {
 		color: var(--odk-error-text-color);

--- a/packages/web-forms/src/components/form-elements/ControlLabel.vue
+++ b/packages/web-forms/src/components/form-elements/ControlLabel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
 import type { AnyControlNode as QuestionNode } from '@getodk/xforms-engine';
 const props = defineProps<{ question: QuestionNode }>();
 </script>
@@ -6,7 +7,7 @@ const props = defineProps<{ question: QuestionNode }>();
 <template>
 	<label :for="question.nodeId">
 		<span v-if="question.currentState.required" class="required">* </span>
-		<span v-html="props.question.currentState.label?.formatted"></span>
+		<MarkdownBlock :elem="props.question.currentState.label?.formatted"/>
 	</label>
 </template>
 

--- a/packages/web-forms/src/components/form-elements/ControlLabel.vue
+++ b/packages/web-forms/src/components/form-elements/ControlLabel.vue
@@ -7,7 +7,7 @@ const props = defineProps<{ question: QuestionNode }>();
 <template>
 	<label :for="question.nodeId">
 		<span v-if="question.currentState.required" class="required">* </span>
-		<MarkdownBlock :elem="props.question.currentState.label?.formatted"/>
+		<MarkdownBlock v-for="elem in props.question.currentState.label?.formatted" :elem="elem"/>
 	</label>
 </template>
 

--- a/packages/web-forms/tests/components/form-elements/ControlLabel.test.ts
+++ b/packages/web-forms/tests/components/form-elements/ControlLabel.test.ts
@@ -1,15 +1,15 @@
+import ControlLabel from '@/components/form-elements/ControlLabel.vue';
 import type { AnyInputNode } from '@getodk/xforms-engine';
 import { mount } from '@vue/test-utils';
 import { assocPath } from 'ramda';
 import { describe, expect, it } from 'vitest';
-import ControlLabel from '@/components/form-elements/ControlLabel.vue';
 
 const baseQuestion = {
 	nodeType: 'input',
 	currentState: {
 		required: true,
 		label: {
-			asString: 'First Name',
+			formatted: [{ role: 'child', value: 'First Name' }],
 		},
 	},
 } as AnyInputNode;

--- a/packages/web-forms/tests/components/form-elements/ControlLabel.test.ts
+++ b/packages/web-forms/tests/components/form-elements/ControlLabel.test.ts
@@ -15,7 +15,7 @@ const baseQuestion = {
 } as AnyInputNode;
 
 describe('ControlLabel', () => {
-	it('shows asterisk with field is required', () => {
+	it('styles field when required', () => {
 		const component = mount(ControlLabel, {
 			props: {
 				question: baseQuestion,
@@ -25,12 +25,9 @@ describe('ControlLabel', () => {
 		const requireSpan = component.find('span.required');
 
 		expect(requireSpan.exists()).toBe(true);
-		expect(requireSpan.text()).toBe('*');
-
-		expect(component.text()).toBe('* First Name');
 	});
 
-	it('does not show asterisk when field is not required', () => {
+	it('does not style field when not required', () => {
 		const component = mount(ControlLabel, {
 			props: {
 				question: assocPath(['currentState', 'required'], false, baseQuestion),
@@ -38,9 +35,6 @@ describe('ControlLabel', () => {
 		});
 
 		const requireSpan = component.find('span.required');
-
 		expect(requireSpan.exists()).toBe(false);
-
-		expect(component.text()).toBe('First Name');
 	});
 });

--- a/packages/web-forms/tests/components/form-elements/ControlLabel.test.ts
+++ b/packages/web-forms/tests/components/form-elements/ControlLabel.test.ts
@@ -22,9 +22,7 @@ describe('ControlLabel', () => {
 			},
 		});
 
-		const requireSpan = component.find('span.required');
-
-		expect(requireSpan.exists()).toBe(true);
+		expect(component.classes().includes('required')).toBe(true);
 	});
 
 	it('does not style field when not required', () => {
@@ -34,7 +32,6 @@ describe('ControlLabel', () => {
 			},
 		});
 
-		const requireSpan = component.find('span.required');
-		expect(requireSpan.exists()).toBe(false);
+		expect(component.classes().includes('required')).toBe(false);
 	});
 });

--- a/packages/xforms-engine/package.json
+++ b/packages/xforms-engine/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "bin-packer": "1.7.0",
+    "mdast-util-from-markdown": "^2.0.2",
     "papaparse": "^5.5.3",
     "solid-js": "^1.9.7",
     "temporal-polyfill": "^0.3.0"

--- a/packages/xforms-engine/src/client/MarkdownNode.ts
+++ b/packages/xforms-engine/src/client/MarkdownNode.ts
@@ -1,0 +1,16 @@
+export type Heading = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export interface MarkdownNode { // TODO more type discrimintation ( as per https://github.com/getodk/web-forms/issues/198 )
+  elementName?: 'strong' | 'em' | 'span' | 'a' | Heading;
+	value?: string;
+  properties?: {
+    style: StyleProperty;
+  };
+  children?: MarkdownNode[];
+  url?: string;
+}
+
+export interface StyleProperty {
+	color?: string;
+	'font-family'?: string;
+}

--- a/packages/xforms-engine/src/client/MarkdownNode.ts
+++ b/packages/xforms-engine/src/client/MarkdownNode.ts
@@ -1,4 +1,11 @@
-export type Heading = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+export type Heading =
+	| 'h1'
+	| 'h2'
+	| 'h3'
+	| 'h4'
+	| 'h5'
+	| 'h6';
+
 export type ElementName =
 	| Heading
 	| 'a'

--- a/packages/xforms-engine/src/client/MarkdownNode.ts
+++ b/packages/xforms-engine/src/client/MarkdownNode.ts
@@ -1,13 +1,15 @@
 export type Heading = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+export type ElementName = Heading | 'a' | 'em' | 'img' | 'li' | 'ol' | 'span' | 'strong' | 'ul';
 
-export interface MarkdownNode { // TODO more type discrimintation ( as per https://github.com/getodk/web-forms/issues/198 )
-  elementName?: 'strong' | 'em' | 'span' | 'a' | Heading;
+export interface MarkdownNode {
+	// TODO more type discrimintation ( as per https://github.com/getodk/web-forms/issues/198 )
+	elementName?: ElementName;
 	value?: string;
-  properties?: {
-    style: StyleProperty;
-  };
-  children?: MarkdownNode[];
-  url?: string;
+	properties?: {
+		style: StyleProperty;
+	};
+	children?: MarkdownNode[];
+	url?: string;
 }
 
 export interface StyleProperty {

--- a/packages/xforms-engine/src/client/MarkdownNode.ts
+++ b/packages/xforms-engine/src/client/MarkdownNode.ts
@@ -1,18 +1,49 @@
 export type Heading = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-export type ElementName = Heading | 'a' | 'em' | 'img' | 'li' | 'ol' | 'span' | 'strong' | 'ul';
+export type ElementName =
+	| Heading
+	| 'a'
+	| 'em'
+	| 'img'
+	| 'li'
+	| 'ol'
+	| 'p'
+	| 'span'
+	| 'strong'
+	| 'ul';
 
-export interface MarkdownNode {
-	// TODO more type discrimintation ( as per https://github.com/getodk/web-forms/issues/198 )
-	elementName?: ElementName;
-	value?: string;
-	properties?: {
-		style: StyleProperty;
-	};
-	children?: MarkdownNode[];
-	url?: string;
+export type MarkdownNode = ChildMarkdownNode | HtmlMarkdownNode | ParentMarkdownNode;
+
+export interface ParentMarkdownNode {
+	readonly role: 'parent';
+	readonly elementName: string;
+	readonly children: MarkdownNode[];
+}
+
+export interface ChildMarkdownNode {
+	readonly role: 'child';
+	readonly value: string;
+}
+
+export interface HtmlMarkdownNode {
+	readonly role: 'html';
+	readonly unsafeHtml: string;
+}
+
+export interface AnchorMarkdownNode extends ParentMarkdownNode {
+	readonly elementName: 'a';
+	readonly url: string;
+}
+
+export interface StyledMarkdownNode extends ParentMarkdownNode {
+	readonly elementName: 'span';
+	readonly properties: MarkdownProperty;
+}
+
+export interface MarkdownProperty {
+	readonly style: StyleProperty;
 }
 
 export interface StyleProperty {
-	color?: string;
-	'font-family'?: string;
+	readonly color: string | undefined;
+	readonly 'font-family': string | undefined;
 }

--- a/packages/xforms-engine/src/client/MarkdownNode.ts
+++ b/packages/xforms-engine/src/client/MarkdownNode.ts
@@ -1,14 +1,9 @@
-export type Heading =
-	| 'h1'
-	| 'h2'
-	| 'h3'
-	| 'h4'
-	| 'h5'
-	| 'h6';
+export type Heading = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 export type ElementName =
 	| Heading
 	| 'a'
+	| 'div'
 	| 'em'
 	| 'img'
 	| 'li'
@@ -42,8 +37,8 @@ export interface AnchorMarkdownNode extends ParentMarkdownNode {
 }
 
 export interface StyledMarkdownNode extends ParentMarkdownNode {
-	readonly elementName: 'span';
-	readonly properties: MarkdownProperty;
+	readonly elementName: 'div' | 'p' | 'span';
+	readonly properties: MarkdownProperty | undefined;
 }
 
 export interface MarkdownProperty {
@@ -53,4 +48,5 @@ export interface MarkdownProperty {
 export interface StyleProperty {
 	readonly color: string | undefined;
 	readonly 'font-family': string | undefined;
+	readonly 'text-align': 'center' | 'left' | 'right' | undefined;
 }

--- a/packages/xforms-engine/src/client/TextRange.ts
+++ b/packages/xforms-engine/src/client/TextRange.ts
@@ -1,5 +1,6 @@
 import { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
 import type { ActiveLanguage } from './FormLanguage.ts';
+import type { MarkdownNode } from './MarkdownNode.ts';
 
 /**
  * **COMMENTARY**
@@ -147,7 +148,7 @@ export interface TextRange<Role extends TextRole, Origin extends TextOrigin = Te
 	[Symbol.iterator](): Iterable<TextChunk>;
 
 	get asString(): string;
-	get formatted(): unknown;
+	get formatted(): MarkdownNode[];
 
 	get imageSource(): JRResourceURL | undefined;
 	get audioSource(): JRResourceURL | undefined;

--- a/packages/xforms-engine/src/client/TextRange.ts
+++ b/packages/xforms-engine/src/client/TextRange.ts
@@ -65,7 +65,6 @@ export type TextChunkSource =
  *
  * @see {@link TextRange}
  */
-// TODO why do we expose this? I think the client should only care about TextRange
 export interface TextChunk {
 	readonly source: TextChunkSource;
 
@@ -75,7 +74,6 @@ export interface TextChunk {
 	get language(): ActiveLanguage;
 
 	get asString(): string;
-	get formatted(): unknown; // TODO remove this - it doesn't make sense to format a chunk in isolation
 }
 
 // eslint-disable-next-line @typescript-eslint/sort-type-constituents

--- a/packages/xforms-engine/src/client/TextRange.ts
+++ b/packages/xforms-engine/src/client/TextRange.ts
@@ -64,6 +64,7 @@ export type TextChunkSource =
  *
  * @see {@link TextRange}
  */
+// TODO why do we expose this? I think the client should only care about TextRange
 export interface TextChunk {
 	readonly source: TextChunkSource;
 
@@ -73,7 +74,7 @@ export interface TextChunk {
 	get language(): ActiveLanguage;
 
 	get asString(): string;
-	get formatted(): unknown;
+	get formatted(): unknown; // TODO remove this - it doesn't make sense to format a chunk in isolation
 }
 
 // eslint-disable-next-line @typescript-eslint/sort-type-constituents

--- a/packages/xforms-engine/src/client/index.ts
+++ b/packages/xforms-engine/src/client/index.ts
@@ -20,7 +20,7 @@ export type {
 	AnyParentNode,
 	GeneralChildNode,
 	GeneralParentNode,
-	RepeatRangeNode
+	RepeatRangeNode,
 } from './hierarchy.ts';
 export type * from './identity.ts';
 export type * from './InputNode.ts';
@@ -48,4 +48,3 @@ export type * from './TriggerNode.ts';
 export type * from './UploadNode.ts';
 export type * from './validation.ts';
 export type * from './ValueType.ts';
-

--- a/packages/xforms-engine/src/client/index.ts
+++ b/packages/xforms-engine/src/client/index.ts
@@ -20,10 +20,11 @@ export type {
 	AnyParentNode,
 	GeneralChildNode,
 	GeneralParentNode,
-	RepeatRangeNode,
+	RepeatRangeNode
 } from './hierarchy.ts';
 export type * from './identity.ts';
 export type * from './InputNode.ts';
+export type * from './MarkdownNode.ts';
 export type * from './ModelValueNode.ts';
 export type * from './NoteNode.ts';
 export type * from './OpaqueReactiveObjectFactory.ts';
@@ -47,3 +48,4 @@ export type * from './TriggerNode.ts';
 export type * from './UploadNode.ts';
 export type * from './validation.ts';
 export type * from './ValueType.ts';
+

--- a/packages/xforms-engine/src/instance/markdown/MarkdownNode.ts
+++ b/packages/xforms-engine/src/instance/markdown/MarkdownNode.ts
@@ -1,0 +1,101 @@
+import {
+	type AnchorMarkdownNode,
+	type ChildMarkdownNode as ClientChildMarkdownNode,
+	type HtmlMarkdownNode as ClientHtmlMarkdownNode,
+	type ParentMarkdownNode as ClientParentMarkdownNode,
+	type ElementName,
+	type MarkdownNode,
+	type MarkdownProperty,
+	type StyledMarkdownNode,
+} from '../../client';
+
+abstract class ParentMarkdownNode implements ClientParentMarkdownNode {
+	readonly children;
+	readonly role = 'parent';
+	abstract elementName: ElementName;
+	constructor(children: MarkdownNode[]) {
+		this.children = children;
+	}
+}
+
+export class Heading1 extends ParentMarkdownNode {
+	readonly elementName = 'h1';
+}
+
+export class Heading2 extends ParentMarkdownNode {
+	readonly elementName = 'h2';
+}
+
+export class Heading3 extends ParentMarkdownNode {
+	readonly elementName = 'h3';
+}
+
+export class Heading4 extends ParentMarkdownNode {
+	readonly elementName = 'h4';
+}
+
+export class Heading5 extends ParentMarkdownNode {
+	readonly elementName = 'h5';
+}
+
+export class Heading6 extends ParentMarkdownNode {
+	readonly elementName = 'h6';
+}
+
+export class Strong extends ParentMarkdownNode {
+	readonly elementName = 'strong';
+}
+
+export class Emphasis extends ParentMarkdownNode {
+	readonly elementName = 'em';
+}
+
+export class Paragraph extends ParentMarkdownNode {
+	readonly elementName = 'p';
+}
+
+export class OrderedList extends ParentMarkdownNode {
+	readonly elementName = 'ol';
+}
+
+export class UnorderedList extends ParentMarkdownNode {
+	readonly elementName = 'ul';
+}
+
+export class ListItem extends ParentMarkdownNode {
+	readonly elementName = 'li';
+}
+
+export class Anchor extends ParentMarkdownNode implements AnchorMarkdownNode {
+	readonly elementName = 'a';
+	readonly url: string;
+	constructor(children: MarkdownNode[], url: string) {
+		super(children);
+		this.url = url;
+	}
+}
+
+export class Span extends ParentMarkdownNode implements StyledMarkdownNode {
+	readonly elementName = 'span';
+	readonly properties: MarkdownProperty;
+	constructor(children: MarkdownNode[], properties: MarkdownProperty) {
+		super(children);
+		this.properties = properties;
+	}
+}
+
+export class ChildMarkdownNode implements ClientChildMarkdownNode {
+	readonly role = 'child';
+	readonly value: string;
+	constructor(value: string) {
+		this.value = value;
+	}
+}
+
+export class Html implements ClientHtmlMarkdownNode {
+	readonly role = 'html';
+	readonly unsafeHtml: string;
+	constructor(unsafeHtml: string) {
+		this.unsafeHtml = unsafeHtml;
+	}
+}

--- a/packages/xforms-engine/src/instance/markdown/MarkdownNode.ts
+++ b/packages/xforms-engine/src/instance/markdown/MarkdownNode.ts
@@ -3,10 +3,10 @@ import {
 	type ChildMarkdownNode as ClientChildMarkdownNode,
 	type HtmlMarkdownNode as ClientHtmlMarkdownNode,
 	type ParentMarkdownNode as ClientParentMarkdownNode,
+	type StyledMarkdownNode as ClientStyledMarkdownNode,
 	type ElementName,
 	type MarkdownNode,
 	type MarkdownProperty,
-	type StyledMarkdownNode,
 } from '../../client';
 
 abstract class ParentMarkdownNode implements ClientParentMarkdownNode {
@@ -50,10 +50,6 @@ export class Emphasis extends ParentMarkdownNode {
 	readonly elementName = 'em';
 }
 
-export class Paragraph extends ParentMarkdownNode {
-	readonly elementName = 'p';
-}
-
 export class OrderedList extends ParentMarkdownNode {
 	readonly elementName = 'ol';
 }
@@ -75,13 +71,27 @@ export class Anchor extends ParentMarkdownNode implements AnchorMarkdownNode {
 	}
 }
 
-export class Span extends ParentMarkdownNode implements StyledMarkdownNode {
-	readonly elementName = 'span';
-	readonly properties: MarkdownProperty;
-	constructor(children: MarkdownNode[], properties: MarkdownProperty) {
-		super(children);
+abstract class StyledMarkdownNode implements ClientParentMarkdownNode {
+	readonly children;
+	readonly role = 'parent';
+	abstract elementName: ElementName;
+	readonly properties: MarkdownProperty | undefined;
+	constructor(children: MarkdownNode[], properties: MarkdownProperty | undefined) {
+		this.children = children;
 		this.properties = properties;
 	}
+}
+
+export class Paragraph extends StyledMarkdownNode implements ClientStyledMarkdownNode {
+	readonly elementName = 'p';
+}
+
+export class Span extends StyledMarkdownNode implements ClientStyledMarkdownNode {
+	readonly elementName = 'span';
+}
+
+export class Div extends StyledMarkdownNode implements ClientStyledMarkdownNode {
+	readonly elementName = 'div';
 }
 
 export class ChildMarkdownNode implements ClientChildMarkdownNode {

--- a/packages/xforms-engine/src/instance/text/FormattedTextStub.ts
+++ b/packages/xforms-engine/src/instance/text/FormattedTextStub.ts
@@ -1,8 +1,0 @@
-export const FormattedTextStub = new Proxy({} as Record<PropertyKey, unknown>, {
-	get() {
-		throw new TypeError('Not implemented');
-	},
-	set() {
-		return false;
-	},
-});

--- a/packages/xforms-engine/src/instance/text/TextChunk.ts
+++ b/packages/xforms-engine/src/instance/text/TextChunk.ts
@@ -1,13 +1,8 @@
 import type { ActiveLanguage } from '../../client/FormLanguage.ts';
 import type { TextChunk as ClientTextChunk, TextChunkSource } from '../../client/TextRange.ts';
 import type { TranslationContext } from '../internal-api/TranslationContext.ts';
-import { FormattedTextStub } from './FormattedTextStub.ts';
 
 export class TextChunk implements ClientTextChunk {
-	get formatted() {
-		return FormattedTextStub;
-	}
-
 	get language(): ActiveLanguage {
 		return this.context.getActiveLanguage();
 	}

--- a/packages/xforms-engine/src/instance/text/TextRange.ts
+++ b/packages/xforms-engine/src/instance/text/TextRange.ts
@@ -5,7 +5,6 @@ import type {
 	TextOrigin,
 	TextRole,
 } from '../../client/TextRange.ts';
-import { FormattedTextStub } from './FormattedTextStub.ts';
 
 export interface MediaSources {
 	image?: JRResourceURL;
@@ -21,7 +20,11 @@ export class TextRange<Role extends TextRole, Origin extends TextOrigin>
 	}
 
 	get formatted() {
-		return FormattedTextStub;
+		const str = this.asString;
+		return str.replace(/^\s*#\s?([^#][^\n]*)(\n|$)/gm, (hashtags: string, content: string) => {
+			console.log({hashtags, content});
+			return `<h1>${content}</h1>`;
+		});
 	}
 
 	get asString(): string {

--- a/packages/xforms-engine/src/instance/text/TextRange.ts
+++ b/packages/xforms-engine/src/instance/text/TextRange.ts
@@ -47,6 +47,5 @@ export class TextRange<Role extends TextRole, Origin extends TextOrigin>
 		readonly role: Role,
 		protected readonly chunks: readonly TextChunk[],
 		protected readonly mediaSources?: MediaSources
-	) {
-	}
+	) {}
 }

--- a/packages/xforms-engine/src/instance/text/TextRange.ts
+++ b/packages/xforms-engine/src/instance/text/TextRange.ts
@@ -1,4 +1,7 @@
 import { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
+import type { Nodes } from 'mdast';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+
 import type {
 	TextRange as ClientTextRange,
 	TextChunk,
@@ -12,6 +15,63 @@ export interface MediaSources {
 	audio?: JRResourceURL;
 }
 
+interface MarkdownElement {
+  elementName?: string;
+	value?: string;
+  properties?: Record<string, unknown>;
+  children?: MarkdownElement[];
+}
+
+function mdastToOdkMarkdown(tree: Nodes): MarkdownElement {
+	if (tree.type === 'root') {
+		const children = tree.children
+			.map(child => mdastToOdkMarkdown(child))
+			.filter(child => !!child);
+		return {
+			children
+		};
+	}
+	if (tree.type === 'paragraph') {
+		const children = tree.children
+			.map(child => mdastToOdkMarkdown(child))
+			.filter(child => !!child);
+		return {
+			elementName: 'p',
+			children
+		};
+	}
+	if (tree.type === 'strong') {
+		const children = tree.children
+			.map(child => mdastToOdkMarkdown(child))
+			.filter(child => !!child);
+		return {
+			elementName: 'strong',
+			children
+		};
+	}
+	if (tree.type === 'emphasis') {
+		const children = tree.children
+			.map(child => mdastToOdkMarkdown(child))
+			.filter(child => !!child);
+		return {
+			elementName: 'em',
+			children
+		};
+	}
+	if (tree.type === 'text') {
+		return {
+			value: tree.value
+		};
+	} 
+	if (tree.type === 'inlineCode') {
+		return {
+			value: tree.value
+		};
+	}
+	return {};
+	// throw new Error('unsupported markdown type: ' + tree.type);
+};
+
 export class TextRange<Role extends TextRole, Origin extends TextOrigin>
 	implements ClientTextRange<Role, Origin>
 {
@@ -19,15 +79,25 @@ export class TextRange<Role extends TextRole, Origin extends TextOrigin>
 		yield* this.chunks;
 	}
 
-	get formatted() {
-		const str = this.asString;
-		return str.replace(/^\s*#\s?([^#][^\n]*)(\n|$)/gm, (hashtags: string, content: string) => {
-			console.log({hashtags, content});
-			return `<h1>${content}</h1>`;
-		});
+	get formatted(): MarkdownElement {
+		console.log('getting formatted');
+		const str = this.chunks.map((chunk) => {
+			if (chunk.source === 'output') {
+				console.log('chunk.asString', chunk.asString);
+				return chunk.asString ? '`' + ( chunk.asString) + '`' : ''; // backticks so it doesn't get markeddown
+			} else {
+				return chunk.asString
+			}
+		}).join('');
+		const tree = fromMarkdown(str);
+		// consider unrolling the first child - always seems to be a <p>
+		const odkMarkdownTree = mdastToOdkMarkdown(tree);
+		console.log({ str, tree, odkMarkdownTree });
+		return odkMarkdownTree;
 	}
 
 	get asString(): string {
+		console.log('getting string');
 		return this.chunks.map((chunk) => chunk.asString).join('');
 	}
 
@@ -48,5 +118,7 @@ export class TextRange<Role extends TextRole, Origin extends TextOrigin>
 		readonly role: Role,
 		protected readonly chunks: readonly TextChunk[],
 		protected readonly mediaSources?: MediaSources
-	) {}
+	) {
+		console.log('construcing');
+	}
 }

--- a/packages/xforms-engine/src/instance/text/TextRange.ts
+++ b/packages/xforms-engine/src/instance/text/TextRange.ts
@@ -27,7 +27,6 @@ export class TextRange<Role extends TextRole, Origin extends TextOrigin>
 	}
 
 	get asString(): string {
-		console.log('getting string');
 		return this.chunks.map((chunk) => chunk.asString).join('');
 	}
 
@@ -49,6 +48,5 @@ export class TextRange<Role extends TextRole, Origin extends TextOrigin>
 		protected readonly chunks: readonly TextChunk[],
 		protected readonly mediaSources?: MediaSources
 	) {
-		console.log('construcing');
 	}
 }

--- a/packages/xforms-engine/src/instance/text/TextRange.ts
+++ b/packages/xforms-engine/src/instance/text/TextRange.ts
@@ -1,76 +1,19 @@
 import { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
-import type { Nodes } from 'mdast';
-import { fromMarkdown } from 'mdast-util-from-markdown';
 
+import type { MarkdownNode } from '../../client/MarkdownNode.ts';
 import type {
 	TextRange as ClientTextRange,
 	TextChunk,
 	TextOrigin,
 	TextRole,
 } from '../../client/TextRange.ts';
+import { format } from './markdownFormat.ts';
 
 export interface MediaSources {
 	image?: JRResourceURL;
 	video?: JRResourceURL;
 	audio?: JRResourceURL;
 }
-
-interface MarkdownElement {
-  elementName?: string;
-	value?: string;
-  properties?: Record<string, unknown>;
-  children?: MarkdownElement[];
-}
-
-function mdastToOdkMarkdown(tree: Nodes): MarkdownElement {
-	if (tree.type === 'root') {
-		const children = tree.children
-			.map(child => mdastToOdkMarkdown(child))
-			.filter(child => !!child);
-		return {
-			children
-		};
-	}
-	if (tree.type === 'paragraph') {
-		const children = tree.children
-			.map(child => mdastToOdkMarkdown(child))
-			.filter(child => !!child);
-		return {
-			elementName: 'p',
-			children
-		};
-	}
-	if (tree.type === 'strong') {
-		const children = tree.children
-			.map(child => mdastToOdkMarkdown(child))
-			.filter(child => !!child);
-		return {
-			elementName: 'strong',
-			children
-		};
-	}
-	if (tree.type === 'emphasis') {
-		const children = tree.children
-			.map(child => mdastToOdkMarkdown(child))
-			.filter(child => !!child);
-		return {
-			elementName: 'em',
-			children
-		};
-	}
-	if (tree.type === 'text') {
-		return {
-			value: tree.value
-		};
-	} 
-	if (tree.type === 'inlineCode') {
-		return {
-			value: tree.value
-		};
-	}
-	return {};
-	// throw new Error('unsupported markdown type: ' + tree.type);
-};
 
 export class TextRange<Role extends TextRole, Origin extends TextOrigin>
 	implements ClientTextRange<Role, Origin>
@@ -79,21 +22,8 @@ export class TextRange<Role extends TextRole, Origin extends TextOrigin>
 		yield* this.chunks;
 	}
 
-	get formatted(): MarkdownElement {
-		console.log('getting formatted');
-		const str = this.chunks.map((chunk) => {
-			if (chunk.source === 'output') {
-				console.log('chunk.asString', chunk.asString);
-				return chunk.asString ? '`' + ( chunk.asString) + '`' : ''; // backticks so it doesn't get markeddown
-			} else {
-				return chunk.asString
-			}
-		}).join('');
-		const tree = fromMarkdown(str);
-		// consider unrolling the first child - always seems to be a <p>
-		const odkMarkdownTree = mdastToOdkMarkdown(tree);
-		console.log({ str, tree, odkMarkdownTree });
-		return odkMarkdownTree;
+	get formatted(): MarkdownNode[] {
+		return format(this.chunks);
 	}
 
 	get asString(): string {

--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -1,101 +1,130 @@
-import type { RootContent } from 'mdast';
+import type { Heading, RootContent } from 'mdast';
 import { fromMarkdown } from 'mdast-util-from-markdown';
-import type { Heading, MarkdownNode, StyleProperty } from '../../client';
+import { type MarkdownNode, type StyleProperty } from '../../client';
 import type { TextChunk } from '../../client/TextRange.ts';
+import {
+	Anchor,
+	ChildMarkdownNode,
+	Emphasis,
+	Heading1,
+	Heading2,
+	Heading3,
+	Heading4,
+	Heading5,
+	Heading6,
+	Html,
+	ListItem,
+	OrderedList,
+	Paragraph,
+	Span,
+	Strong,
+	UnorderedList,
+} from '../markdown/MarkdownNode.ts';
 
 const STYLE_PROPERTY_REGEX = /style\s*=\s*("([^"]*)"|'([^']*)')/i;
 
 function parseStyle(tag: string): StyleProperty {
 	const styleProperty = STYLE_PROPERTY_REGEX.exec(tag);
-	if (!styleProperty || styleProperty.length < 2) {
-		return {};
+	let color;
+	let font;
+	if (styleProperty && styleProperty.length > 1) {
+		const styleValue = styleProperty[2] ?? '';
+		const properties = styleValue.split(';');
+		properties.forEach((property) => {
+			const [name, value] = property.split(':');
+			if (!name || !value) {
+				return;
+			}
+			if (name === 'color') {
+				color = value;
+			} else if (name === 'font-family') {
+				font = value;
+			}
+		});
 	}
-	const styleValue = styleProperty[2] ?? '';
-	const properties = styleValue.split(';');
-	const result: StyleProperty = {};
-	properties.forEach((property) => {
-		const [name, value] = property.split(':');
-		if (!name || !value) {
-			return;
+	return {
+		color,
+		'font-family': font,
+	};
+}
+
+function mdastHeading(tree: Heading, children: MarkdownNode[]): MarkdownNode {
+	if (tree.depth === 1) {
+		return new Heading1(children);
+	}
+	if (tree.depth === 2) {
+		return new Heading2(children);
+	}
+	if (tree.depth === 3) {
+		return new Heading3(children);
+	}
+	if (tree.depth === 4) {
+		return new Heading4(children);
+	}
+	if (tree.depth === 5) {
+		return new Heading5(children);
+	}
+	return new Heading6(children);
+}
+
+function mdastNodeToOdkMarkdown(tree: RootContent): MarkdownNode | undefined {
+	if (tree.type === 'text' || tree.type === 'inlineCode') {
+		return new ChildMarkdownNode(tree.value);
+	}
+	if (tree.type === 'html') {
+		return new Html(tree.value);
+	}
+	if ('children' in tree) {
+		const children = mdastToOdkMarkdown(tree.children);
+		if (tree.type === 'paragraph') {
+			return new Paragraph(children);
 		}
-		if (name === 'color') {
-			result.color = value;
-		} else if (name === 'font-family') {
-			result['font-family'] = value;
+		if (tree.type === 'strong') {
+			return new Strong(children);
 		}
-	});
-	return result;
+		if (tree.type === 'emphasis') {
+			return new Emphasis(children);
+		}
+		if (tree.type === 'link') {
+			return new Anchor(children, tree.url);
+		}
+		if (tree.type === 'list') {
+			if (tree.ordered) {
+				return new OrderedList(children);
+			} else {
+				return new UnorderedList(children);
+			}
+		}
+		if (tree.type === 'listItem') {
+			return new ListItem(children);
+		}
+		if (tree.type === 'heading') {
+			return mdastHeading(tree, children);
+		}
+	}
+	return;
 }
 
 function mdastToOdkMarkdown(elements: RootContent[]): MarkdownNode[] {
 	const result: MarkdownNode[] = [];
 	for (let i = 0; i < elements.length; i++) {
 		const tree = elements[i]!;
-		if (tree.type === 'paragraph') {
-			result.push({
-				children: mdastToOdkMarkdown(tree.children),
-			});
-		}
-		if (tree.type === 'strong') {
-			result.push({
-				elementName: 'strong',
-				children: mdastToOdkMarkdown(tree.children),
-			});
-		}
-		if (tree.type === 'emphasis') {
-			result.push({
-				elementName: 'em',
-				children: mdastToOdkMarkdown(tree.children),
-			});
-		}
-		if (tree.type === 'link') {
-			result.push({
-				elementName: 'a',
-				url: tree.url,
-				children: mdastToOdkMarkdown(tree.children),
-			});
-		}
-		if (tree.type === 'list') {
-			result.push({
-				elementName: tree.ordered ? 'ol' : 'ul',
-				children: mdastToOdkMarkdown(tree.children),
-			});
-		}
-		if (tree.type === 'listItem') {
-			result.push({
-				elementName: 'li',
-				children: mdastToOdkMarkdown(tree.children),
-			});
-		}
-		if (tree.type === 'heading') {
-			let elementName: Heading;
-			if (tree.depth <= 1) elementName = 'h1';
-			else if (tree.depth === 2) elementName = 'h2';
-			else if (tree.depth === 3) elementName = 'h3';
-			else if (tree.depth === 4) elementName = 'h4';
-			else if (tree.depth === 5) elementName = 'h5';
-			else elementName = 'h6';
-			result.push({
-				elementName,
-				children: mdastToOdkMarkdown(tree.children),
-			});
-		}
-		if (tree.type === 'text' || tree.type === 'inlineCode') {
-			result.push({ value: tree.value });
-		}
 		if (tree.type === 'html' && tree.value.startsWith('<span ')) {
-			const children = [];
+			// SPECIAL CASE in mdast processing
+			// span children are parsed into siblings in the mdast for some reason
+			// so we need to advance `i` as we consume siblings
+			const children: RootContent[] = [];
 			let next = elements[++i];
 			while (next && !(next.type === 'html' && next.value === '</span>')) {
 				children.push(next);
 				next = elements[++i];
 			}
-
-			result.push({
-				elementName: 'span',
-				properties: { style: parseStyle(tree.value) },
-				children: mdastToOdkMarkdown(children),
-			});
+			result.push(new Span(mdastToOdkMarkdown(children), { style: parseStyle(tree.value) }));
+		} else {
+			const odkMarkdown = mdastNodeToOdkMarkdown(tree);
+			if (odkMarkdown) {
+				result.push(odkMarkdown);
+			}
 		}
 	}
 	return result;
@@ -106,9 +135,8 @@ function escapeEditableChunks(chunks: readonly TextChunk[]) {
 		.map((chunk) => {
 			if (chunk.source === 'output') {
 				return chunk.asString ? '`' + chunk.asString + '`' : ''; // backticks so it doesn't get markeddown
-			} else {
-				return chunk.asString;
 			}
+			return chunk.asString;
 		})
 		.join('');
 }
@@ -116,6 +144,5 @@ function escapeEditableChunks(chunks: readonly TextChunk[]) {
 export function format(chunks: readonly TextChunk[]): MarkdownNode[] {
 	const str = escapeEditableChunks(chunks);
 	const tree = fromMarkdown(str);
-	const odkMarkdownTree = mdastToOdkMarkdown(tree.children);
-	return odkMarkdownTree;
+	return mdastToOdkMarkdown(tree.children);
 }

--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -1,0 +1,108 @@
+import type { RootContent } from 'mdast';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import type { Heading, MarkdownNode, StyleProperty } from "../../client";
+import type {
+  TextChunk
+} from '../../client/TextRange.ts';
+
+function parseStyle(tag: string): StyleProperty {
+	const styleProperty = tag.match(/style\s*=\s*("([^"]*)"|'([^']*)')/i);
+	if (!styleProperty || styleProperty.length < 2) {
+		return {};
+	}
+	const styleValue = styleProperty[2] ?? '';
+	const properties = styleValue.split(';');
+	const result: StyleProperty = {};
+	properties.forEach(property => {
+		const [name, value] = property.split(':');
+		if (!name || !value) {
+			return;
+		}
+		if (name === 'color') {
+			result.color = value;
+		} else if (name === 'font-family') {
+			result['font-family'] = value;
+		}
+	});
+	return result;
+}
+
+function mdastToOdkMarkdown(elements: RootContent[]): MarkdownNode[] {
+	const result: MarkdownNode[] = [];
+	for (let i = 0; i < elements.length; i++) {
+		const tree = elements[i]!;
+		if (tree.type === 'paragraph') {
+			result.push({
+				children: mdastToOdkMarkdown(tree.children)
+			});
+		}
+		if (tree.type === 'strong') {
+			result.push({
+				elementName: 'strong',
+				children: mdastToOdkMarkdown(tree.children)
+			});
+		}
+		if (tree.type === 'emphasis') {
+			result.push({
+				elementName: 'em',
+				children: mdastToOdkMarkdown(tree.children)
+			});
+		}
+		if (tree.type === 'link') {
+			result.push({
+				elementName: 'a',
+				url: tree.url,
+				children: mdastToOdkMarkdown(tree.children)
+			});
+		}
+		if (tree.type === 'heading') {
+			let elementName: Heading;
+			if (tree.depth <= 1) elementName = 'h1';
+			else if (tree.depth === 2) elementName = 'h2';
+			else if (tree.depth === 3) elementName = 'h3';
+			else if (tree.depth === 4) elementName = 'h4';
+			else if (tree.depth === 5) elementName = 'h5';
+			else elementName = 'h6';
+			result.push({
+				elementName,
+				children: mdastToOdkMarkdown(tree.children)
+			});
+		}
+		if (tree.type === 'text' || tree.type === 'inlineCode') {
+			result.push({ value: tree.value });
+		} 
+		if (tree.type === 'html' && tree.value.startsWith('<span ')) {
+			const children = [];
+			let next = elements[++i];
+			while (next && !(next.type === 'html' && next.value === '</span>')) {
+				children.push(next);
+				next = elements[++i];
+			}
+
+			result.push({
+				elementName: 'span',
+				properties: { style: parseStyle(tree.value) },
+				children: mdastToOdkMarkdown(children)
+			});
+		}
+	}
+	return result;
+};
+
+function escapeEditableChunks(chunks: readonly TextChunk[]) {
+  return chunks.map((chunk) => {
+    if (chunk.source === 'output') {
+      return chunk.asString ? '`' + ( chunk.asString) + '`' : ''; // backticks so it doesn't get markeddown
+    } else {
+      return chunk.asString
+    }
+  }).join('');
+}
+
+export function format(chunks: readonly TextChunk[]): MarkdownNode[] {
+  const str = escapeEditableChunks(chunks);
+  const tree = fromMarkdown(str);
+  // consider unrolling the first child - always seems to be a <p>
+  const odkMarkdownTree = mdastToOdkMarkdown(tree.children);
+  return odkMarkdownTree;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,13 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
+"@asgerf/dts-tree-sitter@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@asgerf/dts-tree-sitter/-/dts-tree-sitter-0.1.0.tgz#d4b77cb5f03a0b1e5141bf4e6fab98f388fc061e"
+  integrity sha512-L1SaiDRbBXLIOxwaW/S3H/LvevCdRLrQh48gFqMX/CCtR1IMYGFqAt3/x8kK/SwEzzH0Ke8JrRHD3w3kVgubTg==
+  dependencies:
+    tree-sitter "^0.16.1"
+
 "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.2":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
@@ -5218,7 +5225,7 @@ tree-sitter-cli@0.24.5:
   resolved "https://registry.yarnpkg.com/tree-sitter-cli/-/tree-sitter-cli-0.24.5.tgz#787236587f4158e3b667c29efad234f26887d8f2"
   integrity sha512-8EIgV/ERQlpvk1rPSCCjxveAb6Sba8tMiBpeeL68Mueuuqr0wNfhps/I1nFm2OTnpPCUV2PS9nbzzAMoyxSQUg==
 
-tree-sitter@0.22.1:
+tree-sitter@0.22.1, tree-sitter@^0.16.1:
   version "0.22.1"
   resolved "https://registry.yarnpkg.com/tree-sitter/-/tree-sitter-0.22.1.tgz#5a5296fc0898b21443657e071b050c95c0d7afbd"
   integrity sha512-gRO+jk2ljxZlIn20QRskIvpLCMtzuLl5T0BY6L9uvPYD17uUrxlxWkvYCiVqED2q2q7CVtY52Uex4WcYo2FEXw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,6 +1571,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
@@ -2716,6 +2721,13 @@ dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+dompurify@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.7.tgz#721d63913db5111dd6dfda8d3a748cfd7982d44a"
+  integrity sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dotenv@^8.1.0:
   version "8.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,13 +21,6 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
-"@asgerf/dts-tree-sitter@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@asgerf/dts-tree-sitter/-/dts-tree-sitter-0.1.0.tgz#d4b77cb5f03a0b1e5141bf4e6fab98f388fc061e"
-  integrity sha512-L1SaiDRbBXLIOxwaW/S3H/LvevCdRLrQh48gFqMX/CCtR1IMYGFqAt3/x8kK/SwEzzH0Ke8JrRHD3w3kVgubTg==
-  dependencies:
-    tree-sitter "^0.16.1"
-
 "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.2":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
@@ -1445,6 +1438,13 @@
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.2.2.tgz#771c4a768d94eb5922cc202a3009558204df0cea"
   integrity sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==
 
+"@types/debug@^4.0.0":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
+  integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/deep-eql@*":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
@@ -1506,6 +1506,18 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/mdast@^4.0.0":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-4.0.4.tgz#7ccf72edd2f1aa7dd3437e180c64373585804dd6"
+  integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
+  dependencies:
+    "@types/unist" "*"
+
+"@types/ms@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
+
 "@types/node@*":
   version "22.10.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.7.tgz#14a1ca33fd0ebdd9d63593ed8d3fbc882a6d28d7"
@@ -1559,7 +1571,7 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
-"@types/unist@*":
+"@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
@@ -2459,6 +2471,11 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+character-entities@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -2630,6 +2647,13 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.0.0:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
@@ -2642,6 +2666,13 @@ decimal.js@^10.5.0:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
   integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
 
+decode-named-character-reference@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz#25c32ae6dd5e21889549d40f676030e9514cc0ed"
+  integrity sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==
+  dependencies:
+    character-entities "^2.0.0"
+
 deep-eql@^5.0.1:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
@@ -2652,7 +2683,7 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-dequal@^2.0.3:
+dequal@^2.0.0, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -2666,6 +2697,13 @@ detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+
+devlop@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+  dependencies:
+    dequal "^2.0.0"
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -3782,6 +3820,31 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+mdast-util-from-markdown@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz#4850390ca7cf17413a9b9a0fbefcd1bc0eb4160a"
+  integrity sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    mdast-util-to-string "^4.0.0"
+    micromark "^4.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-decode-string "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+mdast-util-to-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz#7a5121475556a04e7eddeb67b264aae79d312814"
+  integrity sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+
 mdurl@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
@@ -3796,6 +3859,200 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromark-core-commonmark@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz#c691630e485021a68cf28dbc2b2ca27ebf678cd4"
+  integrity sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-factory-destination "^2.0.0"
+    micromark-factory-label "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-factory-title "^2.0.0"
+    micromark-factory-whitespace "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-html-tag-name "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-destination@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz#8fef8e0f7081f0474fbdd92deb50c990a0264639"
+  integrity sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-label@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz#5267efa97f1e5254efc7f20b459a38cb21058ba1"
+  integrity sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-space@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz#36d0212e962b2b3121f8525fc7a3c7c029f334fc"
+  integrity sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-title@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz#237e4aa5d58a95863f01032d9ee9b090f1de6e94"
+  integrity sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-whitespace@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz#06b26b2983c4d27bfcc657b33e25134d4868b0b1"
+  integrity sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-character@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz#2f987831a40d4c510ac261e89852c4e9703ccda6"
+  integrity sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-chunked@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz#47fbcd93471a3fccab86cff03847fc3552db1051"
+  integrity sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-classify-character@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz#d399faf9c45ca14c8b4be98b1ea481bced87b629"
+  integrity sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-combine-extensions@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz#2a0f490ab08bff5cc2fd5eec6dd0ca04f89b30a9"
+  integrity sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==
+  dependencies:
+    micromark-util-chunked "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-decode-numeric-character-reference@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz#fcf15b660979388e6f118cdb6bf7d79d73d26fe5"
+  integrity sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-decode-string@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz#6cb99582e5d271e84efca8e61a807994d7161eb2"
+  integrity sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-encode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz#0d51d1c095551cfaac368326963cf55f15f540b8"
+  integrity sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+
+micromark-util-html-tag-name@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz#e40403096481986b41c106627f98f72d4d10b825"
+  integrity sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==
+
+micromark-util-normalize-identifier@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz#c30d77b2e832acf6526f8bf1aa47bc9c9438c16d"
+  integrity sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-resolve-all@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz#e1a2d62cdd237230a2ae11839027b19381e31e8b"
+  integrity sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==
+  dependencies:
+    micromark-util-types "^2.0.0"
+
+micromark-util-sanitize-uri@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz#ab89789b818a58752b73d6b55238621b7faa8fd7"
+  integrity sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-subtokenize@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz#d8ade5ba0f3197a1cf6a2999fbbfe6357a1a19ee"
+  integrity sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-symbol@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz#e5da494e8eb2b071a0d08fb34f6cefec6c0a19b8"
+  integrity sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+
+micromark-util-types@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.2.tgz#f00225f5f5a0ebc3254f96c36b6605c4b393908e"
+  integrity sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
+
+micromark@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-4.0.2.tgz#91395a3e1884a198e62116e33c9c568e39936fdb"
+  integrity sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
 micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
@@ -4949,7 +5206,7 @@ tree-sitter-cli@0.24.5:
   resolved "https://registry.yarnpkg.com/tree-sitter-cli/-/tree-sitter-cli-0.24.5.tgz#787236587f4158e3b667c29efad234f26887d8f2"
   integrity sha512-8EIgV/ERQlpvk1rPSCCjxveAb6Sba8tMiBpeeL68Mueuuqr0wNfhps/I1nFm2OTnpPCUV2PS9nbzzAMoyxSQUg==
 
-tree-sitter@0.22.1, tree-sitter@^0.16.1:
+tree-sitter@0.22.1:
   version "0.22.1"
   resolved "https://registry.yarnpkg.com/tree-sitter/-/tree-sitter-0.22.1.tgz#5a5296fc0898b21443657e071b050c95c0d7afbd"
   integrity sha512-gRO+jk2ljxZlIn20QRskIvpLCMtzuLl5T0BY6L9uvPYD17uUrxlxWkvYCiVqED2q2q7CVtY52Uex4WcYo2FEXw==
@@ -5112,6 +5369,13 @@ union@~0.5.0:
   integrity sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==
   dependencies:
     qs "^6.4.0"
+
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
Closes #62 

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Automated tests

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Markdown processing runs automatically on all labels, so forms that include markdown styling accidentally will look different, for example, questions starting with a number will now be rendered as an ordered list which means they will be indented when they weren't before.

### Do we need any specific form for testing your changes? If so, please attach one.

From this branch: `/packages/common/src/fixtures/notes/3-notes-with-markdown.xml`

### What's changed
