### PR TITLE
fix: maps attachments for demo preview

### DIFF
--- a/packages/common/src/fixtures/import-glob-helper.ts
+++ b/packages/common/src/fixtures/import-glob-helper.ts
@@ -67,13 +67,19 @@ export const toGlobLoaderEntries = (
 	const parentPathURL = new URL('./', importMeta.url);
 
 	return Object.entries(globObject).map(([relativePath, value]) => {
-		const { pathname: absolutePath } = new URL(relativePath, parentPathURL);
-		const fixtureAssetURL = new URL(value, import.meta.url);
 		const fixture: GlobFixture = {
-			url: fixtureAssetURL,
+			url: new URL(value, import.meta.url),
 			load: globFixtureLoader(value),
 		};
 
-		return [absolutePath, fixture];
+		let assetsPath: string;
+		if (parentPathURL.pathname.includes('/assets/')) {
+			const filename = /[^/\\]*$/.exec(relativePath)?.[0] ?? '';
+			assetsPath = parentPathURL.pathname + filename;
+		} else {
+			assetsPath = new URL(relativePath, parentPathURL).pathname;
+		}
+
+		return [assetsPath, fixture];
 	});
 };

--- a/packages/common/src/fixtures/xform-attachments.ts
+++ b/packages/common/src/fixtures/xform-attachments.ts
@@ -125,18 +125,6 @@ const xformAttachmentFixtureEntries: XFormAttachmentFixtureEntries =
 		return [absolutePath, fixture];
 	});
 
-type XFormAttachmentFixturesByAbsolutePath = ReadonlyMap<string, XFormAttachmentFixture>;
-
-const buildXFormAttachmentFixturesByAbsolutePath = (
-	entries: XFormAttachmentFixtureEntries
-): XFormAttachmentFixturesByAbsolutePath => {
-	return new Map(entries);
-};
-
-export const xformAttachmentFixturesByPath = buildXFormAttachmentFixturesByAbsolutePath(
-	xformAttachmentFixtureEntries
-);
-
 type XFormAttachmentFixturesByDirectory = ReadonlyMap<string, readonly XFormAttachmentFixture[]>;
 
 const buildXFormAttachmentFixturesByDirectory = (

--- a/packages/common/src/jr-resources/JRResourceService.ts
+++ b/packages/common/src/jr-resources/JRResourceService.ts
@@ -89,6 +89,7 @@ export class JRResourceService {
 		}
 	}
 
+	// Used to mock fetch in unit tests that work with attachments
 	activateResource(metadata: InlineFixtureMetadata, data: string): void {
 		const url = JRResourceURL.from(metadata.url);
 		const load = () => Promise.resolve(data);


### PR DESCRIPTION
The Web Forms' Demo Preview doesn't show attachments because, during a demo build (`/dist-demo`), all form attachments are relocated to `/assets/`. ODK's website takes the demo build (artifact) from this repository's `main` branch once daily and puts it in the `/web-forms/app/` folder. This fix doesn't impact the Web Form package distributed via npm, so I didn't include it in the changeset. 

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?
I tested by running this in 3 ways, and they all work: 
1. No demo preview: `yarn workspace @getodk/web-forms dev` - Form's assets are accessed from the `common` package.
2. Demo preview: `yarn workspace @getodk/web-forms dist-demo` - Form's assets are accessed from `/dist-demo/assets/`.
3. Loading demo preview in [ODK website ](https://github.com/getodk/website)  - Form's assets are accessed from `/web-forms/app/assets/`.

This is from the ODK website (running locally):

<img width="500" src="https://github.com/user-attachments/assets/e6577e3a-c6a9-4c8b-9693-369d4068dcc9" />
<img width="500" src="https://github.com/user-attachments/assets/41946a72-6a44-46fc-8dac-09457b6d39dc" />

### Why is this the best possible solution? Were any other approaches considered?

It's not optimal, but it's okay for now because otherwise it would require a bigger change in how we build and run this project, which isn't the current focus (we're focusing on geo map work). 

The Demo Preview and Web Forms as component/"plugin" are in the same Vue project; it's probably better to only build and start Demo Preview from `yarn workspace @getodk/web-forms dist-demo`. This way, when we run `yarn workspace @getodk/web-forms dev`, it won't start the Demo Preview. That would ensure the form's assets are always accessible from the `/dist-demo/assets/` folder. 

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

N/A

### Do we need any specific form for testing your changes? If so, please attach one.

N/A

### What's changed

- If the form assets' parent's path has `assets`, then use that instead of the `common` package path. 
- Removes unused code
