### PR TITLE
ci: speed up playwright installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
             browser: webkit
 
     steps:
+      # Prepare for playwright install.
+      - if: ${{ matrix.target == 'Web' }}
+        run: sudo apt-get remove --purge man-db
+
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'
@@ -208,6 +212,10 @@ jobs:
             browser: webkit
 
     steps:
+      # Prepare for playwright install.
+      - if: ${{ matrix.target == 'Web' }}
+        run: sudo apt-get remove --purge man-db
+
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'
@@ -268,6 +276,10 @@ jobs:
             browser: webkit
 
     steps:
+      # Prepare for playwright install.
+      - if: ${{ matrix.target == 'Web' }}
+        run: sudo apt-get remove --purge man-db
+
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'
@@ -328,6 +340,10 @@ jobs:
             browser: webkit
 
     steps:
+      # Prepare for playwright install.
+      - if: ${{ matrix.target == 'Web' }}
+        run: sudo apt-get remove --purge man-db
+
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'
@@ -433,6 +449,10 @@ jobs:
             browser: webkit
 
     steps:
+      # Prepare for playwright install.
+      - if: ${{ matrix.target == 'Web' }}
+        run: sudo apt-get remove --purge man-db
+
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'


### PR DESCRIPTION
This one weird trick speeds up every build!

Closes #531

Related:

* https://github.com/actions/runner/issues/4030
* https://github.com/actions/runner-images/issues/10977

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [x] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [x] Not applicable

### What else has been done to verify that this works as intended?

CI!  Check out how quick this build was: **46 mins** (https://github.com/getodk/web-forms/actions/runs/18721265293/usage).

### Why is this the best possible solution? Were any other approaches considered?

On the one hand, it might be helpful to extract the man-db purge + playwright setup into its own `action.yaml` file.  On the other hand, it's probably best to purge as early as possible, and installing playwright can't be done until after yarn dependencies have been installed.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change!

### Do we need any specific form for testing your changes? If so, please attach one.

Nope.

### What's changed

See: https://github.com/getodk/web-forms/pull/532/files