### PR TITLE
fix: enhanced sanitization of markdown input

### DIFF
--- a/.changeset/public-dogs-make.md
+++ b/.changeset/public-dogs-make.md
@@ -1,0 +1,6 @@
+---
+'@getodk/web-forms': patch
+'@getodk/common': patch
+---
+
+Enhanced sanitization of markdown input

--- a/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
+++ b/packages/common/src/fixtures/notes/3-notes-with-markdown.xml
@@ -184,14 +184,14 @@ Escaping: \*hello\*
 
 &lt;div style="text-align:center"&gt;centered div&lt;/div&gt;
 
-&lt;table border="1"&gt;
+&lt;table style="border:1px solid"&gt;
   &lt;tr&gt;
-    &lt;td&gt;name&lt;/td&gt;
-    &lt;td&gt;value&lt;/td&gt;
+    &lt;td style="border:1px solid"&gt;name&lt;/td&gt;
+    &lt;td style="border:1px solid"&gt;value&lt;/td&gt;
   &lt;/tr&gt;
   &lt;tr&gt;
-    &lt;td&gt;once&lt;/td&gt;
-    &lt;td&gt;twice&lt;/td&gt;
+    &lt;td style="border:1px solid"&gt;once&lt;/td&gt;
+    &lt;td style="border:1px solid"&gt;twice&lt;/td&gt;
   &lt;/tr&gt;
 &lt;/table&gt;
 

--- a/packages/web-forms/e2e/page-objects/controls/InputControl.ts
+++ b/packages/web-forms/e2e/page-objects/controls/InputControl.ts
@@ -7,7 +7,7 @@ export class InputControl {
 		this.page = page;
 	}
 
-	private async getInputByLabel(label: string) {
+	async getInputByLabel(label: string) {
 		const container = this.page
 			.locator('.question-container')
 			.filter({ has: this.page.locator(`.control-text label:text-is("${label}")`) });

--- a/packages/web-forms/e2e/test-cases/markdown.test.ts
+++ b/packages/web-forms/e2e/test-cases/markdown.test.ts
@@ -34,4 +34,11 @@ test.describe('Markdown formatting', () => {
 			maxDiffPixelRatio: 0.02,
 		});
 	});
+
+	test('sanitizes user input', async ({ page }) => {
+		const input = await formPage.input.getInputByLabel("What's your name?");
+		await input.fill('<input name="sanitizeme" />');
+		const output = page.locator('input[name="sanitizeme"]');
+		expect(await output.count()).toEqual(0);
+	});
 });

--- a/packages/web-forms/src/components/common/MarkdownBlock.vue
+++ b/packages/web-forms/src/components/common/MarkdownBlock.vue
@@ -9,6 +9,26 @@ import type {
 import DOMPurify from 'dompurify';
 import type { StyleValue } from 'vue';
 
+const DOM_PURIFY_SETTINGS = {
+	ALLOWED_TAGS: [
+		'b',
+		'br',
+		'em',
+		'i',
+		'li',
+		'ol',
+		'p',
+		'span',
+		'strong',
+		'table',
+		'td',
+		'tr',
+		'u',
+		'ul',
+	],
+	ALLOWED_ATTR: ['style'],
+};
+
 interface MarkdownProps {
 	readonly elem: MarkdownNode;
 }
@@ -29,7 +49,7 @@ const getUrl = (node: ParentMarkdownNode): string | undefined => {
 };
 
 const purify = (node: HtmlMarkdownNode): string => {
-	return DOMPurify.sanitize(node.unsafeHtml);
+	return DOMPurify.sanitize(node.unsafeHtml, DOM_PURIFY_SETTINGS);
 };
 </script>
 


### PR DESCRIPTION
Closes https://github.com/getodk/security/issues/87

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Added an e2e test.

### Why is this the best possible solution? Were any other approaches considered?

This makes sanitization much more strict, limiting tags and attributes to only presentation tags not functional.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

`Notes > 3-notes-with-markdown.xml`

### What's changed

Greatly restricted the number of HTML tags and attributes that are allowed in user input.