### PR TITLE
ci: remove playwright cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,6 @@ jobs:
             browser: webkit
 
     steps:
-      # Prepare for playwright install.
-      - if: ${{ matrix.target == 'Web' }}
-        run: sudo bash -ec 'echo "set man-db/auto-update false" | debconf-communicate; dpkg-reconfigure man-db'
-
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'
@@ -212,10 +208,6 @@ jobs:
             browser: webkit
 
     steps:
-      # Prepare for playwright install.
-      - if: ${{ matrix.target == 'Web' }}
-        run: sudo bash -ec 'echo "set man-db/auto-update false" | debconf-communicate; dpkg-reconfigure man-db'
-
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'
@@ -276,10 +268,6 @@ jobs:
             browser: webkit
 
     steps:
-      # Prepare for playwright install.
-      - if: ${{ matrix.target == 'Web' }}
-        run: sudo bash -ec 'echo "set man-db/auto-update false" | debconf-communicate; dpkg-reconfigure man-db'
-
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'
@@ -340,10 +328,6 @@ jobs:
             browser: webkit
 
     steps:
-      # Prepare for playwright install.
-      - if: ${{ matrix.target == 'Web' }}
-        run: sudo bash -ec 'echo "set man-db/auto-update false" | debconf-communicate; dpkg-reconfigure man-db'
-
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'
@@ -449,10 +433,6 @@ jobs:
             browser: webkit
 
     steps:
-      # Prepare for playwright install.
-      - if: ${{ matrix.target == 'Web' }}
-        run: sudo bash -ec 'echo "set man-db/auto-update false" | debconf-communicate; dpkg-reconfigure man-db'
-
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,8 +15,6 @@ jobs:
         browser: [chromium, firefox, webkit]
 
     steps:
-      - run: sudo bash -ec 'echo "set man-db/auto-update false" | debconf-communicate; dpkg-reconfigure man-db'
-
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'
@@ -68,8 +66,6 @@ jobs:
         browser: [chromium, firefox, webkit]
 
     steps:
-      - run: sudo bash -ec 'echo "set man-db/auto-update false" | debconf-communicate; dpkg-reconfigure man-db'
-
       - uses: 'actions/checkout@v4'
 
       - uses: 'volta-cli/action@v4'


### PR DESCRIPTION
`man-db` hacks are no longer necessary as its database updates are disabled by default per https://github.com/actions/runner-images/issues/13213

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [x] Not applicable

### What else has been done to verify that this works as intended?

Checked build logs.

### Why is this the best possible solution? Were any other approaches considered?

Simpler!

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

### Do we need any specific form for testing your changes? If so, please attach one.

No.

### What's changed

Removed hacks to disable man-db updates in CI.