### PR TITLE
chore: upgrade node and yarn to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20.19.3', '22.12.0', '24.3.0']
+        node-version: ['20.19.3', '22.12.0', '24.11.0']
 
     steps:
       - uses: 'actions/checkout@v4'
@@ -92,7 +92,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['22.12.0']
+        node-version: ['24.11.0']
 
     steps:
       - uses: 'actions/checkout@v4'
@@ -133,16 +133,16 @@ jobs:
       fail-fast: false
       matrix:
         target: ['Node']
-        node-version: ['20.19.3', '22.12.0', '24.3.0']
+        node-version: ['20.19.3', '22.12.0', '24.11.0']
         include:
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: chromium
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: firefox
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: webkit
 
     steps:
@@ -192,16 +192,16 @@ jobs:
       fail-fast: false
       matrix:
         target: ['Node']
-        node-version: ['20.19.3', '22.12.0', '24.3.0']
+        node-version: ['20.19.3', '22.12.0', '24.11.0']
         include:
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: chromium
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: firefox
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: webkit
 
     steps:
@@ -251,16 +251,16 @@ jobs:
       fail-fast: false
       matrix:
         target: ['Node']
-        node-version: ['20.19.3', '22.12.0', '24.3.0']
+        node-version: ['20.19.3', '22.12.0', '24.11.0']
         include:
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: chromium
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: firefox
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: webkit
 
     steps:
@@ -310,16 +310,16 @@ jobs:
       fail-fast: false
       matrix:
         target: ['Node']
-        node-version: ['20.19.3', '22.12.0', '24.3.0']
+        node-version: ['20.19.3', '22.12.0', '24.11.0']
         include:
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: chromium
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: firefox
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: webkit
 
     steps:
@@ -374,7 +374,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20.19.3', '22.12.0', '24.3.0']
+        node-version: ['20.19.3', '22.12.0', '24.11.0']
 
     steps:
       - uses: 'actions/checkout@v4'
@@ -413,16 +413,16 @@ jobs:
       fail-fast: false
       matrix:
         target: ['Node']
-        node-version: ['20.19.3', '22.12.0', '24.3.0']
+        node-version: ['20.19.3', '22.12.0', '24.11.0']
         include:
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: chromium
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: firefox
           - target: 'Web'
-            node-version: '22.12.0'
+            node-version: '24.11.0'
             browser: webkit
 
     steps:
@@ -469,7 +469,7 @@ jobs:
       - if: ${{ matrix.target == 'Web' && matrix.browser != 'webkit' }}
         run: 'yarn workspace @getodk/web-forms test-browser:${{ matrix.browser }}'
 
-      - if: ${{ matrix.node-version == '22.12.0' && matrix.target == 'Node' }}
+      - if: ${{ matrix.node-version == '24.11.0' && matrix.target == 'Node' }}
         uses: actions/upload-artifact@v4
         with:
           name: dist-demo

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   "type": "module",
   "version": "0.1.0",
   "engines": {
-    "node": "^20.19.3 || ^22.12.0 || ^24.3.0",
-    "yarn": "4.10.3"
+    "node": "^20.19.3 || ^22.12.0 || ^24.11.0",
+    "yarn": "4.11.0"
   },
   "volta": {
-    "node": "22.12.0",
-    "yarn": "4.10.3"
+    "node": "24.11.0",
+    "yarn": "4.11.0"
   },
-  "packageManager": "yarn@4.10.3",
+  "packageManager": "yarn@4.11.0",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -35,8 +35,8 @@
     "README.md"
   ],
   "engines": {
-    "node": "^20.19.3 || ^22.12.0 || ^24.3.0",
-    "yarn": "4.10.3"
+    "node": "^20.19.3 || ^22.12.0 || ^24.11.0",
+    "yarn": "4.11.0"
   },
   "scripts": {
     "test": "npm-run-all -nl 'test-node:*' 'test-browser:*'",

--- a/packages/scenario/package.json
+++ b/packages/scenario/package.json
@@ -26,8 +26,8 @@
     "./types/do-not-import.d.ts"
   ],
   "engines": {
-    "node": "^20.19.3 || ^22.12.0 || ^24.3.0",
-    "yarn": "4.10.3"
+    "node": "^20.19.3 || ^22.12.0 || ^24.11.0",
+    "yarn": "4.11.0"
   },
   "scripts": {
     "benchmark": "npm-run-all -nl 'benchmark-node:*' 'benchmark-browser:*'",

--- a/packages/tree-sitter-xpath/package.json
+++ b/packages/tree-sitter-xpath/package.json
@@ -20,8 +20,8 @@
     "index.d.ts"
   ],
   "engines": {
-    "node": "^20.19.3 || ^22.12.0 || ^24.3.0",
-    "yarn": "4.10.3"
+    "node": "^20.19.3 || ^22.12.0 || ^24.11.0",
+    "yarn": "4.11.0"
   },
   "scripts": {
     "build": "npm-run-all -nl 'build:*'",

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -23,8 +23,8 @@
     "README.md"
   ],
   "engines": {
-    "node": "^20.19.3 || ^22.12.0 || ^24.3.0",
-    "yarn": "4.10.3"
+    "node": "^20.19.3 || ^22.12.0 || ^24.11.0",
+    "yarn": "4.11.0"
   },
   "scripts": {
     "build": "npm-run-all -nl 'build:*'",

--- a/packages/xforms-engine/package.json
+++ b/packages/xforms-engine/package.json
@@ -29,8 +29,8 @@
     "README.md"
   ],
   "engines": {
-    "node": "^20.19.3 || ^22.12.0 || ^24.3.0",
-    "yarn": "4.10.3"
+    "node": "^20.19.3 || ^22.12.0 || ^24.11.0",
+    "yarn": "4.11.0"
   },
   "scripts": {
     "build": "npm-run-all -nl 'build:*'",

--- a/packages/xpath/package.json
+++ b/packages/xpath/package.json
@@ -31,8 +31,8 @@
     "README.md"
   ],
   "engines": {
-    "node": "^20.19.3 || ^22.12.0 || ^24.3.0",
-    "yarn": "4.10.3"
+    "node": "^20.19.3 || ^22.12.0 || ^24.11.0",
+    "yarn": "4.11.0"
   },
   "scripts": {
     "build": "npm-run-all -nl 'build:*'",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,14 +4,14 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "^20.19.3 || ^22.12.0 || ^24.3.0",
-    "yarn": "4.10.3"
+    "node": "^20.19.3 || ^22.12.0 || ^24.11.0",
+    "yarn": "4.11.0"
   },
   "volta": {
     "node": "22.12.0",
-    "yarn": "4.10.3"
+    "yarn": "4.11.0"
   },
-  "packageManager": "yarn@4.10.3",
+  "packageManager": "yarn@4.11.0",
   "scripts": {
     "test": "true"
   },


### PR DESCRIPTION
Node 24 is now LTS so this bumps the build to use it. This doesn't affect anyone in production just our build environment.