### PR TITLE
chore: fixes release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           registry-url: "https://registry.npmjs.org"
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Yarn dependencies
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cache/yarn
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
             **/node_modules
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |

--- a/README.md
+++ b/README.md
@@ -507,5 +507,5 @@ If you'd like to try the functionality available on `main`, see the preview [on 
 1. Run `yarn changeset version` to generate changelog files and version bumps from the changeset files
 1. Run `yarn install` to update yarn.lock with the new versions
 1. Verify that the changelogs look good, commit changes, open a PR, merge the PR
-1. Push tags for each package in the format `package@x.x.x`. A Github action will publish the packages on NPM
+1. Push tags for each package in the format `@getodk/<package>@x.x.x`. A Github action will publish the packages on NPM
 1. Update dependencies to kick off the new release cycle. We do this so that dependency updates get verified implicitly during development.


### PR DESCRIPTION
Attempt to fix:

```sh
Run yarn install --immutable
error This project's package.json defines "packageManager": "yarn@4.11.0". However the current global version of Yarn is 1.22.22.

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
Error: Process completed with exit code 1.
```
