### PR TITLE
chore: fixes release workflow - yarn command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Cache Yarn dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
Attempt # 2. The yarn v4 has a different way to access the folder; I was using the old way. 

Error:

```sh
Run echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
! Corepack is about to download https://repo.yarnpkg.com/4.11.0/packages/yarnpkg-cli/bin/yarn.js
Error: Unable to process file command 'output' successfully.
Error: Invalid format '  0. yarn cache clean [--mirror] [--all]'
```

With this change, the command should print the cache folder, like this:
```sh
yarn config get cacheFolder
/Users/jack/.yarn/berry/cache
```