### PR TITLE
fix(#577): bind preload parameters on form reset

### DIFF
--- a/.changeset/eager-onions-serve.md
+++ b/.changeset/eager-onions-serve.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': patch
+---
+
+Fix form reset to set preload parameters correctly

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -66,8 +66,11 @@ const hostSubmissionResultCallbackFactory = (
 		hostResult: OptionalAwaitableHostSubmissionResult
 	): Promise<void> => {
 		const submissionResult = await hostResult;
-
-		state.value = updateSubmittedFormState(submissionResult, currentState);
+		const options = {
+			preloadProperties: props.preloadProperties,
+			trackDevice: props.trackDevice,
+		};
+		state.value = updateSubmittedFormState(submissionResult, currentState, options);
 	};
 
 	return (hostResult) => {

--- a/packages/web-forms/src/demo/FormPreview.vue
+++ b/packages/web-forms/src/demo/FormPreview.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { POST_SUBMIT__NEW_INSTANCE } from '@/lib/constants/control-flow';
+import type { HostSubmissionResultCallback } from '@/lib/submission/host-submission-result-callback';
 import { xformFixturesByCategory, XFormResource } from '@getodk/common/fixtures/xforms.ts';
 import type {
 	ChunkedInstancePayload,
@@ -60,7 +62,10 @@ xformResource
 		alert('Failed to load the Form XML');
 	});
 
-const handleSubmit = async (payload: MonolithicInstancePayload) => {
+const handleSubmit = async (
+	payload: MonolithicInstancePayload,
+	clearFormCallback: HostSubmissionResultCallback
+) => {
 	// eslint-disable-next-line no-console
 	console.log('submission payload:', payload);
 	for (const value of payload.data[0].values()) {
@@ -68,6 +73,7 @@ const handleSubmit = async (payload: MonolithicInstancePayload) => {
 		console.log(await value.text());
 	}
 	alert('Submit button was pressed');
+	clearFormCallback({ next: POST_SUBMIT__NEW_INSTANCE });
 };
 
 const handleSubmitChunked = (payload: ChunkedInstancePayload) => {

--- a/packages/web-forms/src/lib/init/engine-config.ts
+++ b/packages/web-forms/src/lib/init/engine-config.ts
@@ -1,10 +1,18 @@
 import type {
 	EditFormInstance,
-	FormInstanceConfig,
 	InstanceAttachmentsConfig,
 	InstancePayload,
+	PreloadProperties,
 } from '@getodk/xforms-engine';
 import { reactive } from 'vue';
+
+const DEVICE_ID_KEY = 'odk-deviceid';
+const DEVICE_ID_PREFIX = 'getodk.org:webforms:';
+
+interface GetFormInstanceConfigOptions {
+	readonly trackDevice?: boolean;
+	readonly preloadProperties?: PreloadProperties;
+}
 
 /**
  * At present, the Web Forms strategy for producing distinct instance attachment
@@ -32,7 +40,30 @@ const INSTANCE_ATTACHMENTS_CONFIG: InstanceAttachmentsConfig = {
 	},
 };
 
-export const ENGINE_FORM_INSTANCE_CONFIG: FormInstanceConfig = {
-	stateFactory: reactive,
-	instanceAttachments: INSTANCE_ATTACHMENTS_CONFIG,
+const getDeviceId = () => {
+	const id = localStorage.getItem(DEVICE_ID_KEY);
+	if (id) {
+		return id;
+	}
+	const deviceId = DEVICE_ID_PREFIX + crypto.randomUUID();
+	localStorage.setItem(DEVICE_ID_KEY, deviceId);
+	return deviceId;
+};
+
+const getPreloadProperties = (options: GetFormInstanceConfigOptions) => {
+	if (!options.trackDevice || options.preloadProperties?.deviceID) {
+		return options.preloadProperties;
+	}
+	return {
+		...options.preloadProperties,
+		deviceID: getDeviceId(),
+	};
+};
+
+export const getFormInstanceConfig = (options: GetFormInstanceConfigOptions) => {
+	return {
+		stateFactory: reactive,
+		instanceAttachments: INSTANCE_ATTACHMENTS_CONFIG,
+		preloadProperties: getPreloadProperties(options),
+	};
 };

--- a/packages/web-forms/src/lib/init/load-form-state.ts
+++ b/packages/web-forms/src/lib/init/load-form-state.ts
@@ -10,16 +10,13 @@ import type {
 } from '@getodk/xforms-engine';
 import { loadForm } from '@getodk/xforms-engine';
 import { FormInitializationError } from '../error/FormInitializationError.ts';
-import { ENGINE_FORM_INSTANCE_CONFIG } from './engine-config.ts';
+import { getFormInstanceConfig } from './engine-config.ts';
 import type {
 	FormState,
 	FormStateFailureResult,
 	FormStateSuccessResult,
 	InstantiableForm,
 } from './form-state.ts';
-
-const DEVICE_ID_KEY = 'odk-deviceid';
-const DEVICE_ID_PREFIX = 'getodk.org:webforms:';
 
 export interface FormOptions {
 	readonly fetchFormAttachment: FetchFormAttachment;
@@ -91,29 +88,6 @@ const success = (form: InstantiableForm, instance: AnyFormInstance): FormStateSu
 		form,
 		instance,
 		root: instance.root,
-	};
-};
-
-const getDeviceId = () => {
-	const id = localStorage.getItem(DEVICE_ID_KEY);
-	if (id) {
-		return id;
-	}
-	const deviceId = DEVICE_ID_PREFIX + crypto.randomUUID();
-	localStorage.setItem(DEVICE_ID_KEY, deviceId);
-	return deviceId;
-};
-
-const getFormInstanceConfig = (options: LoadFormStateOptions) => {
-	const preloadProperties = {
-		...options.preloadProperties,
-	};
-	if (!preloadProperties.deviceID && options.trackDevice) {
-		preloadProperties.deviceID = getDeviceId();
-	}
-	return {
-		...ENGINE_FORM_INSTANCE_CONFIG,
-		preloadProperties,
 	};
 };
 

--- a/packages/web-forms/src/lib/init/update-submitted-form-state.ts
+++ b/packages/web-forms/src/lib/init/update-submitted-form-state.ts
@@ -1,16 +1,26 @@
 import { POST_SUBMIT__NEW_INSTANCE } from '@/lib/constants/control-flow.ts';
 import type { OptionalHostSubmissionResult } from '@/lib/submission/host-submission-result-callback.ts';
-import { ENGINE_FORM_INSTANCE_CONFIG } from './engine-config.ts';
+import type { PreloadProperties } from '@getodk/xforms-engine';
+import { getFormInstanceConfig } from './engine-config.ts';
 import type { FormStateSuccessResult } from './form-state.ts';
+
+interface ResetFormStateOptions {
+	readonly trackDevice?: boolean;
+	readonly preloadProperties?: PreloadProperties;
+}
 
 /**
  * @todo Clean up {@link currentState}'s {@link FormStateSuccessResult.instance}
  * before creating a new one. (Requires engine support, but will need to be
  * invoked here!)
  */
-const resetInstanceState = (currentState: FormStateSuccessResult): FormStateSuccessResult => {
+const resetInstanceState = (
+	currentState: FormStateSuccessResult,
+	options: ResetFormStateOptions
+): FormStateSuccessResult => {
 	const { form } = currentState;
-	const instance = form.createInstance(ENGINE_FORM_INSTANCE_CONFIG);
+	const instanceConfig = getFormInstanceConfig(options);
+	const instance = form.createInstance(instanceConfig);
 
 	return {
 		status: 'FORM_STATE_SUCCESS',
@@ -23,10 +33,11 @@ const resetInstanceState = (currentState: FormStateSuccessResult): FormStateSucc
 
 export const updateSubmittedFormState = (
 	submissionResult: OptionalHostSubmissionResult,
-	currentState: FormStateSuccessResult
+	currentState: FormStateSuccessResult,
+	options: ResetFormStateOptions
 ): FormStateSuccessResult => {
 	if (submissionResult?.next === POST_SUBMIT__NEW_INSTANCE) {
-		return resetInstanceState(currentState);
+		return resetInstanceState(currentState, options);
 	}
 
 	return currentState;


### PR DESCRIPTION
Closes #577 

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Updated the demo app to execute the form reset.
Integrated into central and proven it works there.

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
