### PR TITLE
fix(#599): add a key to markdown nodes for use as key in vue loops

### DIFF
--- a/.changeset/poor-papayas-rest.md
+++ b/.changeset/poor-papayas-rest.md
@@ -1,0 +1,6 @@
+---
+'@getodk/xforms-engine': patch
+'@getodk/web-forms': patch
+---
+
+Adds a generated ID to markdown nodes to use as the key in vue loops

--- a/packages/web-forms/src/components/common/MarkdownBlock.vue
+++ b/packages/web-forms/src/components/common/MarkdownBlock.vue
@@ -20,11 +20,11 @@ const { elem } = defineProps<MarkdownProps>();
 
 	<!-- link -->
 	<a v-else-if="elem.role === 'parent' && elem.elementName === 'a'" :href="getUrl(elem)" target="_blank">
-		<MarkdownBlock v-for="(child, index) in elem.children" :key="index" :elem="child" />
+		<MarkdownBlock v-for="child in elem.children" :key="child.id" :elem="child" />
 	</a>
 
 	<!-- any other parent element -->
 	<component :is="elem.elementName" v-else-if="elem.elementName" :style="getStylePropertyMap(elem)">
-		<MarkdownBlock v-for="(child, index) in elem.children" :key="index" :elem="child" />
+		<MarkdownBlock v-for="child in elem.children" :key="child.id" :elem="child" />
 	</component>
 </template>

--- a/packages/web-forms/src/components/common/MultiselectDropdown.vue
+++ b/packages/web-forms/src/components/common/MultiselectDropdown.vue
@@ -69,13 +69,13 @@ const selectedLabels = computed(() => {
 		@change="$emit('change')"
 	>
 		<template #option="slotProps">
-			<MarkdownBlock v-for="(elem, index) in slotProps.option.label" :key="index" :elem="elem" />
+			<MarkdownBlock v-for="elem in slotProps.option.label" :key="elem.id" :elem="elem" />
 		</template>
 		<template #value>
 			<template v-for="(markdown, index) in selectedLabels" :key="index">
 				<!-- eslint-disable-next-line -->
 				<template v-if="index > 0">, </template>
-				<MarkdownBlock v-for="(elem, j) in markdown" :key="j" :elem="elem" />
+				<MarkdownBlock v-for="elem in markdown" :key="elem.id" :elem="elem" />
 			</template>
 		</template>
 	</MultiSelect>

--- a/packages/web-forms/src/components/common/SearchableDropdown.vue
+++ b/packages/web-forms/src/components/common/SearchableDropdown.vue
@@ -59,10 +59,10 @@ const selectValue = (value: string) => {
 		@change="$emit('change')"
 	>
 		<template #option="slotProps">
-			<MarkdownBlock v-for="(elem, index) in slotProps.option.label" :key="index" :elem="elem" />
+			<MarkdownBlock v-for="elem in slotProps.option.label" :key="elem.id" :elem="elem" />
 		</template>
 		<template #value>
-			<MarkdownBlock v-for="(elem, index) in selectedLabel" :key="index" :elem="elem" />
+			<MarkdownBlock v-for="elem in selectedLabel" :key="elem.id" :elem="elem" />
 		</template>
 	</Select>
 </template>

--- a/packages/web-forms/src/components/common/TextMedia.vue
+++ b/packages/web-forms/src/components/common/TextMedia.vue
@@ -19,7 +19,7 @@ const audio = computed(() => props.label.audioSource);
 
 <template>
 	<span v-if="text != null" class="text-content">
-		<MarkdownBlock v-for="(elem, index) in text" :key="index" :elem="elem" />
+		<MarkdownBlock v-for="elem in text" :key="elem.id" :elem="elem" />
 	</span>
 
 	<div v-if="image || video || audio" class="media-content">

--- a/packages/web-forms/src/components/common/ValidationMessage.vue
+++ b/packages/web-forms/src/components/common/ValidationMessage.vue
@@ -24,7 +24,7 @@ const showMessage = inject<ComputedRef<boolean>>(
 <template>
 	<div :class="{ 'validation-placeholder': addPlaceholder }">
 		<span v-show="showMessage" class="validation-message">
-			<MarkdownBlock v-for="(elem, index) in message" :key="index" :elem="elem" />
+			<MarkdownBlock v-for="elem in message" :key="elem.id" :elem="elem" />
 		</span>
 	</div>
 </template>

--- a/packages/web-forms/src/components/form-elements/ControlHint.vue
+++ b/packages/web-forms/src/components/form-elements/ControlHint.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
 import type { AnyControlNode as QuestionNode } from '@getodk/xforms-engine';
-defineProps<{ question: QuestionNode }>();
+import { computed } from 'vue';
+const props = defineProps<{ question: QuestionNode }>();
+
+const label = computed(() => props.question.currentState.hint?.formatted);
 </script>
 
 <template>
 	<div v-if="question.currentState.hint" class="hint">
-		<MarkdownBlock v-for="(elem, index) in question.currentState.hint?.formatted" :key="index" :elem="elem" />
+		<MarkdownBlock v-for="elem in label" :key="elem.id" :elem="elem" />
 	</div>
 </template>
 

--- a/packages/web-forms/src/components/form-elements/ControlLabel.vue
+++ b/packages/web-forms/src/components/form-elements/ControlLabel.vue
@@ -15,7 +15,7 @@ const audio = computed(() => question.currentState.label?.audioSource);
 
 <template>
 	<label :for="question.nodeId" :class="{ required: question.currentState.required }">
-		<MarkdownBlock v-for="(elem, index) in text" :key="index" :elem="elem" />
+		<MarkdownBlock v-for="elem in text" :key="elem.id" :elem="elem" />
 		<div v-if="image || video || audio" class="media-content">
 			<ImageBlock v-if="image" :resource-url="image" :alt="alt" />
 

--- a/packages/web-forms/src/components/form-elements/RankControl.vue
+++ b/packages/web-forms/src/components/form-elements/RankControl.vue
@@ -145,7 +145,7 @@ const onDragEnd = (oldIndex: number | undefined, newIndex: number | undefined) =
 			>
 				<div class="rank-label">
 					<IconSVG name="mdiDragVertical" />
-					<MarkdownBlock v-for="(elem, j) in props.question.getValueLabel(value)?.formatted" :key="j" :elem="elem" />
+					<MarkdownBlock v-for="elem in props.question.getValueLabel(value)?.formatted" :key="elem.id" :elem="elem" />
 				</div>
 
 				<div class="rank-buttons">

--- a/packages/web-forms/src/components/form-layout/FormPanel.vue
+++ b/packages/web-forms/src/components/form-layout/FormPanel.vue
@@ -47,7 +47,7 @@ const menu = ref<InstanceType<typeof Menu> & MenuState>();
 					<IconSVG v-if="panelState" name="mdiChevronDown" />
 					<IconSVG v-if="!panelState" name="mdiChevronUp" />
 					<span v-if="titleFormatted">
-						<MarkdownBlock v-for="(elem, index) in titleFormatted" :key="index" :elem="elem" />
+						<MarkdownBlock v-for="elem in titleFormatted" :key="elem.id" :elem="elem" />
 					</span>
 					<span v-else>{{ title }}</span>
 				</h2>

--- a/packages/web-forms/src/components/form-layout/RepeatRange.vue
+++ b/packages/web-forms/src/components/form-layout/RepeatRange.vue
@@ -23,7 +23,7 @@ const label = computed(() => props.node.currentState.label?.formatted);
 		<!-- TODO: translations -->
 		<span>
 			Add
-			<MarkdownBlock v-for="(elem, index) in label" :key="index" :elem="elem" />
+			<MarkdownBlock v-for="elem in label" :key="elem.id" :elem="elem" />
 		</span>
 	</Button>
 </template>

--- a/packages/xforms-engine/src/client/MarkdownNode.ts
+++ b/packages/xforms-engine/src/client/MarkdownNode.ts
@@ -16,17 +16,20 @@ export type ElementName =
 export type MarkdownNode = ChildMarkdownNode | HtmlMarkdownNode | ParentMarkdownNode;
 
 export interface ParentMarkdownNode {
+	readonly id: string;
 	readonly role: 'parent';
 	readonly elementName: string;
 	readonly children: MarkdownNode[];
 }
 
 export interface ChildMarkdownNode {
+	readonly id: string;
 	readonly role: 'child';
 	readonly value: string;
 }
 
 export interface HtmlMarkdownNode {
+	readonly id: string;
 	readonly role: 'html';
 	readonly unsafeHtml: string;
 }

--- a/packages/xforms-engine/src/instance/markdown/MarkdownNode.ts
+++ b/packages/xforms-engine/src/instance/markdown/MarkdownNode.ts
@@ -2,18 +2,26 @@ import {
 	type AnchorMarkdownNode,
 	type ChildMarkdownNode as ClientChildMarkdownNode,
 	type HtmlMarkdownNode as ClientHtmlMarkdownNode,
+	type MarkdownNode as ClientMarkdownNode,
 	type ParentMarkdownNode as ClientParentMarkdownNode,
 	type StyledMarkdownNode as ClientStyledMarkdownNode,
 	type ElementName,
-	type MarkdownNode,
 	type MarkdownProperty,
 } from '../../client';
 
-abstract class ParentMarkdownNode implements ClientParentMarkdownNode {
+abstract class MarkdownNode {
+	readonly id: string;
+	constructor() {
+		this.id = crypto.randomUUID();
+	}
+}
+
+abstract class ParentMarkdownNode extends MarkdownNode implements ClientParentMarkdownNode {
 	readonly children;
 	readonly role = 'parent';
 	abstract elementName: ElementName;
-	constructor(children: MarkdownNode[]) {
+	constructor(children: ClientMarkdownNode[]) {
+		super();
 		this.children = children;
 	}
 }
@@ -69,18 +77,20 @@ export class ListItem extends ParentMarkdownNode {
 export class Anchor extends ParentMarkdownNode implements AnchorMarkdownNode {
 	readonly elementName = 'a';
 	readonly url: string;
-	constructor(children: MarkdownNode[], url: string) {
+	constructor(children: ClientMarkdownNode[], url: string) {
 		super(children);
 		this.url = url;
 	}
 }
 
 abstract class StyledMarkdownNode implements ClientParentMarkdownNode {
+	readonly id: string;
 	readonly children;
 	readonly role = 'parent';
 	abstract elementName: ElementName;
 	readonly properties: MarkdownProperty | undefined;
-	constructor(children: MarkdownNode[], properties: MarkdownProperty | undefined) {
+	constructor(children: ClientMarkdownNode[], properties: MarkdownProperty | undefined) {
+		this.id = crypto.randomUUID();
 		this.children = children;
 		this.properties = properties;
 	}
@@ -98,18 +108,20 @@ export class Div extends StyledMarkdownNode implements ClientStyledMarkdownNode 
 	readonly elementName = 'div';
 }
 
-export class ChildMarkdownNode implements ClientChildMarkdownNode {
+export class ChildMarkdownNode extends MarkdownNode implements ClientChildMarkdownNode {
 	readonly role = 'child';
 	readonly value: string;
 	constructor(value: string) {
+		super();
 		this.value = value;
 	}
 }
 
-export class Html implements ClientHtmlMarkdownNode {
+export class Html extends MarkdownNode implements ClientHtmlMarkdownNode {
 	readonly role = 'html';
 	readonly unsafeHtml: string;
 	constructor(unsafeHtml: string) {
+		super();
 		this.unsafeHtml = unsafeHtml;
 	}
 }


### PR DESCRIPTION
Closes #599

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

I did some performance testing timing first load on the all questions form which has lots of markdown nodes and didn't detect any performance difference.

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
