### PR TITLE
chore: fixes scenario test 

### DIFF
--- a/packages/common/src/fixtures/test-scenario/child_vaccination_VOL_tool_v12-alt.xml
+++ b/packages/common/src/fixtures/test-scenario/child_vaccination_VOL_tool_v12-alt.xml
@@ -505,16 +505,16 @@
                             <label>Record<output value=" ../NameB "/>'s year of birth
                             </label>
                             <item>
-                                <label>2017</label>
-                                <value>2017</value>
+                                <label>2024</label>
+                                <value>2024</value>
                             </item>
                             <item>
-                                <label>2018</label>
-                                <value>2018</value>
+                                <label>2025</label>
+                                <value>2025</value>
                             </item>
                             <item>
-                                <label>2019</label>
-                                <value>2019</value>
+                                <label>2026</label>
+                                <value>2026</value>
                             </item>
                         </select1>
                         <select1 ref="/data/household/child_repeat/dob_month">


### PR DESCRIPTION
### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [x] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
Update birth year options in `child_vaccination_VOL_tool_v12-alt.xml` to support current test dates.
Previously, the `<select1>` for `/data/household/child_repeat/dob_year` only included outdated options (2017-2019), which prevented valid selections for dynamic DOB calculations (e.g., 2024 for a 23-month-old child in 2026). This caused mismatches in leap year logic and test failures in January when DOBs land in February of a leap year.

Updated options to 2024, 2025, and 2026 to align with children under 2 years old, as a practical quick fix. Tests now pass consistently. No changes to test code or data.
Note: This will need revisiting in January 2030, but it's sufficient for now.

<details><summary>See error in CI</summary>

<img width="800" src="https://github.com/user-attachments/assets/8d175f42-8514-4002-9fc9-89e47c48de98" />

</details>
