### PR TITLE
fix(#653): don't trigger odk-instance-first-load events on add repeat

### DIFF
--- a/.changeset/thick-parts-repair.md
+++ b/.changeset/thick-parts-repair.md
@@ -1,0 +1,7 @@
+---
+'@getodk/xforms-engine': patch
+'@getodk/scenario': patch
+'@getodk/web-forms': patch
+---
+
+Fixes odk-instance-first-load so it doesn't run on add repeat

--- a/packages/scenario/test/actions-events/set-value-action.test.ts
+++ b/packages/scenario/test/actions-events/set-value-action.test.ts
@@ -576,6 +576,27 @@ describe('setvalue action', () => {
 			expect(scenario.answerOf('/data/output')).toEqualAnswer(stringAnswer(''));
 		});
 
+		it('odk-instance-first-load does not update on repeat add', async () => {
+			const scenario = await Scenario.init(
+				'Setvalue repeat',
+				html(
+					head(
+						title('Setvalue multiple'),
+						model(
+							mainInstance(t('data id="setvalue-multiple"', t('repeat id=""', t('source')))),
+							setvalueLiteral('odk-instance-first-load', '/data/repeat/source', 'first')
+						)
+					),
+					body(repeat('/data/repeat', input('/data/repeat/source')))
+				)
+			);
+
+			expect(scenario.answerOf('/data/repeat[1]/source').getValue()).toBe('first');
+			scenario.createNewRepeat('/data/repeat');
+			expect(scenario.answerOf('/data/repeat[1]/source').getValue()).toBe('first');
+			expect(scenario.answerOf('/data/repeat[2]/source').getValue()).toBe('');
+		});
+
 		// ported from: https://github.com/getodk/javarosa/blob/2dd8e15e9f3110a86f8d7d851efc98627ae5692e/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java#L468
 		describe('with inner empty string', () => {
 			it('clears the `ref` target', async () => {

--- a/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
@@ -17,7 +17,7 @@ const REPEAT_INDEX_REGEX = /([^[]*)(\[[0-9]+\])/g;
 type ValueContext = AttributeContext | InstanceValueContext;
 
 const isInstanceFirstLoad = (context: ValueContext) => {
-	return context.rootDocument.initializationMode === 'create';
+	return context.rootDocument.initializationMode === 'create' && !isAddingRepeatChild(context);
 };
 
 const isAddingRepeatChild = (context: ValueContext) => {
@@ -28,7 +28,7 @@ const isAddingRepeatChild = (context: ValueContext) => {
  * Special case, does not correspond to any event.
  */
 const isEditInitialLoad = (context: ValueContext) => {
-	return context.rootDocument.initializationMode === 'edit';
+	return context.rootDocument.initializationMode === 'edit' && !isAddingRepeatChild(context);
 };
 
 const getInitialValue = (context: ValueContext): string => {


### PR DESCRIPTION
Closes #

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
