### PR TITLE
chore: add test for the order of value evaluations

### DIFF
--- a/packages/scenario/test/value-evaluation-order.test.ts
+++ b/packages/scenario/test/value-evaluation-order.test.ts
@@ -8,7 +8,7 @@ import {
 	model,
 	setvalueLiteral,
 	t,
-	title
+	title,
 } from '@getodk/common/test/fixtures/xform-dsl/index.ts';
 import { type ResolvedFormInstanceInputType } from '@getodk/xforms-engine';
 import { describe, expect, it } from 'vitest';
@@ -20,16 +20,13 @@ import { stringAnswer } from '../src/answer/ExpectedStringAnswer.ts';
 const { INSTANCE_FILE_NAME, INSTANCE_FILE_TYPE } = constants;
 
 describe('Value evaluation order', () => {
-
 	it('default value', async () => {
 		const scenario = await Scenario.init(
 			'Value evalatation order',
 			html(
 				head(
 					title('Value evaluation order'),
-					model(
-						mainInstance(t('data id="value-evaluation-order"', t('element', 'default'))),
-					)
+					model(mainInstance(t('data id="value-evaluation-order"', t('element', 'default'))))
 				),
 				body(input('/data/element'))
 			)
@@ -57,7 +54,7 @@ describe('Value evaluation order', () => {
 	});
 
 	it('editing instance', async () => {
-			const instanceXML = `<data id="value-evaluation-order">
+		const instanceXML = `<data id="value-evaluation-order">
 	<element>editing value</element>
 </data>`;
 		const instanceFile = new File([instanceXML], INSTANCE_FILE_NAME, {
@@ -81,8 +78,9 @@ describe('Value evaluation order', () => {
 					)
 				),
 				body(input('/data/element'))
-			), {
-				editInstance: instance
+			),
+			{
+				editInstance: instance,
 			}
 		);
 
@@ -90,7 +88,7 @@ describe('Value evaluation order', () => {
 	});
 
 	it('bind calculation', async () => {
-			const instanceXML = `<data id="value-evaluation-order">
+		const instanceXML = `<data id="value-evaluation-order">
 	<element>editing value</element>
 </data>`;
 		const instanceFile = new File([instanceXML], INSTANCE_FILE_NAME, {
@@ -114,8 +112,9 @@ describe('Value evaluation order', () => {
 					)
 				),
 				body(input('/data/element'))
-			), {
-				editInstance: instance
+			),
+			{
+				editInstance: instance,
 			}
 		);
 
@@ -123,7 +122,7 @@ describe('Value evaluation order', () => {
 	});
 
 	it('setvalue calculation', async () => {
-			const instanceXML = `<data id="value-evaluation-order">
+		const instanceXML = `<data id="value-evaluation-order">
 	<element>editing value</element>
 </data>`;
 		const instanceFile = new File([instanceXML], INSTANCE_FILE_NAME, {
@@ -147,13 +146,13 @@ describe('Value evaluation order', () => {
 						bind('/data/element').preload('uid').calculate("'bind value'")
 					)
 				),
-				body(input('/data/element'), )
-			), {
-				editInstance: instance
+				body(input('/data/element'))
+			),
+			{
+				editInstance: instance,
 			}
 		);
 
 		expect(scenario.answerOf('/data/element')).toEqualAnswer(stringAnswer('setvalue value'));
 	});
-
 });


### PR DESCRIPTION
Adding a test which verifies some of the assumptions. Arose from discussion on [the forum](https://forum.getodk.org/t/create-and-update-entities-from-repeats/55163/28) and in Slack.