### PR TITLE
fix(#685): fixes markdown to ignore simple string starting with number

### DIFF
--- a/.changeset/cute-guests-build.md
+++ b/.changeset/cute-guests-build.md
@@ -1,0 +1,7 @@
+---
+'@getodk/xforms-engine': patch
+'@getodk/scenario': patch
+'@getodk/web-forms': patch
+---
+
+Fixed markdown parser to ignore single labels that start with numbers instead of turning them into ordered lists

--- a/packages/scenario/test/markdown.test.ts
+++ b/packages/scenario/test/markdown.test.ts
@@ -189,6 +189,36 @@ describe('Markdown', () => {
 			];
 			await run(given, expected);
 		});
+
+		describe('ordered lists with a single item', () => {
+			it('ignores single child at the top level', async () => {
+				const given = '3. third question';
+				const expected = [{ value: '3. third question' }];
+				await run(given, expected);
+			});
+
+			it('parses when sibling', async () => {
+				const given = `### My section
+
+3. third question`;
+				const expected = [
+					{
+						elementName: 'h3',
+						children: [{ value: 'My section' }],
+					},
+					{
+						elementName: 'ol',
+						children: [
+							{
+								elementName: 'li',
+								children: [{ elementName: 'p', children: [{ value: 'third question' }] }],
+							},
+						],
+					},
+				];
+				await run(given, expected);
+			});
+		});
 	});
 
 	describe('should handle html', () => {

--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -196,9 +196,22 @@ function escapeEditableChunks(chunks: readonly TextChunk[]) {
 		.join('');
 }
 
+function isSingleOrderedList(odk: MarkdownNode[]) {
+	return (
+		odk.length === 1 &&
+		odk[0]?.role === 'parent' &&
+		odk[0]?.elementName === 'ol' &&
+		odk[0].children.length === 1
+	);
+}
+
 function toOdkMarkdown(str: string): MarkdownNode[] {
 	const tree = fromMarkdown(str);
 	const odk = mdastToOdkMarkdown(tree.children);
+	if (isSingleOrderedList(odk)) {
+		// do not return a numbered list with only a single element - this is almost never what people expect
+		return [new ChildMarkdownNode(str)];
+	}
 	if (odk.length === 1 && odk[0]?.role === 'parent' && odk[0]?.elementName === 'p') {
 		// mdast tends to add too many paragraphs which if left in place, puts a block level
 		// element where it's not needed


### PR DESCRIPTION
Closes #685

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
