### PR TITLE
fix(#740): fixes decimal-date-time to allow node as param

### DIFF
--- a/.changeset/wet-icons-wave.md
+++ b/.changeset/wet-icons-wave.md
@@ -1,0 +1,5 @@
+---
+'@getodk/xpath': patch
+---
+
+Fixed decimal-date-time function to accept a node as a parameter

--- a/packages/xpath/src/functions/xforms/datetime.ts
+++ b/packages/xpath/src/functions/xforms/datetime.ts
@@ -1,3 +1,4 @@
+import { DAY_MILLISECONDS } from '@getodk/common/constants/datetime.ts';
 import { Temporal } from 'temporal-polyfill';
 import type { XPathNode } from '../../adapter/interface/XPathNode.ts';
 import { EvaluationContext } from '../../context/EvaluationContext.ts';
@@ -8,7 +9,6 @@ import { FunctionImplementation } from '../../evaluator/functions/FunctionImplem
 import { NumberFunction } from '../../evaluator/functions/NumberFunction.ts';
 import { StringFunction } from '../../evaluator/functions/StringFunction.ts';
 import { dateTimeFromNumber, dateTimeFromString } from '../../lib/datetime/coercion.ts';
-import { DAY_MILLISECONDS } from '@getodk/common/constants/datetime.ts';
 import { now } from '../../lib/datetime/functions.ts';
 import { isValidTimeString } from '../../lib/datetime/predicates.ts';
 
@@ -228,20 +228,19 @@ const evaluateDateTime = <T extends XPathNode>(
 			}
 
 			const milliseconds = days * DAY_MILLISECONDS;
-
 			return dateTimeFromNumber(timeZone, milliseconds);
 		}
 
-		case 'STRING': {
-			const stringValue = evaluation.toString();
-
-			return dateTimeFromString(timeZone, stringValue);
-		}
-
-		default:
+		case 'BOOLEAN': {
 			throw new Error(
 				'Expected a NUMBER or STRING evaluation type for date-time conversion, but received an invalid type.'
 			);
+		}
+
+		default: {
+			const stringValue = evaluation.toString();
+			return dateTimeFromString(timeZone, stringValue);
+		}
 	}
 };
 
@@ -263,6 +262,7 @@ export const date = new FunctionImplementation(
 			case 'BOOLEAN':
 				return new StringEvaluation(context, '');
 
+			case 'NODE':
 			case 'STRING': {
 				const string = results.toString();
 
@@ -290,9 +290,6 @@ export const date = new FunctionImplementation(
 
 			case 'NUMBER':
 				break;
-
-			default:
-				throw new Error('Invalid input type for date function: expected STRING or NUMBER.');
 		}
 
 		const dateTime = evaluateDateTime(context, results);

--- a/packages/xpath/test/xforms/date.test.ts
+++ b/packages/xpath/test/xforms/date.test.ts
@@ -121,7 +121,7 @@ describe('#date()', () => {
 			{ expression: 'date(1.5)', expected: '1970-01-02T05:00:00.000-07:00' },
 			{ expression: 'date(-1)', expected: '1969-12-30T17:00:00.000-07:00' },
 		].forEach(({ expression, expected }) => {
-			it(expression + ' should be converted to ' + expected, () => {
+			it(`${expression} should be converted to ${expected}`, () => {
 				testContext.assertStringValue(expression, expected);
 			});
 		});
@@ -166,7 +166,7 @@ describe('#date()', () => {
 			{ expression: 'date("2100-01-02") > 1', expected: true },
 			{ expression: 'date("1970-01-02") < 3', expected: true },
 		].forEach(({ expression, expected }) => {
-			it("should evaluate '" + expression + "' to: " + expected, () => {
+			it(`should evaluate '${expression}' to '${expected}'`, () => {
 				testContext.assertBooleanValue(expression, expected);
 			});
 		});
@@ -181,7 +181,7 @@ describe('#date()', () => {
 			{ expression: '3 + date("2001-12-26") + 5', expected: '11690.291666666666' },
 			{ expression: '3 + date("2001-12-26") - 5', expected: '11680.291666666666' },
 		].forEach(({ expression, expected }) => {
-			it("should evaluate '" + expression + "' to: " + expected, () => {
+			it(`should evaluate '${expression}' to '${expected}'`, () => {
 				testContext.assertStringValue(expression, expected);
 			});
 		});
@@ -206,6 +206,30 @@ describe('#date()', () => {
 		].forEach(({ expression, expected }) => {
 			it(`should convert ${expression} to ${expected}`, () => {
 				testContext.assertNumberRounded(expression, expected, 100);
+			});
+		});
+	});
+
+	describe('with node reference', () => {
+		beforeEach(() => {
+			testContext = createXFormsTestContext(`
+				<div id="TestCase">
+					<div id="DateField">1970-01-01</div>
+					<div id="DateTimeField">1970-01-02T03:00:00</div>
+				</div>`);
+		});
+
+		it('date field', () => {
+			const contextNode = testContext.document.getElementById('DateField');
+			testContext.assertNumberRounded('date(.)', 0.291667, 1000000, {
+				contextNode,
+			});
+		});
+
+		it('datetime field', () => {
+			const contextNode = testContext.document.getElementById('DateTimeField');
+			testContext.assertNumberRounded('date(.)', 1.416667, 1000000, {
+				contextNode,
 			});
 		});
 	});

--- a/packages/xpath/test/xforms/decimal-date-time.test.ts
+++ b/packages/xpath/test/xforms/decimal-date-time.test.ts
@@ -64,10 +64,33 @@ describe('#decimal-date-time()', () => {
 	});
 
 	it('different format', () => {
-		// testContext.assertNumberRounded('decimal-date-time("2018-04-24T15:30:00.000+06:00")', 17645.396, 1000);
 		testContext.assertNumberValue(
 			'decimal-date-time("2018-04-24T15:30:00.000+06:00")',
 			17645.395833333332
 		);
+	});
+
+	describe('with node reference', () => {
+		beforeEach(() => {
+			testContext = createXFormsTestContext(`
+				<div id="TestCase">
+					<div id="DateField">1970-01-01</div>
+					<div id="DateTimeField">1970-01-02T03:00:00</div>
+				</div>`);
+		});
+
+		it('date field', () => {
+			const contextNode = testContext.document.getElementById('DateField');
+			testContext.assertNumberRounded('decimal-date-time(.)', 0.291667, 1000000, {
+				contextNode,
+			});
+		});
+
+		it('datetime field', () => {
+			const contextNode = testContext.document.getElementById('DateTimeField');
+			testContext.assertNumberRounded('decimal-date-time(.)', 1.416667, 1000000, {
+				contextNode,
+			});
+		});
 	});
 });


### PR DESCRIPTION
Closes #740

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

xpath unit tests

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
