### PR TITLE
fix(#745): fixes markdown rendering of outputs with empty values

### DIFF
--- a/.changeset/tiny-coins-repeat.md
+++ b/.changeset/tiny-coins-repeat.md
@@ -1,0 +1,7 @@
+---
+'@getodk/xforms-engine': patch
+'@getodk/web-forms': patch
+'@getodk/scenario': patch
+---
+
+Fixed a bug with markdown rendering outputs with empty values

--- a/packages/scenario/test/markdown.test.ts
+++ b/packages/scenario/test/markdown.test.ts
@@ -442,7 +442,9 @@ double line break`;
 	});
 
 	describe('should handle output elements', () => {
-		const outputScenario = async () => {
+		const outputScenario = async (
+			markdown = '**Dear <output value=" /data/name " />!** Welcome.'
+		) => {
 			return await Scenario.init(
 				'markdown',
 				html(
@@ -453,10 +455,7 @@ double line break`;
 								'itext',
 								t(
 									'translation lang="default"',
-									t(
-										'text id="/data/name:label"',
-										t('value', `**Dear <output value=" /data/name " />!** Welcome.`)
-									)
+									t('text id="/data/name:label"', t('value', markdown))
 								)
 							),
 							mainInstance(t('data id="markdown"', t('name'))),
@@ -483,6 +482,24 @@ double line break`;
 							children: [{ value: 'Alice' }],
 						},
 						{ value: '!' },
+					],
+				},
+				{ value: ' Welcome.' },
+			]);
+		});
+
+		it('style wraps empty output elements', async () => {
+			const scenario = await outputScenario('**<output value=" /data/name " />** Welcome.');
+			scenario.next('/data/name');
+			const label = scenario.getQuestionLabel({ assertCurrentReference: '/data/name' }).formatted;
+			expect(label).toMatchObject([
+				{
+					elementName: 'strong',
+					children: [
+						{
+							elementName: 'span',
+							children: [],
+						},
 					],
 				},
 				{ value: ' Welcome.' },

--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -106,7 +106,7 @@ function mdastNodeToOdkMarkdown(tree: RootContent): MarkdownNode | undefined {
 	}
 	if (tree.type === 'text' || tree.type === 'inlineCode') {
 		const outputString = outputStrings.get(tree.value);
-		if (outputString) {
+		if (outputString != null) {
 			const children = toOdkMarkdown(outputString);
 			return new Span(children, undefined);
 		}
@@ -193,15 +193,15 @@ function mdastToOdkMarkdown(elements: RootContent[]): MarkdownNode[] {
 function escapeEditableChunks(chunks: readonly TextChunk[]) {
 	return chunks
 		.map((chunk, i) => {
-			const str = chunk.asString.replace(LEADING_WHITESPACE_REGEX, ' ');
-			if (str && chunk.source === 'output') {
+			const str = chunk.asString.replace(LEADING_WHITESPACE_REGEX, ' ') ?? '';
+			if (chunk.source === 'output') {
 				// we need to process this separately otherwise user entered markup will
 				// interract with form markup in unexpected ways
 				const id = `--ODK-OUTPUT-STRING-${i}--`;
 				outputStrings.set(id, str);
 				return '`' + id + '`';
 			}
-			return str ?? '';
+			return str;
 		})
 		.join('');
 }


### PR DESCRIPTION
Closes #745 

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Scenario testing

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

The form in the issue.

### What's changed
