### PR TITLE
feat(#332): Prioritize form designer's default language

### DIFF
--- a/packages/scenario/src/assertion/extensions/answers.ts
+++ b/packages/scenario/src/assertion/extensions/answers.ts
@@ -1,6 +1,6 @@
 import { UnreachableError } from '@getodk/common/lib/error/UnreachableError.ts';
 import { getBlobText } from '@getodk/common/lib/web-compat/blob.ts';
-import { constants, type ValidationCondition } from '@getodk/xforms-engine';
+import { type ValidationCondition } from '@getodk/xforms-engine';
 import { assert, expect } from 'vitest';
 import { ComparableAnswer } from '../../answer/ComparableAnswer.ts';
 import { ExpectedApproximateUOMAnswer } from '../../answer/ExpectedApproximateUOMAnswer.ts';
@@ -40,24 +40,16 @@ const assertAnswerResult: AssertAnswerResult = (value) => {
 };
 
 const matchDefaultMessage = (condition: ValidationCondition) => {
-	const expectedMessage = constants.VALIDATION_TEXT[`${condition}Msg`];
-
 	return {
 		node: {
 			validationState: {
 				[condition]: {
 					valid: false,
-					message: {
-						origin: 'engine',
-						asString: expectedMessage,
-					},
+					message: null,
 				},
 				violation: {
 					condition,
-					message: {
-						origin: 'engine',
-						asString: expectedMessage,
-					},
+					message: null,
 				},
 			},
 		},

--- a/packages/web-forms/locales/strings_en.json
+++ b/packages/web-forms/locales/strings_en.json
@@ -48,11 +48,11 @@
     "developer_comment": "Displays the GPS longitude coordinate. {longitude} is the numeric longitude value."
   },
   "validation_message.required.error": {
-    "string": "Condition not satisfied: required",
+    "string": "This field is required.",
     "developer_comment": "Default error shown when a required field has no value and the form designer did not specify a custom message."
   },
   "validation_message.constraint.error": {
-    "string": "Condition not satisfied: constraint",
+    "string": "This value doesn't meet the constraint.",
     "developer_comment": "Default error shown when a field's value fails a constraint and the form designer did not specify a custom message."
   },
   "map_async.load_error.message": {

--- a/packages/web-forms/locales/strings_en.json
+++ b/packages/web-forms/locales/strings_en.json
@@ -47,6 +47,14 @@
     "string": "Longitude: {longitude}.",
     "developer_comment": "Displays the GPS longitude coordinate. {longitude} is the numeric longitude value."
   },
+  "validation_message.required.error": {
+    "string": "Condition not satisfied: required",
+    "developer_comment": "Default error shown when a required field has no value and the form designer did not specify a custom message."
+  },
+  "validation_message.constraint.error": {
+    "string": "Condition not satisfied: constraint",
+    "developer_comment": "Default error shown when a field's value fails a constraint and the form designer did not specify a custom message."
+  },
   "map_async.load_error.message": {
     "string": "Unable to load map",
     "developer_comment": "Error message shown when the map component fails to load."

--- a/packages/web-forms/locales/strings_es.json
+++ b/packages/web-forms/locales/strings_es.json
@@ -47,6 +47,14 @@
     "string": "Longitud: {longitude}.",
     "developer_comment": "Displays the GPS longitude coordinate. {longitude} is the numeric longitude value."
   },
+  "validation_message.required.error": {
+    "string": "Este campo es obligatorio.",
+    "developer_comment": "Default error shown when a required field has no value and the form designer did not specify a custom message."
+  },
+  "validation_message.constraint.error": {
+    "string": "No cumple los requisitos.",
+    "developer_comment": "Default error shown when a field's value fails a constraint and the form designer did not specify a custom message."
+  },
   "map_async.load_error.message": {
     "string": "No se puede cargar el mapa",
     "developer_comment": "Error message shown when the map component fails to load."

--- a/packages/web-forms/src/components/common/ValidationMessage.i18n.json
+++ b/packages/web-forms/src/components/common/ValidationMessage.i18n.json
@@ -1,0 +1,10 @@
+{
+  "validation_message.required.error": {
+    "string": "Condition not satisfied: required",
+    "developer_comment": "Default error shown when a required field has no value and the form designer did not specify a custom message."
+  },
+  "validation_message.constraint.error": {
+    "string": "Condition not satisfied: constraint",
+    "developer_comment": "Default error shown when a field's value fails a constraint and the form designer did not specify a custom message."
+  }
+}

--- a/packages/web-forms/src/components/common/ValidationMessage.i18n.json
+++ b/packages/web-forms/src/components/common/ValidationMessage.i18n.json
@@ -1,10 +1,10 @@
 {
   "validation_message.required.error": {
-    "string": "Condition not satisfied: required",
+    "string": "This field is required.",
     "developer_comment": "Default error shown when a required field has no value and the form designer did not specify a custom message."
   },
   "validation_message.constraint.error": {
-    "string": "Condition not satisfied: constraint",
+    "string": "This value doesn't meet the constraint.",
     "developer_comment": "Default error shown when a field's value fails a constraint and the form designer did not specify a custom message."
   }
 }

--- a/packages/web-forms/src/components/common/ValidationMessage.vue
+++ b/packages/web-forms/src/components/common/ValidationMessage.vue
@@ -26,17 +26,22 @@ const defaultMessage = computed(() => {
 	if (!props.violation || props.violation.message) {
 		return null;
 	}
-	return t(`validation_message.${props.violation.condition}.error`);
+
+	if (props.violation.condition === 'required') {
+		return t('validation_message.required.error')
+	}
+
+	return t('validation_message.constraint.error');
 });
 </script>
 
 <template>
 	<div :class="{ 'validation-placeholder': addPlaceholder }">
 		<span v-show="showMessage" class="validation-message">
-			<template v-if="defaultMessage">{{ defaultMessage }}</template>
-			<template v-else-if="violation?.message">
+			<template v-if="violation?.message">
 				<MarkdownBlock v-for="elem in violation.message.formatted" :key="elem.id" :elem="elem" />
 			</template>
+			<template v-else-if="defaultMessage">{{ defaultMessage }}</template>
 		</span>
 	</div>
 </template>

--- a/packages/web-forms/src/components/common/ValidationMessage.vue
+++ b/packages/web-forms/src/components/common/ValidationMessage.vue
@@ -1,30 +1,42 @@
 <script setup lang="ts">
 import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
-import { QUESTION_HAS_ERROR } from '@/lib/constants/injection-keys.ts';
-import type { MarkdownNode } from '@getodk/xforms-engine';
+import { QUESTION_HAS_ERROR, TRANSLATE } from '@/lib/constants/injection-keys.ts';
+import type { Translate } from '@/lib/locale/useLocale.ts';
+import type { AnyViolation } from '@getodk/xforms-engine';
 import { computed, type ComputedRef, inject } from 'vue';
 
-withDefaults(
+const props = withDefaults(
 	defineProps<{
-		message?: MarkdownNode[];
+		violation?: AnyViolation | null;
 		addPlaceholder?: boolean;
 	}>(),
 	{
-		message: undefined,
+		violation: undefined,
 		addPlaceholder: true,
 	}
 );
 
+const t: Translate = inject(TRANSLATE)!;
 const showMessage = inject<ComputedRef<boolean>>(
 	QUESTION_HAS_ERROR,
 	computed(() => false)
 );
+
+const defaultMessage = computed(() => {
+	if (!props.violation || props.violation.message) {
+		return null;
+	}
+	return t(`validation_message.${props.violation.condition}.error`);
+});
 </script>
 
 <template>
 	<div :class="{ 'validation-placeholder': addPlaceholder }">
 		<span v-show="showMessage" class="validation-message">
-			<MarkdownBlock v-for="elem in message" :key="elem.id" :elem="elem" />
+			<template v-if="defaultMessage">{{ defaultMessage }}</template>
+			<template v-else-if="violation?.message">
+				<MarkdownBlock v-for="elem in violation.message.formatted" :key="elem.id" :elem="elem" />
+			</template>
 		</span>
 	</div>
 </template>

--- a/packages/web-forms/src/components/form-elements/RankControl.vue
+++ b/packages/web-forms/src/components/form-elements/RankControl.vue
@@ -185,7 +185,7 @@ const onDragEnd = (oldIndex: number | undefined, newIndex: number | undefined) =
 		</VueDraggable>
 	</div>
 
-	<ValidationMessage :message="question.validationState.violation?.message.formatted" />
+	<ValidationMessage :violation="question.validationState.violation" />
 </template>
 
 <style scoped lang="scss">

--- a/packages/web-forms/src/components/form-elements/input/InputControl.vue
+++ b/packages/web-forms/src/components/form-elements/input/InputControl.vue
@@ -57,7 +57,7 @@ const isFormEditMode = inject(IS_FORM_EDIT_MODE);
 			<InputText :node="node" />
 		</template>
 	</div>
-	<ValidationMessage :message="node.validationState.violation?.message.formatted" />
+	<ValidationMessage :violation="node.validationState.violation" />
 </template>
 
 <style scoped lang="scss">

--- a/packages/web-forms/src/components/form-elements/select/Select1Control.vue
+++ b/packages/web-forms/src/components/form-elements/select/Select1Control.vue
@@ -100,7 +100,7 @@ watchEffect(() => {
 	</template>
 
 	<ValidationMessage
-		:message="question.validationState.violation?.message.formatted"
+		:violation="question.validationState.violation"
 		:add-placeholder="!hasFieldListRelatedAppearance"
 	/>
 </template>

--- a/packages/web-forms/src/components/form-elements/select/SelectNControl.vue
+++ b/packages/web-forms/src/components/form-elements/select/SelectNControl.vue
@@ -66,7 +66,7 @@ watchEffect(() => {
 	</template>
 
 	<ValidationMessage
-		:message="question.validationState.violation?.message.formatted"
+		:violation="question.validationState.violation"
 		:add-placeholder="!hasFieldListRelatedAppearance"
 	/>
 </template>

--- a/packages/web-forms/src/lib/locale/useLocale.ts
+++ b/packages/web-forms/src/lib/locale/useLocale.ts
@@ -112,6 +112,10 @@ const resolveUILocaleCandidates = (formLanguage?: FormLanguage): string[] => {
 	return browserLanguages;
 };
 
+const findDefaultFormLanguage = (languages: FormLanguage[]) => {
+	return languages.find((lang) => lang.isDefault);
+};
+
 const findBrowserFormLanguage = (languages: FormLanguage[]) => {
 	const browserLanguages = navigator.languages ?? [navigator.language];
 	for (const lang of browserLanguages) {
@@ -215,7 +219,10 @@ export const useLocale = (formRef: Ref<RootNode | null>) => {
 				return;
 			}
 			const formLanguage =
-				findSavedFormLanguage(langs) ?? findBrowserFormLanguage(langs) ?? langs[0]!;
+				findSavedFormLanguage(langs) ??
+				findDefaultFormLanguage(langs) ??
+				findBrowserFormLanguage(langs) ??
+				langs[0]!;
 			setLanguage(formLanguage);
 		},
 		{ immediate: true }

--- a/packages/web-forms/tests/components/form-elements/input/InputControl.test.ts
+++ b/packages/web-forms/tests/components/form-elements/input/InputControl.test.ts
@@ -34,7 +34,7 @@ describe('InputControl', () => {
 			await input.setValue('lorem ipsum');
 			await input.setValue('');
 			expect(component.get('.validation-message').isVisible()).toBe(true);
-			expect(component.get('.validation-message').text()).toBe('Condition not satisfied: required');
+			expect(component.get('.validation-message').text()).toBe('validation_message.required.error');
 		});
 
 		it('hides validation message when user enters a valid value', async () => {
@@ -47,7 +47,7 @@ describe('InputControl', () => {
 		it('shows validation message on submit pressed even when no interaction is made with the component', async () => {
 			const component = await mountComponent(0, true);
 			expect(component.get('.validation-message').isVisible()).toBe(true);
-			expect(component.get('.validation-message').text()).toBe('Condition not satisfied: required');
+			expect(component.get('.validation-message').text()).toBe('validation_message.required.error');
 		});
 	});
 });

--- a/packages/web-forms/tests/components/form-elements/input/InputControl.test.ts
+++ b/packages/web-forms/tests/components/form-elements/input/InputControl.test.ts
@@ -15,7 +15,11 @@ const mountComponent = async (questionNumber: number, submitPressed = false) => 
 		props: { question },
 		global: {
 			...globalMountOptions,
-			provide: { [SUBMIT_PRESSED]: ref(submitPressed), [IS_FORM_EDIT_MODE]: shallowRef(false) },
+			provide: {
+				...globalMountOptions.provide,
+				[SUBMIT_PRESSED]: ref(submitPressed),
+				[IS_FORM_EDIT_MODE]: shallowRef(false),
+			},
 		},
 		attachTo: document.body,
 	});

--- a/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
+++ b/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
@@ -406,7 +406,7 @@ describe('SelectControl', () => {
 			const component = mountComponent(selectNode, true);
 
 			expect(component.get('.validation-message').isVisible()).toBe(true);
-			expect(component.get('.validation-message').text()).toBe('Condition not satisfied: required');
+			expect(component.get('.validation-message').text()).toBe('validation_message.required.error');
 		});
 	});
 });

--- a/packages/web-forms/tests/lib/locale/useLocale.test.ts
+++ b/packages/web-forms/tests/lib/locale/useLocale.test.ts
@@ -11,6 +11,7 @@ describe('useLocale', () => {
 	let wrappers: Array<ReturnType<typeof mount>> = [];
 
 	const makeLanguage = (language: string, localeCode: string): FormLanguage => ({
+		isDefault: false,
 		language,
 		locale: new Intl.Locale(localeCode),
 	});

--- a/packages/web-forms/tests/lib/locale/useLocale.test.ts
+++ b/packages/web-forms/tests/lib/locale/useLocale.test.ts
@@ -10,8 +10,8 @@ describe('useLocale', () => {
 	// onUnmounted state pollution (document.documentElement.lang) across tests
 	let wrappers: Array<ReturnType<typeof mount>> = [];
 
-	const makeLanguage = (language: string, localeCode: string): FormLanguage => ({
-		isDefault: false,
+	const makeLanguage = (language: string, localeCode: string, isDefault = false): FormLanguage => ({
+		isDefault,
 		language,
 		locale: new Intl.Locale(localeCode),
 	});
@@ -49,7 +49,7 @@ describe('useLocale', () => {
 		wrappers = [];
 	});
 
-	describe('language priority order (saved > browser > first)', () => {
+	describe('language priority order (saved > designer default > browser > first)', () => {
 		it('prefers saved locale over browser language', () => {
 			localStorage.setItem(STORAGE_KEY as string, 'fr');
 			vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['en']);
@@ -60,7 +60,19 @@ describe('useLocale', () => {
 			expect(document.documentElement.lang).toBe('fr');
 		});
 
-		it('uses browser language when no saved locale', () => {
+		it('prefers designer default over browser language when no saved locale', () => {
+			vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['en']);
+
+			const formRef = makeFormRef([
+				makeLanguage('English', 'en'),
+				makeLanguage('French', 'fr', true),
+			]);
+			mountLocale(formRef);
+
+			expect(document.documentElement.lang).toBe('fr');
+		});
+
+		it('uses browser language when no saved locale and no designer default', () => {
 			vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['jp']);
 
 			const formRef = makeFormRef([makeLanguage('English', 'en'), makeLanguage('Japanese', 'jp')]);
@@ -69,7 +81,7 @@ describe('useLocale', () => {
 			expect(document.documentElement.lang).toBe('jp');
 		});
 
-		it('falls back to first available language when no saved locale and no browser match', () => {
+		it('falls back to first available language when no saved locale, no designer default, and no browser match', () => {
 			vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['de']);
 
 			const formRef = makeFormRef([makeLanguage('English', 'en'), makeLanguage('French', 'fr')]);

--- a/packages/xforms-engine/src/client/FormLanguage.ts
+++ b/packages/xforms-engine/src/client/FormLanguage.ts
@@ -18,6 +18,12 @@ interface BaseFormLanguage {
 	// similar functionality, but we'll want to seriously consider how best to
 	// accomplish this if/as it becomes a priority.
 	readonly locale?: Intl.Locale | undefined;
+
+	/**
+	 * Indicates the language explicitly designated as default by the form designer via
+	 * the `default` attribute on an `<translation>` element.
+	 */
+	readonly isDefault: boolean;
 }
 
 /**

--- a/packages/xforms-engine/src/client/NoteNode.ts
+++ b/packages/xforms-engine/src/client/NoteNode.ts
@@ -40,8 +40,8 @@ export interface NoteNodeState<V extends ValueType> extends BaseValueNodeState<N
 	 */
 	readonly readonly: true;
 
-	get label(): TextRange<'label', 'form'> | null;
-	get hint(): TextRange<'hint', 'form'> | null;
+	get label(): TextRange<'label'> | null;
+	get hint(): TextRange<'hint'> | null;
 	get children(): null;
 	get valueOptions(): null;
 

--- a/packages/xforms-engine/src/client/TextRange.ts
+++ b/packages/xforms-engine/src/client/TextRange.ts
@@ -82,34 +82,6 @@ export type ValidationTextRole = 'constraintMsg' | 'requiredMsg';
 export type TextRole = ElementTextRole | ValidationTextRole;
 
 /**
- * Specifies the origin of a {@link TextRange}.
- *
- * - 'form': text is computed from the form definition, as specified for the
- *   {@link TextRole}. User-facing clients should present text with this origin
- *   where appropriate.
- *
- * - 'form-derived': the form definition lacks a text definition for the
- *   {@link TextRole}, but an appropriate one has been derived from a related
- *   (and semantically appropriate) aspect of the form (example: a select item
- *   without a label may derive that label from the item's value). User-facing
- *   clients should generally present text with this origin where provided; this
- *   origin clarifies the source of such text.
- *
- * - 'engine': the form definition lacks a definition for the {@link TextRole},
- *   but provides a constant default in its absence. User facing clients may
- *   disregard these constant text values, or may use them where a sensible
- *   default is desired. Clients may also use these constants as keys for
- *   translation purposes, as appropriate. Non-user facing clients may reference
- *   these constants for e.g. testing purposes.
- */
-// prettier-ignore
-export type TextOrigin =
-	// eslint-disable-next-line @typescript-eslint/sort-type-constituents
-	| 'form'
-	| 'form-derived'
-	| 'engine';
-
-/**
  * Represents aspects of a form which produce text, which _might_ be:
  *
  * - Computed from multiple sources
@@ -139,8 +111,7 @@ export type TextOrigin =
  * a text range's role may correspond to the "short" or "guidance" `form` of a
  * {@link https://getodk.github.io/xforms-spec/#languages | translation}).
  */
-export interface TextRange<Role extends TextRole, Origin extends TextOrigin = TextOrigin> {
-	readonly origin: Origin;
+export interface TextRange<Role extends TextRole> {
 	readonly role: Role;
 
 	[Symbol.iterator](): Iterable<TextChunk>;

--- a/packages/xforms-engine/src/client/constants.ts
+++ b/packages/xforms-engine/src/client/constants.ts
@@ -1,5 +1,4 @@
 import type { LoadForm } from './form/LoadForm.ts';
-import type { ValidationTextRole } from './TextRange.ts';
 
 export const MISSING_RESOURCE_BEHAVIOR = {
 	/**
@@ -58,15 +57,6 @@ export type MissingResourceBehavior =
 	// eslint-disable-next-line @typescript-eslint/sort-type-constituents
 	| MissingResourceBehaviorError
 	| MissingResourceBehaviorBlank;
-
-export const VALIDATION_TEXT = {
-	constraintMsg: 'Condition not satisfied: constraint',
-	requiredMsg: 'Condition not satisfied: required',
-} as const satisfies Record<ValidationTextRole, string>;
-
-type ValidationTextDefaults = typeof VALIDATION_TEXT;
-
-export type ValidationTextDefault<Role extends ValidationTextRole> = ValidationTextDefaults[Role];
 
 export const INSTANCE_FILE_NAME = 'xml_submission_file';
 export type INSTANCE_FILE_NAME = typeof INSTANCE_FILE_NAME;

--- a/packages/xforms-engine/src/client/validation.ts
+++ b/packages/xforms-engine/src/client/validation.ts
@@ -45,57 +45,17 @@ export type ValidationConditionMessageRole<Condition extends ValidationCondition
 	ValidationConditionMessageRoles[Condition];
 
 /**
- * Source of a condition's violation message.
+ * A form-defined violation message, present when the form designer specified `jr:constraintMsg`
+ * or `jr:requiredMsg`. The text may be translated ({@link https://getodk.github.io/xforms-spec/#fn:jr:itext | `jr:itext`})
+ * and dynamic (via {@link https://getodk.github.io/xforms-spec/#body-elements | `<output>`}).
  *
- * - Form-defined messages (specified by the
- *   {@link https://getodk.github.io/xforms-spec/#bind-attributes | `jr:constraintMsg` and `jr:requiredMsg`}
- *   attributes) will be favored when provided by the form, and will be
- *   translated according to the form's active language (where applicable).
- *
- * - Otherwise, an engine-defined message will be provided as a fallback. This
- *   fallback is provided mainly for API consistency, and may be referenced for
- *   testing purposes; user-facing clients are expected to provide fallback
- *   messaging language most appropriate for their user neeeds. Engine-defined
- *   fallback messages **are not translated**. They are intended to be used, if
- *   at all, as sentinel values when a form-defined message is not available.
+ * When absent, {@link ConditionViolation.message} is `null` and clients are expected to provide
+ * their own default messaging (e.g. a translated fallback).
  */
-// eslint-disable-next-line @typescript-eslint/sort-type-constituents
-export type ViolationMessageSource = 'form' | 'engine';
-
-/**
- * @see {@link ViolationMessage.asString}
- */
-// prettier-ignore
-type ViolationMessageAsString<
-	Source extends ViolationMessageSource,
-	Condition extends ValidationCondition,
-> =
-	Source extends 'form'
-		? string
-		: `Condition not satisfied: ${Condition}`;
-
-/**
- * A violation message is provided for every violation of a form-defined
- * {@link ValidationCondition}.
- */
-export interface ViolationMessage<
-	Condition extends ValidationCondition,
-	Source extends ViolationMessageSource = ViolationMessageSource,
-> extends TextRange<ValidationConditionMessageRole<Condition>> {
-	/**
-	 * - Form-defined violation messages may produce arbitrary text. This text may
-	 *   be translated
-	 *   ({@link https://getodk.github.io/xforms-spec/#fn:jr:itext | `jr:itext`}),
-	 *   and it may be dynamic (translations may reference form state with
-	 *   {@link https://getodk.github.io/xforms-spec/#body-elements | `<output>`}).
-	 *
-	 * - When a form-defined violation message is not available, an engine-defined
-	 *   message will be provided in its place. Engine-defined violation messages
-	 *   are statically defined (and therefore not presently translated by the
-	 *   engine). Their static value can also be referenced as a static type, by
-	 *   checking {@link isFallbackMessage}.
-	 */
-	get asString(): ViolationMessageAsString<Source, Condition>;
+export interface ViolationMessage<Condition extends ValidationCondition> extends TextRange<
+	ValidationConditionMessageRole<Condition>
+> {
+	get asString(): string;
 }
 
 export interface ConditionSatisfied<Condition extends ValidationCondition> extends BaseValidity {
@@ -107,7 +67,7 @@ export interface ConditionSatisfied<Condition extends ValidationCondition> exten
 export interface ConditionViolation<Condition extends ValidationCondition> extends BaseValidity {
 	readonly condition: Condition;
 	readonly valid: false;
-	readonly message: ViolationMessage<Condition>;
+	readonly message: ViolationMessage<Condition> | null;
 }
 
 export type ConditionValidation<Condition extends ValidationCondition> =

--- a/packages/xforms-engine/src/instance/Note.ts
+++ b/packages/xforms-engine/src/instance/Note.ts
@@ -32,8 +32,8 @@ import type { ValidationContext } from './internal-api/ValidationContext.ts';
 interface NoteStateSpec<V extends ValueType> extends ValueNodeStateSpec<NoteValue<V>> {
 	readonly readonly: Accessor<true>;
 	readonly noteText: ComputedNoteText;
-	readonly label: Accessor<TextRange<'label', 'form'> | null>;
-	readonly hint: Accessor<TextRange<'hint', 'form'> | null>;
+	readonly label: Accessor<TextRange<'label'> | null>;
+	readonly hint: Accessor<TextRange<'hint'> | null>;
 	readonly valueOptions: null;
 }
 
@@ -76,8 +76,8 @@ export class Note<V extends ValueType = ValueType>
 		this.attributeState = createAttributeState(this.scope);
 
 		let noteText: ComputedNoteText;
-		let label: Accessor<TextRange<'label', 'form'> | null>;
-		let hint: Accessor<TextRange<'hint', 'form'> | null>;
+		let label: Accessor<TextRange<'label'> | null>;
+		let hint: Accessor<TextRange<'hint'> | null>;
 
 		switch (noteTextComputation.role) {
 			case 'label': {

--- a/packages/xforms-engine/src/instance/text/TextRange.ts
+++ b/packages/xforms-engine/src/instance/text/TextRange.ts
@@ -1,12 +1,7 @@
 import { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
 
 import type { MarkdownNode } from '../../client/MarkdownNode.ts';
-import type {
-	TextRange as ClientTextRange,
-	TextChunk,
-	TextOrigin,
-	TextRole,
-} from '../../client/TextRange.ts';
+import type { TextRange as ClientTextRange, TextChunk, TextRole } from '../../client/TextRange.ts';
 import { format } from './markdownFormat.ts';
 
 export interface MediaSources {
@@ -15,10 +10,7 @@ export interface MediaSources {
 	audio?: JRResourceURL;
 }
 
-export class TextRange<Role extends TextRole, Origin extends TextOrigin> implements ClientTextRange<
-	Role,
-	Origin
-> {
+export class TextRange<Role extends TextRole> implements ClientTextRange<Role> {
 	*[Symbol.iterator]() {
 		yield* this.chunks;
 	}
@@ -44,7 +36,6 @@ export class TextRange<Role extends TextRole, Origin extends TextOrigin> impleme
 	}
 
 	constructor(
-		readonly origin: Origin,
 		readonly role: Role,
 		protected readonly chunks: readonly TextChunk[],
 		protected readonly mediaSources?: MediaSources

--- a/packages/xforms-engine/src/lib/reactivity/createItemCollection.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createItemCollection.ts
@@ -19,12 +19,12 @@ import type { ReactiveScope } from './scope.ts';
 import { createTextRange } from './text/createTextRange.ts';
 
 type ItemCollectionControl = RankControl | SelectControl;
-type DerivedItemLabel = ClientTextRange<'item-label', 'form-derived'>;
+type DerivedItemLabel = ClientTextRange<'item-label'>;
 
 const derivedItemLabel = (context: TranslationContext, value: string): DerivedItemLabel => {
 	const chunk = new TextChunk(context, 'literal', value);
 
-	return new TextRange('form-derived', 'item-label', [chunk]);
+	return new TextRange('item-label', [chunk]);
 };
 
 const createItemLabel = (

--- a/packages/xforms-engine/src/lib/reactivity/createTranslationState.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createTranslationState.ts
@@ -57,23 +57,26 @@ export const createTranslationState = (
 ): TranslationState => {
 	const activeLanguageName = evaluator.getActiveLanguage();
 	const languageNames = evaluator.getLanguages();
+	const explicitDefaultLanguageName = evaluator.getExplicitDefaultLanguage();
 
-	let defaultLanguage: ActiveLanguage;
+	let initialActiveLanguage: ActiveLanguage;
 	let languages: FormLanguages;
 
 	if (activeLanguageName == null) {
-		defaultLanguage = { isSyntheticDefault: true, language: '' };
-		languages = [defaultLanguage];
+		initialActiveLanguage = { isSyntheticDefault: true, language: '', isDefault: false };
+		languages = [initialActiveLanguage];
 	} else {
-		const inactiveLanguages = languageNames
-			.filter((languageName) => languageName !== activeLanguageName)
-			.map((language) => ({ language, locale: extractLocale(language) }));
+		const formLanguages = languageNames.map((language) => ({
+			language,
+			locale: extractLocale(language),
+			isDefault: language === explicitDefaultLanguageName,
+		}));
 
-		defaultLanguage = { language: activeLanguageName, locale: extractLocale(activeLanguageName) };
-		languages = [defaultLanguage, ...inactiveLanguages];
+		initialActiveLanguage = formLanguages.find((l) => l.language === activeLanguageName)!;
+		languages = formLanguages as [FormLanguage, ...FormLanguage[]];
 	}
 
-	const [getActiveLanguage, baseSetActiveLanguage] = createSignal(defaultLanguage);
+	const [getActiveLanguage, baseSetActiveLanguage] = createSignal(initialActiveLanguage);
 
 	const setActiveLanguage: SimpleAtomicStateSetter<FormLanguage> = (value) => {
 		return baseSetActiveLanguage(value);

--- a/packages/xforms-engine/src/lib/reactivity/createTranslationState.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createTranslationState.ts
@@ -59,12 +59,12 @@ export const createTranslationState = (
 	const languageNames = evaluator.getLanguages();
 	const explicitDefaultLanguageName = evaluator.getExplicitDefaultLanguage();
 
-	let initialActiveLanguage: ActiveLanguage;
+	let defaultLanguage: ActiveLanguage;
 	let languages: FormLanguages;
 
 	if (activeLanguageName == null) {
-		initialActiveLanguage = { isSyntheticDefault: true, language: '', isDefault: false };
-		languages = [initialActiveLanguage];
+		defaultLanguage = { isSyntheticDefault: true, language: '', isDefault: false };
+		languages = [defaultLanguage];
 	} else {
 		const formLanguages = languageNames.map((language) => ({
 			language,
@@ -72,11 +72,11 @@ export const createTranslationState = (
 			isDefault: language === explicitDefaultLanguageName,
 		}));
 
-		initialActiveLanguage = formLanguages.find((l) => l.language === activeLanguageName)!;
+		defaultLanguage = formLanguages.find((l) => l.language === activeLanguageName)!;
 		languages = formLanguages as [FormLanguage, ...FormLanguage[]];
 	}
 
-	const [getActiveLanguage, baseSetActiveLanguage] = createSignal(initialActiveLanguage);
+	const [getActiveLanguage, baseSetActiveLanguage] = createSignal(defaultLanguage);
 
 	const setActiveLanguage: SimpleAtomicStateSetter<FormLanguage> = (value) => {
 		return baseSetActiveLanguage(value);

--- a/packages/xforms-engine/src/lib/reactivity/text/createFieldHint.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createFieldHint.ts
@@ -7,7 +7,7 @@ import { createTextRange } from './createTextRange.ts';
 export const createFieldHint = (
 	context: EvaluationContext,
 	definition: LeafNodeDefinition
-): Accessor<TextRange<'hint', 'form'> | null> => {
+): Accessor<TextRange<'hint'> | null> => {
 	const hintDefinition = definition.bodyElement?.hint ?? null;
 
 	if (hintDefinition == null) {

--- a/packages/xforms-engine/src/lib/reactivity/text/createNodeLabel.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createNodeLabel.ts
@@ -7,7 +7,7 @@ import { createTextRange } from './createTextRange.ts';
 export const createNodeLabel = (
 	context: EvaluationContext,
 	definition: AnyNodeDefinition
-): Accessor<TextRange<'label', 'form'> | null> => {
+): Accessor<TextRange<'label'> | null> => {
 	const labelDefinition = definition.bodyElement?.label ?? null;
 
 	if (labelDefinition == null) {

--- a/packages/xforms-engine/src/lib/reactivity/text/createNoteText.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createNoteText.ts
@@ -8,9 +8,7 @@ import { createTextRange } from './createTextRange.ts';
 // eslint-disable-next-line @typescript-eslint/sort-type-constituents
 export type NoteTextRole = 'label' | 'hint';
 
-export type ComputedNoteText<Role extends NoteTextRole = NoteTextRole> = Accessor<
-	TextRange<Role, 'form'>
->;
+export type ComputedNoteText<Role extends NoteTextRole = NoteTextRole> = Accessor<TextRange<Role>>;
 
 interface BaseNoteText {
 	readonly role: NoteTextRole;

--- a/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
+++ b/packages/xforms-engine/src/lib/reactivity/text/createTextRange.ts
@@ -100,7 +100,7 @@ const createTextChunks = <Role extends TextRole>(
 	return { chunks, mediaSources };
 };
 
-type ComputedFormTextRange<Role extends TextRole> = Accessor<TextRange<Role, 'form'>>;
+type ComputedFormTextRange<Role extends TextRole> = Accessor<TextRange<Role>>;
 
 /**
  * Creates a text range (e.g. label or hint) from the provided definition, reactive to:
@@ -116,7 +116,7 @@ export const createTextRange = <Role extends TextRole>(
 	return context.scope.runTask(() => {
 		return createMemo(() => {
 			const chunks = createTextChunks(context, definition);
-			return new TextRange('form', role, chunks.chunks, chunks.mediaSources);
+			return new TextRange(role, chunks.chunks, chunks.mediaSources);
 		});
 	});
 };

--- a/packages/xforms-engine/src/lib/reactivity/validation/createValidation.ts
+++ b/packages/xforms-engine/src/lib/reactivity/validation/createValidation.ts
@@ -2,11 +2,6 @@ import type { Accessor } from 'solid-js';
 import { createMemo } from 'solid-js';
 import type { OpaqueReactiveObjectFactory } from '../../../client/OpaqueReactiveObjectFactory.ts';
 import type {
-	TextRange as ClientTextRange,
-	ValidationTextRole,
-} from '../../../client/TextRange.ts';
-import { VALIDATION_TEXT } from '../../../client/constants.ts';
-import type {
 	AnyViolation,
 	ConditionSatisfied,
 	ConditionValidation,
@@ -14,9 +9,6 @@ import type {
 	ValidationCondition,
 } from '../../../client/validation.ts';
 import type { ValidationContext } from '../../../instance/internal-api/ValidationContext.ts';
-import { TextChunk } from '../../../instance/text/TextChunk.ts';
-import { TextRange } from '../../../instance/text/TextRange.ts';
-import type { MessageDefinition } from '../../../parse/text/MessageDefinition.ts';
 import { createComputedExpression } from '../createComputedExpression.ts';
 import type {
 	SharedNodeState,
@@ -25,29 +17,6 @@ import type {
 import { createSharedNodeState } from '../node-state/createSharedNodeState.ts';
 import type { ReactiveScope } from '../scope.ts';
 import { createTextRange } from '../text/createTextRange.ts';
-
-type EngineViolationMessage<Role extends ValidationTextRole> = ClientTextRange<Role, 'engine'>;
-
-const engineViolationMessage = <Role extends ValidationTextRole>(
-	context: ValidationContext,
-	role: Role
-): Accessor<EngineViolationMessage<Role>> => {
-	const messageText = VALIDATION_TEXT[role];
-	const chunk = new TextChunk(context, 'literal', messageText);
-	return () => new TextRange('engine', role, [chunk]);
-};
-
-const createViolationMessage = <Role extends ValidationTextRole>(
-	context: ValidationContext,
-	role: Role,
-	definition: MessageDefinition<Role> | null
-) => {
-	if (definition == null) {
-		return engineViolationMessage(context, role);
-	}
-
-	return createTextRange(context, role, definition);
-};
 
 // prettier-ignore
 type ComputedConditionValidation<
@@ -75,7 +44,7 @@ const createConstraintValidation = (
 		const isValid = createComputedExpression(context, constraint, {
 			defaultValue: true,
 		});
-		const message = createViolationMessage(context, 'constraintMsg', constraintMsg);
+		const message = constraintMsg ? createTextRange(context, 'constraintMsg', constraintMsg) : null;
 
 		return createMemo(() => {
 			if (!context.isRelevant() || context.isBlank() || isValid()) {
@@ -85,7 +54,7 @@ const createConstraintValidation = (
 			return {
 				condition: 'constraint',
 				valid: false,
-				message: message(),
+				message: message?.() ?? null,
 			} as const;
 		});
 	});
@@ -117,7 +86,7 @@ const createRequiredValidation = (
 			return true;
 		};
 
-		const message = createViolationMessage(context, 'requiredMsg', requiredMsg);
+		const message = requiredMsg ? createTextRange(context, 'requiredMsg', requiredMsg) : null;
 
 		return createMemo(() => {
 			if (!context.isRelevant() || isValid()) {
@@ -127,7 +96,7 @@ const createRequiredValidation = (
 			return {
 				condition: 'required',
 				valid: false,
-				message: message(),
+				message: message?.() ?? null,
 			} as const;
 		});
 	});

--- a/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
+++ b/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
@@ -131,10 +131,14 @@ describe('PrimaryInstance engine representation of instance state', () => {
 
 			expect(languages).toEqual([
 				{
+					isDefault: false,
 					language: 'English',
+					locale: undefined,
 				},
 				{
+					isDefault: false,
 					language: 'Spanish',
+					locale: undefined,
 				},
 			]);
 		});
@@ -147,7 +151,9 @@ describe('PrimaryInstance engine representation of instance state', () => {
 			});
 
 			expect(activeLanguage).toEqual({
+				isDefault: false,
 				language: 'English',
+				locale: undefined,
 			});
 		});
 
@@ -156,14 +162,18 @@ describe('PrimaryInstance engine representation of instance state', () => {
 				const root = createRootNode(mutable);
 
 				root.setLanguage({
+					isDefault: false,
 					language: 'Spanish',
+					locale: undefined,
 				});
 
 				return root.currentState;
 			});
 
 			expect(activeLanguage).toEqual({
+				isDefault: false,
 				language: 'Spanish',
+				locale: undefined,
 			});
 		});
 
@@ -172,7 +182,7 @@ describe('PrimaryInstance engine representation of instance state', () => {
 				const root = createRootNode(mutable);
 
 				try {
-					root.setLanguage({ language: 'Not supported' });
+					root.setLanguage({ isDefault: false, language: 'Not supported', locale: undefined });
 				} catch (error) {
 					return error;
 				}
@@ -199,18 +209,26 @@ describe('PrimaryInstance engine representation of instance state', () => {
 					// The above `effect` was run immediately. Assert to confirm that
 					// assumption, then revert its state to `null` so we can be sure we're
 					// testing the subsequent effect after explicitly updating the state.
-					expect(observedClientLanguage).toEqual({ language: 'English' });
+					expect(observedClientLanguage).toEqual({
+						isDefault: false,
+						language: 'English',
+						locale: undefined,
+					});
 					observedClientLanguage = null;
 
 					// Here is the actual action under test: this call should trigger the
 					// client's `effect`.
-					root.setLanguage({ language: 'Spanish' });
+					root.setLanguage({ isDefault: false, language: 'Spanish', locale: undefined });
 
 					return observedClientLanguage;
 				}
 			);
 
-			expect(lastObservedClientLanguage).toEqual({ language: 'Spanish' });
+			expect(lastObservedClientLanguage).toEqual({
+			isDefault: false,
+			language: 'Spanish',
+			locale: undefined,
+		});
 		});
 	});
 

--- a/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
+++ b/packages/xforms-engine/test/instance/PrimaryInstance.test.ts
@@ -225,10 +225,57 @@ describe('PrimaryInstance engine representation of instance state', () => {
 			);
 
 			expect(lastObservedClientLanguage).toEqual({
-			isDefault: false,
-			language: 'Spanish',
-			locale: undefined,
+				isDefault: false,
+				language: 'Spanish',
+				locale: undefined,
+			});
 		});
+
+		it('marks the explicitly-designated default language with isDefault: true', () => {
+			// prettier-ignore
+			const xform = html(
+				head(
+					title('Form title'),
+					model(
+						t('itext',
+							t('translation lang="English"', t('text id="q1:label"', t('value', '1. Question one'))),
+							t('translation lang="Spanish" default="true()"', t('text id="q1:label"', t('value', '1. Pregunta uno')))
+						),
+						mainInstance(
+							t('data id="test-form"', t('q1'))
+						),
+						bind('/data/q1').type('string')
+					)
+				),
+				body(input('/data/first-question', label('First question')))
+			);
+
+			const xformDOM = XFormDOM.from(xform.asXml());
+			const def = new XFormDefinition(xformDOM);
+
+			const languages = reactiveTestScope(({ mutable }) => {
+				return scope.runTask(
+					() =>
+						new PrimaryInstance({
+							mode: 'create',
+							initialState: null,
+							scope,
+							model: def.model,
+							secondaryInstances: SecondaryInstancesDefinition.loadSync(xformDOM),
+							config: {
+								clientStateFactory: mutable,
+								computeAttachmentName: () => null,
+								preloadProperties: {},
+								geolocationProvider: { getLocation: () => Promise.resolve('') },
+							},
+						}).root.languages
+				);
+			});
+
+			expect(languages).toEqual([
+				{ isDefault: true, language: 'Spanish', locale: undefined },
+				{ isDefault: false, language: 'English', locale: undefined },
+			]);
 		});
 	});
 

--- a/packages/xforms-engine/test/lib/reactivity/createAggregatedViolations.test.ts
+++ b/packages/xforms-engine/test/lib/reactivity/createAggregatedViolations.test.ts
@@ -15,8 +15,7 @@ import {
 	title,
 } from '@getodk/common/test-utils/xform-dsl/index.ts';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { VALIDATION_TEXT } from '../../../src/client/constants.ts';
-import type { ValidationCondition } from '../../../src/client/validation.ts';
+import type { ValidationCondition, ViolationMessage } from '../../../src/client/validation.ts';
 import { createInstance } from '../../../src/entrypoints/createInstance.ts';
 import { reactiveTestScope } from '../../helpers/reactive/internal.ts';
 
@@ -81,7 +80,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 	interface SimplifiedViolation {
 		readonly condition: ValidationCondition;
 		readonly valid: false;
-		readonly message: string;
+		readonly message: ViolationMessage<ValidationCondition> | null;
 	}
 
 	interface SimplifiedViolationReference {
@@ -129,7 +128,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 							const violation: SimplifiedViolation = {
 								condition: violationReference.violation.condition,
 								valid: violationReference.violation.valid,
-								message: violationReference.violation.message.asString,
+								message: violationReference.violation.message,
 							};
 
 							return {
@@ -151,7 +150,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 				],
@@ -192,7 +191,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 							const violation: SimplifiedViolation = {
 								condition: violationReference.violation.condition,
 								valid: violationReference.violation.valid,
-								message: violationReference.violation.message.asString,
+								message: violationReference.violation.message,
 							};
 
 							return {
@@ -214,7 +213,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 				],
@@ -257,7 +256,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 							const violation: SimplifiedViolation = {
 								condition: violationReference.violation.condition,
 								valid: violationReference.violation.valid,
-								message: violationReference.violation.message.asString,
+								message: violationReference.violation.message,
 							};
 
 							return {
@@ -291,7 +290,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 				],
@@ -335,7 +334,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 							const violation: SimplifiedViolation = {
 								condition: violationReference.violation.condition,
 								valid: violationReference.violation.valid,
-								message: violationReference.violation.message.asString,
+								message: violationReference.violation.message,
 							};
 
 							return {
@@ -375,7 +374,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 				],
@@ -412,7 +411,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 							const violation: SimplifiedViolation = {
 								condition: violationReference.violation.condition,
 								valid: violationReference.violation.valid,
-								message: violationReference.violation.message.asString,
+								message: violationReference.violation.message,
 							};
 
 							return {
@@ -455,7 +454,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 					{
@@ -463,7 +462,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 				],
@@ -475,7 +474,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 				],
@@ -507,7 +506,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 							const violation: SimplifiedViolation = {
 								condition: violationReference.violation.condition,
 								valid: violationReference.violation.valid,
-								message: violationReference.violation.message.asString,
+								message: violationReference.violation.message,
 							};
 
 							return {
@@ -556,7 +555,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 					{
@@ -564,7 +563,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 				],
@@ -576,7 +575,7 @@ describe('createAggregatedViolations - reactive aggregated `constraint` and `req
 						violation: {
 							condition: 'required',
 							valid: false,
-							message: VALIDATION_TEXT.requiredMsg,
+							message: null,
 						},
 					},
 				],

--- a/packages/xpath/src/xforms/XFormsItextTranslations.ts
+++ b/packages/xpath/src/xforms/XFormsItextTranslations.ts
@@ -42,7 +42,7 @@ export type XFormsItextTranslationMap<T extends XPathNode> = ReadonlyMap<
 >;
 
 interface TranslationMetadata {
-	readonly defaultLanguage: XFormsItextTranslationLanguage | null;
+	readonly explicitDefaultLanguage: XFormsItextTranslationLanguage | null;
 	readonly languages: readonly XFormsItextTranslationLanguage[];
 }
 
@@ -56,6 +56,11 @@ export interface XFormsItextTranslationsState {
 	setActiveLanguage(
 		language: XFormsItextTranslationLanguage | null
 	): XFormsItextTranslationLanguage | null;
+	/**
+	 * Returns the language explicitly designated as default by the form designer via
+	 * the `default` attribute on an `<translation>` element, or `null` if no explicit default was specified.
+	 */
+	getExplicitDefaultLanguage(): XFormsItextTranslationLanguage | null;
 }
 
 /**
@@ -72,7 +77,7 @@ export interface XFormsItextTranslationsState {
  * @see {@link XFormsItextTranslationsState} for the corresponding public interface.
  */
 export class XFormsItextTranslations<T extends XPathNode> implements XFormsItextTranslationsState {
-	protected readonly defaultLanguage: XFormsItextTranslationLanguage | null = null;
+	protected readonly explicitDefaultLanguage: XFormsItextTranslationLanguage | null = null;
 	protected readonly languages: readonly XFormsItextTranslationLanguage[] = [];
 
 	protected activeLanguage: XFormsItextTranslationLanguage | null = null;
@@ -87,13 +92,13 @@ export class XFormsItextTranslations<T extends XPathNode> implements XFormsItext
 
 		this.translationElementMap = translationElementMap;
 
-		const { defaultLanguage, languages } = this.getTranslationMetadata(
+		const { explicitDefaultLanguage, languages } = this.getTranslationMetadata(
 			domProvider,
 			translationElementMap
 		);
 
-		this.defaultLanguage = defaultLanguage;
-		this.activeLanguage = defaultLanguage;
+		this.explicitDefaultLanguage = explicitDefaultLanguage;
+		this.activeLanguage = explicitDefaultLanguage ?? languages[0] ?? null;
 		this.languages = languages;
 	}
 
@@ -103,21 +108,19 @@ export class XFormsItextTranslations<T extends XPathNode> implements XFormsItext
 	): TranslationMetadata {
 		const languages: XFormsItextTranslationLanguage[] = [];
 
-		let defaultLanguage: XFormsItextTranslationLanguage | null = null;
+		let explicitDefaultLanguage: XFormsItextTranslationLanguage | null = null;
 
 		for (const [language, element] of translationElementMap) {
-			if (defaultLanguage == null && domProvider.hasLocalNamedAttribute(element, 'default')) {
-				defaultLanguage = language;
+			if (!explicitDefaultLanguage && domProvider.hasLocalNamedAttribute(element, 'default')) {
+				explicitDefaultLanguage = language;
 				languages.unshift(language);
 			} else {
 				languages.push(language);
 			}
 		}
 
-		defaultLanguage ??= languages[0] ?? null;
-
 		return {
-			defaultLanguage,
+			explicitDefaultLanguage,
 			languages,
 		};
 	}
@@ -209,10 +212,14 @@ export class XFormsItextTranslations<T extends XPathNode> implements XFormsItext
 		return this.activeLanguage;
 	}
 
+	getExplicitDefaultLanguage(): XFormsItextTranslationLanguage | null {
+		return this.explicitDefaultLanguage;
+	}
+
 	setActiveLanguage(
 		language: XFormsItextTranslationLanguage | null
 	): XFormsItextTranslationLanguage | null {
-		this.activeLanguage = language ?? this.defaultLanguage;
+		this.activeLanguage = language ?? this.languages[0] ?? null;
 
 		return this.activeLanguage;
 	}

--- a/packages/xpath/src/xforms/XFormsXPathEvaluator.ts
+++ b/packages/xpath/src/xforms/XFormsXPathEvaluator.ts
@@ -155,6 +155,10 @@ export class XFormsXPathEvaluator<T extends XPathNode>
 		return this.itextTranslations.setActiveLanguage(language);
 	}
 
+	getExplicitDefaultLanguage(): XFormsItextTranslationLanguage | null {
+		return this.itextTranslations.getExplicitDefaultLanguage();
+	}
+
 	getSecondaryInstance(id: string) {
 		return this.secondaryInstancesById.get(id);
 	}


### PR DESCRIPTION
Closes #332

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
- Refactors validation message in the engine
  - Removes hard-coded error message for "required" and "constraint".
  - Removes "origin" since it wasn't used, as the Vue client can evaluate the validation object to determine how to react and display the UI. 
  - Validation message can be null, such as when the form designer did not specify a message. 
- Refactors default language in form 
  - The form language interface has an `isDefault` property, which is used to mark when a form design explicitly sets one language as the default. 