### PR TITLE
chore: update volta-cli gh action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -141,7 +141,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -200,7 +200,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -259,7 +259,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -318,7 +318,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -366,7 +366,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -415,7 +415,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,7 @@ jobs:
         run: 'yarn workspace @getodk/web-forms test-browser:${{ matrix.browser }}'
 
       - if: ${{ matrix.node-version == '24.11.0' && matrix.target == 'Node' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-demo
           path: packages/web-forms/dist-demo

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v5'
 
-      - uses: 'volta-cli/action@v4'
+      - uses: 'volta-cli/action@v5'
         with:
           node-version: '${{ matrix.node-version }}'
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: 'Upload Playwright results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-results-functional-${{ matrix.browser }}
           path: packages/web-forms/test-results
@@ -98,7 +98,7 @@ jobs:
 
       - name: 'Upload Playwright results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-results-visual-${{ matrix.browser }}
           path: packages/web-forms/test-results


### PR DESCRIPTION
This version of volta-cli bumps the node version to 24 which resolves our GH warnings.

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
