### PR TITLE
fix(#788): number() on the dateTime string to return day count.

### DIFF
--- a/.changeset/modern-adults-read.md
+++ b/.changeset/modern-adults-read.md
@@ -1,0 +1,5 @@
+---
+'@getodk/xpath': patch
+---
+
+Fix the number() on the dateTime string to return day count.

--- a/packages/xpath/src/functions/xforms/number.ts
+++ b/packages/xpath/src/functions/xforms/number.ts
@@ -60,13 +60,9 @@ export const number = new FunctionImplementation(
 			const dateTime = dateTimeFromString(context.timeZone, stringValue);
 
 			if (dateTime != null) {
-				const dayCount = stringValue.includes('T')
-					? String(Math.floor(dateTime.epochMilliseconds / DAY_MILLISECONDS))
-					: stringValue;
-
 				return new DateTimeLikeEvaluation(context, dateTime, {
 					booleanValue: true,
-					stringValue: dayCount,
+					stringValue: String(Math.floor(dateTime.epochMilliseconds / DAY_MILLISECONDS)),
 				});
 			}
 		}

--- a/packages/xpath/src/functions/xforms/number.ts
+++ b/packages/xpath/src/functions/xforms/number.ts
@@ -60,13 +60,13 @@ export const number = new FunctionImplementation(
 			const dateTime = dateTimeFromString(context.timeZone, stringValue);
 
 			if (dateTime != null) {
-				const resultStringValue = stringValue.includes('T')
+				const dayCount = stringValue.includes('T')
 					? String(Math.floor(dateTime.epochMilliseconds / DAY_MILLISECONDS))
 					: stringValue;
 
 				return new DateTimeLikeEvaluation(context, dateTime, {
 					booleanValue: true,
-					stringValue: resultStringValue,
+					stringValue: dayCount,
 				});
 			}
 		}

--- a/packages/xpath/src/functions/xforms/number.ts
+++ b/packages/xpath/src/functions/xforms/number.ts
@@ -1,3 +1,4 @@
+import { DAY_MILLISECONDS } from '@getodk/common/constants/datetime.ts';
 import { DateTimeLikeEvaluation } from '../../evaluations/DateTimeLikeEvaluation.ts';
 import { NumberEvaluation } from '../../evaluations/NumberEvaluation.ts';
 import { FunctionImplementation } from '../../evaluator/functions/FunctionImplementation.ts';
@@ -59,9 +60,13 @@ export const number = new FunctionImplementation(
 			const dateTime = dateTimeFromString(context.timeZone, stringValue);
 
 			if (dateTime != null) {
+				const resultStringValue = stringValue.includes('T')
+					? String(Math.floor(dateTime.epochMilliseconds / DAY_MILLISECONDS))
+					: stringValue;
+
 				return new DateTimeLikeEvaluation(context, dateTime, {
 					booleanValue: true,
-					stringValue,
+					stringValue: resultStringValue,
 				});
 			}
 		}

--- a/packages/xpath/test/xforms/number.test.ts
+++ b/packages/xpath/test/xforms/number.test.ts
@@ -77,6 +77,20 @@ describe('#number()', () => {
 		});
 	});
 
+	describe('called on a date string', () => {
+		[
+			{ expression: 'number("1970-01-01")', expected: '0' },
+			{ expression: 'number("1970-01-02")', expected: '1' },
+			{ expression: 'number("1969-12-31")', expected: '-1' },
+			{ expression: 'number("2008-09-05")', expected: '14127' },
+			{ expression: 'number("1941-12-07")', expected: '-10252' },
+		].forEach(({ expression, expected }) => {
+			it(`${expression} should be ${expected} days since the epoch`, () => {
+				testContext.assertStringValue(expression, expected);
+			});
+		});
+	});
+
 	describe('called on a datetime string', () => {
 		[
 			{ expression: 'number("1970-01-01T00:00:00Z")', expected: '0' },

--- a/packages/xpath/test/xforms/number.test.ts
+++ b/packages/xpath/test/xforms/number.test.ts
@@ -77,6 +77,20 @@ describe('#number()', () => {
 		});
 	});
 
+	describe('called on a datetime string', () => {
+		[
+			{ expression: 'number("1970-01-01T00:00:00Z")', expected: '0' },
+			{ expression: 'number("1970-01-02T00:00:00Z")', expected: '1' },
+			{ expression: 'number("1969-12-31T00:00:00Z")', expected: '-1' },
+			{ expression: 'number("2026-08-27T08:27:00.000+07:00")', expected: '20692' },
+			{ expression: 'number("2026-10-28T19:23:00.000+07:00")', expected: '20754' },
+		].forEach(({ expression, expected }) => {
+			it(`${expression} should be ${expected} days since the epoch`, () => {
+				testContext.assertStringValue(expression, expected);
+			});
+		});
+	});
+
 	describe('number() conversions returns NaN if not convertible', () => {
 		it('number() conversions returns NaN if not convertible', () => {
 			[


### PR DESCRIPTION
Closes #788

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

[date_time_comparison 02.xml](https://github.com/user-attachments/files/27059879/date_time_comparison.02.xml)


### What's changed
