### PR TITLE
fix(#791): execute setvalue when first relevant

### DIFF
--- a/.changeset/slimy-areas-stand.md
+++ b/.changeset/slimy-areas-stand.md
@@ -1,0 +1,7 @@
+---
+'@getodk/xforms-engine': patch
+'@getodk/scenario': patch
+'@getodk/web-forms': patch
+---
+
+Fixed setvalue not firing when the field becomes relevant

--- a/packages/scenario/test/actions-events/set-value-action.test.ts
+++ b/packages/scenario/test/actions-events/set-value-action.test.ts
@@ -762,6 +762,80 @@ describe('setvalue action', () => {
 
 			expect(scenario.answerOf('/data/destination')).toEqualAnswer(stringAnswer('myvalue'));
 		});
+
+		it('is triggered only once target is relevant', async () => {
+			const scenario = await Scenario.init(
+				'xforms-value-changed-event',
+				html(
+					head(
+						title('Value changed event'),
+						model(
+							mainInstance(
+								t(
+									'data id="xforms-value-changed-event"',
+									t('source', 'foo'),
+									t('trigger'),
+									t('grp', t('destination'))
+								)
+							),
+							bind('/data/source').type('string'),
+							bind('/data/trigger').type('string'),
+							bind('/data/grp/destination').type('string').relevant("/data/trigger = 'yes'")
+						)
+					),
+					body(
+						input(
+							'/data/source',
+							setvalue('xforms-value-changed', '/data/grp/destination', '/data/source')
+						),
+						input('/data/trigger'),
+						group('/data/grp', input('/data/grp/destination'))
+					)
+				)
+			);
+
+			expect(scenario.answerOf('/data/grp/destination')).toEqualAnswer(stringAnswer(''));
+			scenario.answer('/data/trigger', 'yes'); // make destination relevant
+			expect(scenario.answerOf('/data/grp/destination')).toEqualAnswer(stringAnswer(''));
+		});
+
+		it('sets value even if not relevant (yet)', async () => {
+			const scenario = await Scenario.init(
+				'xforms-value-changed-event',
+				html(
+					head(
+						title('Value changed event'),
+						model(
+							mainInstance(
+								t(
+									'data id="xforms-value-changed-event"',
+									t('source', 'foo'),
+									t('trigger'),
+									t('grp', t('destination'))
+								)
+							),
+							bind('/data/source').type('string'),
+							bind('/data/trigger').type('string'),
+							bind('/data/grp/destination').type('string').relevant("/data/trigger = 'yes'")
+						)
+					),
+					body(
+						input(
+							'/data/source',
+							setvalue('xforms-value-changed', '/data/grp/destination', '/data/source')
+						),
+						input('/data/trigger'),
+						group('/data/grp', input('/data/grp/destination'))
+					)
+				)
+			);
+
+			expect(scenario.answerOf('/data/grp/destination')).toEqualAnswer(stringAnswer(''));
+			scenario.answer('/data/trigger', 'no');
+			scenario.answer('/data/source', 'bar');
+			scenario.answer('/data/trigger', 'yes');
+			expect(scenario.answerOf('/data/grp/destination')).toEqualAnswer(stringAnswer('bar'));
+		});
 	});
 
 	describe('`setvalue`', () => {

--- a/packages/scenario/test/actions-events/set-value-action.test.ts
+++ b/packages/scenario/test/actions-events/set-value-action.test.ts
@@ -734,6 +734,34 @@ describe('setvalue action', () => {
 			scenario.answer('/data/source', 12);
 			expect(scenario.answerOf('/data/destination')).not.toEqualAnswer(stringAnswer(originalDate));
 		});
+
+		it('is triggered when target is made relevant', async () => {
+			const scenario = await Scenario.init(
+				'xforms-value-changed-event',
+				html(
+					head(
+						title('Value changed event'),
+						model(
+							mainInstance(
+								t('data id="xforms-value-changed-event"', t('source'), t('destination'))
+							),
+							bind('/data/source').type('string'),
+							bind('/data/destination').type('string').relevant("/data/source != ''")
+						)
+					),
+					body(
+						input(
+							'/data/source',
+							setvalue('xforms-value-changed', '/data/destination', '/data/source')
+						)
+					)
+				)
+			);
+
+			scenario.answer('/data/source', 'myvalue');
+
+			expect(scenario.answerOf('/data/destination')).toEqualAnswer(stringAnswer('myvalue'));
+		});
 	});
 
 	describe('`setvalue`', () => {

--- a/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
@@ -240,17 +240,17 @@ const createValueChangedCalculation = (
 		// No element to listen to
 		return;
 	}
-	let previous: string;
 	const sourceElementExpression = new ActionComputationExpression('string', source);
 	const calculateValueSource = createComputedExpression(context, sourceElementExpression); // Registers listener
+	let previous = calculateValueSource();
 	createComputed(() => {
+		if (isEditInitialLoad(context)) {
+			// reset the initial value now that the edit instance is bound
+			previous = calculateValueSource();
+		}
 		if (context.isAttached() && context.isRelevant()) {
 			const valueSource = calculateValueSource();
-			if (
-				previous !== undefined &&
-				previous !== valueSource &&
-				referencesCurrentNode(context, ref)
-			) {
+			if (previous !== valueSource && referencesCurrentNode(context, ref)) {
 				// Only update if value has changed
 				if (action.element.nodeName === SET_GEOPOINT_LOCAL_NAME) {
 					getGeopointValue(context, (point) => {

--- a/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
@@ -242,15 +242,15 @@ const createValueChangedCalculation = (
 	}
 	const sourceElementExpression = new ActionComputationExpression('string', source);
 	const calculateValueSource = createComputedExpression(context, sourceElementExpression); // Registers listener
-	let previous = calculateValueSource();
+	let previous: string;
 	createComputed(() => {
-		if (isEditInitialLoad(context)) {
-			// reset the initial value now that the edit instance is bound
-			previous = calculateValueSource();
-		}
-		if (context.isAttached() && context.isRelevant()) {
+		if (context.isAttached()) {
 			const valueSource = calculateValueSource();
-			if (previous !== valueSource && referencesCurrentNode(context, ref)) {
+			if (
+				previous !== undefined &&
+				previous !== valueSource &&
+				referencesCurrentNode(context, ref)
+			) {
 				// Only update if value has changed
 				if (action.element.nodeName === SET_GEOPOINT_LOCAL_NAME) {
 					getGeopointValue(context, (point) => {


### PR DESCRIPTION
Closes #791 

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
