### PR TITLE
fix(#790): input numeric should update reactively when value changes

### DIFF
--- a/.changeset/neat-berries-win.md
+++ b/.changeset/neat-berries-win.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': patch
+---
+
+Fixed numeric inputs to update the UI when setvalue actions trigger

--- a/packages/web-forms/src/components/form-elements/input/InputNumeric.vue
+++ b/packages/web-forms/src/components/form-elements/input/InputNumeric.vue
@@ -84,7 +84,6 @@ const modelValue = computed<number | null>({
 				renderKey.value++;
 			}
 		} catch {
-			props.setNumericValue(currentValue);
 			// Re-render to restore previous value if something fails
 			renderKey.value++;
 		}

--- a/packages/web-forms/src/components/form-elements/input/InputNumeric.vue
+++ b/packages/web-forms/src/components/form-elements/input/InputNumeric.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import type { InputNumberInputEvent } from 'primevue/inputnumber';
 import InputNumber from 'primevue/inputnumber';
-import { type ComponentPublicInstance, nextTick, watch } from 'vue';
-import { customRef, ref } from 'vue';
+import { type ComponentPublicInstance, computed, nextTick, ref, watch } from 'vue';
 
 interface NumericNodeState {
 	get required(): boolean;
@@ -63,37 +62,33 @@ if (props.isDecimal) {
  * - If the assigned value differs from the effective value (due to clamping or rollback),
  *   triggers a re-render via `renderKey` to update the displayed value.
  */
-const modelValue = customRef<number | null>(() => {
-	const internalValue = ref(props.numericValue);
-	return {
-		get: () => internalValue.value,
-		set: (assignedValue) => {
-			const currentValue = internalValue.value;
-			const stringValue = assignedValue != null ? assignedValue.toString() : '';
-			let newValue = stringValue.length <= props.maxCharacters ? assignedValue : currentValue;
+const modelValue = computed<number | null>({
+	get: () => props.numericValue,
+	set: (assignedValue) => {
+		const currentValue = props.numericValue;
+		const stringValue = assignedValue != null ? assignedValue.toString() : '';
+		let newValue = stringValue.length <= props.maxCharacters ? assignedValue : currentValue;
 
-			if (newValue != null) {
-				const { min = newValue, max = newValue } = props;
+		if (newValue != null) {
+			const { min = newValue, max = newValue } = props;
 
-				if (min !== newValue || max !== newValue) {
-					newValue = Math.max(min, Math.min(newValue, max));
-				}
+			if (min !== newValue || max !== newValue) {
+				newValue = Math.max(min, Math.min(newValue, max));
 			}
+		}
 
-			try {
-				props.setNumericValue(newValue);
-				internalValue.value = newValue;
-				if (newValue !== assignedValue) {
-					// Re-render if value is clamped
-					renderKey.value++;
-				}
-			} catch {
-				internalValue.value = currentValue;
-				// Re-render to restore previous value if something fails
+		try {
+			props.setNumericValue(newValue);
+			if (newValue !== assignedValue) {
+				// Re-render if value is clamped
 				renderKey.value++;
 			}
-		},
-	};
+		} catch {
+			props.setNumericValue(currentValue);
+			// Re-render to restore previous value if something fails
+			renderKey.value++;
+		}
+	}
 });
 
 // After re-render, refocus input so user can continue typing seamlessly


### PR DESCRIPTION
Closes #790 

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
