### PR TITLE
fix(#749): handle negative step values

### DIFF
--- a/.changeset/proud-years-chew.md
+++ b/.changeset/proud-years-chew.md
@@ -1,0 +1,6 @@
+---
+'@getodk/xforms-engine': patch
+'@getodk/common': patch
+---
+
+Fixed handling of ranges with negative step values

--- a/packages/common/test-utils/xform-dsl/index.ts
+++ b/packages/common/test-utils/xform-dsl/index.ts
@@ -127,9 +127,9 @@ export const select1 = (ref: string, ...children: XFormsElement[]): XFormsElemen
 };
 
 interface RangeAttributes {
-	start: string;
-	end: string;
-	step: string;
+	start: number;
+	end: number;
+	step: number;
 }
 export const range = (
 	ref: string,

--- a/packages/common/test-utils/xform-dsl/index.ts
+++ b/packages/common/test-utils/xform-dsl/index.ts
@@ -126,6 +126,22 @@ export const select1 = (ref: string, ...children: XFormsElement[]): XFormsElemen
 	return t(`select1 ref="${ref}"`, ...children);
 };
 
+interface RangeAttributes {
+	start: string;
+	end: string;
+	step: string;
+}
+export const range = (
+	ref: string,
+	attributes: RangeAttributes,
+	...children: XFormsElement[]
+): XFormsElement => {
+	return t(
+		`range ref="${ref}" start="${attributes.start}" end="${attributes.end}" step="${attributes.step}"`,
+		...children
+	);
+};
+
 type Select1DynamicParameters =
 	// eslint-disable-next-line @typescript-eslint/sort-type-constituents
 	| readonly [ref: string, nodesetRef: string]

--- a/packages/xforms-engine/src/parse/body/control/RangeControlDefinition.ts
+++ b/packages/xforms-engine/src/parse/body/control/RangeControlDefinition.ts
@@ -46,11 +46,18 @@ const assertNumericStringAttribute: AssertNumericStringAttribute = (localName, v
 	}
 };
 
-const parseNumericStringAttribute = (element: Element, localName: string): NumericString => {
-	const value = element.getAttribute(localName);
+const parseNumericStringAttribute = (
+	element: Element,
+	localName: string,
+	unsign?: boolean
+): NumericString => {
+	let value = element.getAttribute(localName);
+
+	if (unsign === true && value?.length && value.startsWith('-')) {
+		value = value.substring(1);
+	}
 
 	assertNumericStringAttribute(localName, value);
-
 	return value;
 };
 
@@ -77,7 +84,7 @@ export class RangeControlBoundsDefinition {
 	static from(element: Element) {
 		const start = parseNumericStringAttribute(element, 'start');
 		const end = parseNumericStringAttribute(element, 'end');
-		const step = parseNumericStringAttribute(element, 'step');
+		const step = parseNumericStringAttribute(element, 'step', true);
 
 		return new this(start, end, step);
 	}

--- a/packages/xforms-engine/src/parse/body/control/RangeControlDefinition.ts
+++ b/packages/xforms-engine/src/parse/body/control/RangeControlDefinition.ts
@@ -46,18 +46,21 @@ const assertNumericStringAttribute: AssertNumericStringAttribute = (localName, v
 	}
 };
 
-const parseNumericStringAttribute = (
-	element: Element,
-	localName: string,
-	unsign?: boolean
-): NumericString => {
-	let value = element.getAttribute(localName);
-
-	if (unsign === true && value?.length && value.startsWith('-')) {
-		value = value.substring(1);
-	}
+const parseNumericStringAttribute = (element: Element, localName: string): NumericString => {
+	const value = element.getAttribute(localName);
 
 	assertNumericStringAttribute(localName, value);
+
+	return value;
+};
+
+const abs = (value: string | null) => (value?.startsWith('-') ? value.substring(1) : value);
+
+const parseNumericStringAttributeAbs = (element: Element, localName: string): NumericString => {
+	const value = abs(element.getAttribute(localName));
+
+	assertNumericStringAttribute(localName, value);
+
 	return value;
 };
 
@@ -76,15 +79,13 @@ const parseNumericStringAttribute = (
  * checking only that they appear to be numeric values. We also preserve the
  * attributes' names here, for consistency with the spec.
  *
- * Downstream, we parse these to their appropriate numeric runtime types, and
- * alias them to their more conventional names (i.e. "start" -> "min", "end" ->
- * "max").
+ * Downstream, we parse these to their appropriate numeric runtime types.
  */
 export class RangeControlBoundsDefinition {
 	static from(element: Element) {
 		const start = parseNumericStringAttribute(element, 'start');
 		const end = parseNumericStringAttribute(element, 'end');
-		const step = parseNumericStringAttribute(element, 'step', true);
+		const step = parseNumericStringAttributeAbs(element, 'step');
 
 		return new this(start, end, step);
 	}

--- a/packages/xforms-engine/test/parse/body/control/RangeControlDefinition.test.ts
+++ b/packages/xforms-engine/test/parse/body/control/RangeControlDefinition.test.ts
@@ -1,0 +1,70 @@
+import {
+	bind,
+	body,
+	head,
+	html,
+	mainInstance,
+	model,
+	range,
+	t,
+	title,
+} from '@getodk/common/test-utils/xform-dsl/index.ts';
+import { describe, expect, it } from 'vitest';
+import { RangeControlDefinition } from '../../../../src/parse/body/control/RangeControlDefinition.ts';
+import { XFormDefinition } from '../../../../src/parse/XFormDefinition.ts';
+import { XFormDOM } from '../../../../src/parse/XFormDOM.ts';
+
+describe('RangeControlDefinition', () => {
+	const create = (type: string, start: string, end: string, step: string) => {
+		const xform = html(
+			head(
+				title('Range definition'),
+				model(
+					mainInstance(t('root id="body-definition"', t('range'))),
+					bind('/root/range').type(type)
+				)
+			),
+			body(range('/root/range', { start, end, step }))
+		);
+
+		const xformDOM = XFormDOM.from(xform.asXml());
+		const xformDefinition = new XFormDefinition(xformDOM);
+		const rangeElement = xformDefinition.body.element.children[0];
+
+		return new RangeControlDefinition(xformDefinition, xformDefinition.body, rangeElement!);
+	};
+
+	describe('bounds', () => {
+		describe('int', () => {
+			it('parses', () => {
+				const definition = create('int', '-2', '10', '2');
+				expect(definition.bounds.start).to.equal('-2');
+				expect(definition.bounds.step).to.equal('2');
+				expect(definition.bounds.end).to.equal('10');
+			});
+
+			it('takes the absolute value of step', () => {
+				const definition = create('int', '0', '10', '-2');
+				expect(definition.bounds.start).to.equal('0');
+				expect(definition.bounds.step).to.equal('2');
+				expect(definition.bounds.end).to.equal('10');
+			});
+		});
+
+		describe('decimal', () => {
+			it('parses', () => {
+				const definition = create('decimal', '-2.5', '10.5', '2.5');
+				expect(definition.bounds.start).to.equal('-2.5');
+				expect(definition.bounds.step).to.equal('2.5');
+				expect(definition.bounds.end).to.equal('10.5');
+			});
+
+			it('takes the absolute value of step', () => {
+				const definition = create('decimal', '0', '10', '-2.5');
+				expect(definition.bounds.start).to.equal('0');
+				expect(definition.bounds.step).to.equal('2.5');
+				expect(definition.bounds.end).to.equal('10');
+			});
+		});
+	});
+});

--- a/packages/xforms-engine/test/parse/body/control/RangeControlDefinition.test.ts
+++ b/packages/xforms-engine/test/parse/body/control/RangeControlDefinition.test.ts
@@ -15,7 +15,7 @@ import { XFormDefinition } from '../../../../src/parse/XFormDefinition.ts';
 import { XFormDOM } from '../../../../src/parse/XFormDOM.ts';
 
 describe('RangeControlDefinition', () => {
-	const create = (type: string, start: string, end: string, step: string) => {
+	const create = (type: string, start: number, end: number, step: number) => {
 		const xform = html(
 			head(
 				title('Range definition'),
@@ -37,14 +37,14 @@ describe('RangeControlDefinition', () => {
 	describe('bounds', () => {
 		describe('int', () => {
 			it('parses', () => {
-				const definition = create('int', '-2', '10', '2');
+				const definition = create('int', -2, 10, 2);
 				expect(definition.bounds.start).to.equal('-2');
 				expect(definition.bounds.step).to.equal('2');
 				expect(definition.bounds.end).to.equal('10');
 			});
 
 			it('takes the absolute value of step', () => {
-				const definition = create('int', '0', '10', '-2');
+				const definition = create('int', 0, 10, -2);
 				expect(definition.bounds.start).to.equal('0');
 				expect(definition.bounds.step).to.equal('2');
 				expect(definition.bounds.end).to.equal('10');
@@ -53,14 +53,14 @@ describe('RangeControlDefinition', () => {
 
 		describe('decimal', () => {
 			it('parses', () => {
-				const definition = create('decimal', '-2.5', '10.5', '2.5');
+				const definition = create('decimal', -2.5, 10.5, 2.5);
 				expect(definition.bounds.start).to.equal('-2.5');
 				expect(definition.bounds.step).to.equal('2.5');
 				expect(definition.bounds.end).to.equal('10.5');
 			});
 
 			it('takes the absolute value of step', () => {
-				const definition = create('decimal', '0', '10', '-2.5');
+				const definition = create('decimal', 0, 10, -2.5);
 				expect(definition.bounds.start).to.equal('0');
 				expect(definition.bounds.step).to.equal('2.5');
 				expect(definition.bounds.end).to.equal('10');


### PR DESCRIPTION
Closes #749

### I have verified this PR works in these browsers (latest versions):

- [ ] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

Test written

### Why is this the best possible solution? Were any other approaches considered?

This would've been much easier to do in the vue component but because it's a spec feature I think it's better to have it in the engine for all clients to benefit from.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

```xml
<h:html xmlns="http://www.w3.org/2002/xforms"
  xmlns:h="http://www.w3.org/1999/xhtml">

  <h:head>
    <h:title>Range controls</h:title>
    <model>
      <instance>
        <root id="range-controls">
          <range-decimal>1.0</range-decimal>
          <range-int>2</range-int>

          <vertical>
            <v-decimal>1.25</v-decimal>
            <v-int>1</v-int>
          </vertical>
        </root>
      </instance>
      <bind nodeset="/root/range-decimal" type="xsd:decimal" />
      <bind nodeset="/root/range-int" type="int" />
      <bind nodeset="/root/vertical/v-decimal" type="decimal" />
      <bind nodeset="/root/vertical/v-int" type="xsd:int" />
    </model>
  </h:head>

  <h:body>
    <range ref="/root/range-decimal" start="-2.0" end="2.0" step="-0.5">
      <label>Range control (decimal)</label>
    </range>
    <range ref="/root/range-int" start="-6" end="4" step="-2">
      <label>Range control (int)</label>
    </range>

    <group ref="/root/vertical">
      <range ref="/root/vertical/v-decimal" start="-5.0" end="7.0" step="-0.5"
        appearance="vertical">
        <label>Range control (decimal)</label>
      </range>
      <range ref="/root/vertical/v-int" start="-3" end="4" step="-3" appearance="vertical no-ticks">
        <label>Range control (int)</label>
      </range>
    </group>
  </h:body>

</h:html>

```

### What's changed
