### PR TITLE
fix(#799): flips min and max labels to match the selected value

### DIFF
--- a/.changeset/chilly-mice-admire.md
+++ b/.changeset/chilly-mice-admire.md
@@ -1,0 +1,5 @@
+---
+'@getodk/web-forms': patch
+---
+
+Fixed vertical range control to record the correct value

--- a/packages/web-forms/src/components/form-elements/range/RangeControl.vue
+++ b/packages/web-forms/src/components/form-elements/range/RangeControl.vue
@@ -59,9 +59,6 @@ const orientation = props.node.appearances.vertical ? 'vertical' : 'horizontal';
 			<div class="range-value">
 				<span>{{ numberValue }}</span>
 			</div>
-			<div class="range-bound range-min">
-				{{ start }}
-			</div>
 			<RangeSlider
 				:id="node.nodeId"
 				:disabled="node.currentState.readonly"
@@ -72,6 +69,9 @@ const orientation = props.node.appearances.vertical ? 'vertical' : 'horizontal';
 				:model-value="numberValue"
 				@update:model-value="setValue"
 			/>
+			<div class="range-bound range-min">
+				{{ start }}
+			</div>
 			<div class="range-bound range-max">
 				{{ end }}
 			</div>
@@ -164,11 +164,11 @@ const orientation = props.node.appearances.vertical ? 'vertical' : 'horizontal';
 		}
 
 		.range-min {
-			top: 0;
+			bottom: 0;
 		}
 
 		.range-max {
-			bottom: 0;
+			top: 0;
 		}
 
 		.range-value {


### PR DESCRIPTION
Closes #799

### I have verified this PR works in these browsers (latest versions):

- [x] Chrome
- [x] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?

The other option would be to keep the labels where they were and invert the value out of the primevue widget. However I think the min should be at the bottom, and this is consistent with other implementations, so should be more intuitive.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed

I put the min label at the bottom of the slider, and the max label at the top.